### PR TITLE
Fix #1876 reconcile chain: retry required exec on warm transport before eviction

### DIFF
--- a/app/src/integrationTest/java/com/pocketshell/app/projects/Issue1876FolderReconcileMobileRttIntegrationTest.kt
+++ b/app/src/integrationTest/java/com/pocketshell/app/projects/Issue1876FolderReconcileMobileRttIntegrationTest.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.app.projects
 
+import com.pocketshell.app.diagnostics.DiagnosticEventSink
+import com.pocketshell.app.diagnostics.DiagnosticEvents
 import com.pocketshell.app.repos.ReposJsonParser
 import com.pocketshell.app.repos.ReposRemoteSource
 import com.pocketshell.app.sessions.ActiveTmuxClients
@@ -54,11 +56,18 @@ import java.nio.file.Paths
  * ## The load-bearing assertion (G6)
  *
  * [reconcileChainFitsTheProductionReconcileBoundOnAMobileLink] measures the
- * WALL CLOCK of one real `listSessionsWithFolder` over the shaped transport and
- * asserts it against the PRODUCTION bound the view model actually enforces. That
- * is the symptom-defining signal — not "a seam fired", not "N execs were
- * issued". It is RED on the pre-fix serial chain and GREEN once the independent
- * probes are issued concurrently.
+ * WALL CLOCK of real `listSessionsWithFolder` calls over the shaped transport and
+ * asserts against the PRODUCTION bound the view model actually enforces. That is
+ * the symptom-defining signal — not "a seam fired", not "N execs were issued". It
+ * is RED on the pre-fix serial chain and GREEN once the independent probes are
+ * issued concurrently.
+ *
+ * Issue #2422 made that measurement a SAMPLE SET rather than a single reading,
+ * and added the two arms that keep it honest: `mutationADoubledChainIsRejectedByTheSameBudget`
+ * (the budget must still fail closed on a genuinely slower chain) and
+ * [aTransientlySlowRequiredExecCostsNoFreshDialAndKeepsTheTree] (a required exec
+ * that over-runs its per-exec bound must not cost a fresh SSH dial). See
+ * [CHAIN_SAMPLES] and [CHAIN_BUDGET_MS] for the recorded distribution behind both.
  *
  * [theReconcileStillReturnsTheFullTreeUnderTheSameMobileProfile] is the G6
  * negative: a chain can always be made fast by doing LESS work, so the same run
@@ -135,6 +144,93 @@ class Issue1876FolderReconcileMobileRttIntegrationTest {
          * widening the production timeout.
          */
         private const val SLOW_LOGS_SECONDS = "4"
+
+        /**
+         * Flag file that arms one slow `tmux list-sessions`.
+         *
+         * It lives in the user's home, not the sticky `/tmp`, so the shim — which
+         * runs as `testuser` while the test writes the flag over `su` — can delete
+         * it after consuming it.
+         */
+        private const val TMUX_ONCE_DELAY_FLAG = "/home/testuser/.ps2422-list-sessions-delay"
+
+        /**
+         * Where the fixture's `tmux` actually lives. `Dockerfile.agents` moves
+         * Alpine's real binary to `/usr/bin/tmux.real` and installs the shared
+         * fault-injection shim at `/usr/local/bin/tmux`, which is what the
+         * production `PATH` resolves. `/usr/bin/tmux` does not exist.
+         */
+        private const val TMUX_SHIM_PATH = "/usr/local/bin/tmux"
+
+        /** Where this test's wrapper moves the fixture shim before delegating. */
+        private const val TMUX_DELEGATE_PATH = "/usr/local/bin/tmux.issue2422"
+
+        /**
+         * Seconds the armed `tmux list-sessions` sleeps. Must exceed
+         * [SshFolderListGateway.EXEC_READ_TIMEOUT_MS] (3.5 s) so the required
+         * landing batch is ABANDONED, which is the state under test.
+         */
+        private const val SLOW_LIST_SESSIONS_SECONDS = "5"
+
+        /**
+         * How many reconciles each timing assertion measures — issue #2422.
+         *
+         * One wall-clock sample over a shaped, lossy link is not a measurement of
+         * the chain: TCP loss recovery (RTO, with exponential backoff on a lost
+         * retransmit) and shared-runner CPU steal are STRICTLY ADDITIVE, so a
+         * sample is `structural cost + non-negative noise`. Nothing makes a
+         * reconcile finish faster than its structure allows. That makes
+         * [minElapsedMs] the natural estimator of the structural cost, and the
+         * single-sample assertion this test used to carry a coin flip: on the
+         * scheduled run that filed this issue it read `elapsedMs=12545` against a
+         * hard 12 000 ms bound while the very next measurement in the SAME JVM,
+         * container and shaper read 6 496 ms.
+         */
+        private const val CHAIN_SAMPLES = 5
+
+        /**
+         * Samples for the slow-host-CLI arm. Each one carries a real 4 s host
+         * probe, so it is the most expensive arm to repeat; 3 is enough for a
+         * minimum that is not a single unlucky draw.
+         */
+        private const val SLOW_CLI_SAMPLES = 3
+
+        /**
+         * The measured budget for the un-amplified chain, in milliseconds.
+         *
+         * Recorded distribution of `listSessionsWithFolder` over this fixture
+         * (18 sessions, 3 watched roots, ~400 ms RTT, 5 % loss), warm lease:
+         *
+         * ```text
+         * local, 25 consecutive samples : min 5787  p50 6854  max 8273
+         * local, 6 consecutive samples  : min 6195  p50 6845  max 7658
+         * GitHub-hosted runner          : 6353, 6496, 7309, 7441   (un-amplified)
+         * GitHub-hosted runner          : 12545                    (amplified, see below)
+         * ```
+         *
+         * The base cost is RTT-bound, not CPU-bound, which is why the hosted
+         * runner and this workstation agree to within ~10 % despite very different
+         * machines. 9 000 ms sits ~9 % above the slowest un-amplified sample ever
+         * recorded on either machine and ~30 % above the median, and it is applied
+         * to the MINIMUM of [CHAIN_SAMPLES], which lands near the median.
+         *
+         * It is deliberately TIGHTER than the 12 000 ms production bound: this
+         * assertion's job is to catch a STRUCTURAL regression (#1876's pre-fix
+         * serial chain measured 11.2-14.1 s here), and a bound that only trips at
+         * 12 s cannot see a 1.5x re-serialisation. `mutationADoubledChainIsRejected`
+         * pins that the budget still fails closed.
+         *
+         * The 12 545 ms outlier is not ordinary runner noise. Forcing a required
+         * landing exec to lose its race against the 3.5 s per-exec bound (see
+         * [aTransientlySlowRequiredExecCostsNoFreshDialAndKeepsTheTree]) moves the
+         * chain into a separate 12.3-13.5 s band with no overlap against the
+         * 5.8-8.5 s un-amplified band — and 12 545 ms sits in the first one, while
+         * the very next measurement on the same commit, JVM and shaper read
+         * 6 496 ms. So the outlier is a distinct MODE, not a tail, which is
+         * precisely why one sample is not a measurement and the minimum of
+         * [CHAIN_SAMPLES] is.
+         */
+        private const val CHAIN_BUDGET_MS = 9_000L
 
         private val projectRoot: Path by lazy { findProjectRoot() }
 
@@ -249,6 +345,7 @@ class Issue1876FolderReconcileMobileRttIntegrationTest {
             )
             check(mkdirs.exitCode == 0) { "Failed to seed watched roots: ${mkdirs.stderr}" }
             installHostCliCostShim(container)
+            installOneShotSlowListSessionsShim(container)
         }
 
         /**
@@ -292,6 +389,97 @@ class Issue1876FolderReconcileMobileRttIntegrationTest {
                 "host-CLI cost shim did not preserve the fixture CLI: " +
                     "rc=${verify.exitCode} out=${verify.stdout} err=${verify.stderr}"
             }
+        }
+
+        /**
+         * Issue #2422 (G10 — "add the fixture that reproduces it"): wrap the
+         * fixture's `tmux` so the NEXT `list-sessions` — and only that one —
+         * sleeps, deterministically pushing the REQUIRED landing batch past
+         * [SshFolderListGateway.EXEC_READ_TIMEOUT_MS].
+         *
+         * That is the exact non-happy host state the flake needs and no happy
+         * fixture can enter: on the shaped mobile link 1-3 execs per reconcile
+         * already run into their 3.5 s bound, and which one loses is luck. The
+         * required batch losing is the expensive case, so it has to be forced
+         * rather than waited for.
+         *
+         * The delay is armed by writing [TMUX_ONCE_DELAY_FLAG] and is consumed by
+         * the FIRST matching invocation, so a single reconcile pays it once. The
+         * flag lives in the user's home rather than the sticky `/tmp` so the shim
+         * (running as `testuser`) can delete it.
+         *
+         * Scoped to THIS test's own container — the shared `agent-bin/tmux`
+         * fault-injection shim and every sibling suite are untouched.
+         */
+        private fun installOneShotSlowListSessionsShim(container: GenericContainer<*>) {
+            val shim = """
+                set -e
+                test -x $TMUX_SHIM_PATH
+                mv $TMUX_SHIM_PATH $TMUX_DELEGATE_PATH
+                cat > $TMUX_SHIM_PATH <<'SHIM'
+                #!/bin/sh
+                if [ -f "$TMUX_ONCE_DELAY_FLAG" ]; then
+                  case " ${'$'}* " in
+                    *@ps_agent_state_updated_at*)
+                      ps2422_delay="${'$'}(cat "$TMUX_ONCE_DELAY_FLAG" 2>/dev/null || echo 0)"
+                      rm -f "$TMUX_ONCE_DELAY_FLAG"
+                      sleep "${'$'}ps2422_delay"
+                      ;;
+                  esac
+                fi
+                exec $TMUX_DELEGATE_PATH "${'$'}@"
+                SHIM
+                sed -i 's/^                //' $TMUX_SHIM_PATH
+                chmod +x $TMUX_SHIM_PATH
+            """.trimIndent()
+            val result = container.execInContainer("sh", "-c", shim)
+            check(result.exitCode == 0) {
+                "Failed to install the one-shot slow list-sessions shim: " +
+                    "${result.stdout}${result.stderr}"
+            }
+            // The wrapper is only useful if it sits on the path the PRODUCTION
+            // command actually resolves. The reconcile runs `/bin/sh -lc 'PATH=…;
+            // tmux …'` as `testuser`, so resolve `tmux` exactly that way and
+            // require it to BE the wrapper — the first draft of this fixture
+            // wrapped /usr/bin/tmux, which the fixture image does not even ship,
+            // so the injection silently did nothing and the arm passed vacuously.
+            val resolved = container.execInContainer(
+                "su", "testuser", "-c",
+                "sh -lc 'PATH=\"\$HOME/.local/bin:\$HOME/.cargo/bin:\$PATH\"; command -v tmux'",
+            )
+            check(resolved.exitCode == 0 && resolved.stdout.trim() == TMUX_SHIM_PATH) {
+                "the production PATH must resolve tmux to the issue #2422 wrapper, got " +
+                    "'${resolved.stdout.trim()}' (rc=${resolved.exitCode} ${resolved.stderr})"
+            }
+            val verify = container.execInContainer("su", "testuser", "-c", "tmux list-sessions")
+            check(verify.exitCode == 0 && verify.stdout.contains("s1")) {
+                "one-shot tmux shim did not preserve the fixture tmux: " +
+                    "rc=${verify.exitCode} out=${verify.stdout} err=${verify.stderr}"
+            }
+        }
+
+        /**
+         * Arm the one-shot required-exec over-run. [seconds] must exceed
+         * [SshFolderListGateway.EXEC_READ_TIMEOUT_MS] so the required batch is
+         * abandoned rather than merely slow.
+         */
+        private fun armOneShotSlowListSessions(seconds: String) {
+            val result = agents!!.execInContainer(
+                "su", "testuser", "-c",
+                "printf '%s' '$seconds' > $TMUX_ONCE_DELAY_FLAG",
+            )
+            check(result.exitCode == 0) {
+                "Failed to arm the one-shot slow list-sessions: ${result.stderr}"
+            }
+        }
+
+        /**
+         * Disarm, so an armed-but-unconsumed delay can never leak into a sibling
+         * test in this class (JUnit method order is not guaranteed, and every
+         * other arm measures wall clock).
+         */
+        private fun disarmSlowListSessions() {
+            agents!!.execInContainer("su", "testuser", "-c", "rm -f $TMUX_ONCE_DELAY_FLAG")
         }
 
         /** Charge `pocketshell logs …` an extra [seconds] on the fixture host. */
@@ -346,13 +534,16 @@ class Issue1876FolderReconcileMobileRttIntegrationTest {
             ProjectRootEntity(id = index + 1L, hostId = 1L, label = "root$index", path = path)
         }
 
-    private fun newGateway(leaseManager: SshLeaseManager): SshFolderListGateway =
+    private fun newGateway(
+        leaseManager: SshLeaseManager,
+        execReadTimeoutMs: Long = SshFolderListGateway.EXEC_READ_TIMEOUT_MS,
+    ): SshFolderListGateway =
         SshFolderListGateway(
             reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
             activeTmuxClients = ActiveTmuxClients(),
             sshLeaseManager = leaseManager,
             sessionListParser = HostTmuxSessionListParser(),
-            execReadTimeoutMs = SshFolderListGateway.EXEC_READ_TIMEOUT_MS,
+            execReadTimeoutMs = execReadTimeoutMs,
         )
 
     /**
@@ -407,34 +598,263 @@ class Issue1876FolderReconcileMobileRttIntegrationTest {
     }
 
     /**
+     * Measure [count] consecutive reconciles over ONE warm lease — issue #2422.
+     *
+     * This mirrors production: the folder screen POLLS over a lease that stays
+     * warm, so consecutive measurements are the real unit of observation, and a
+     * single one is a sample from a heavy-tailed distribution rather than "the"
+     * chain duration (see [CHAIN_SAMPLES]).
+     *
+     * [beforeEachSample] runs on the fixture host between measurements, which is
+     * how the one-shot required-exec over-run is re-armed per sample.
+     * [reconcilesPerSample] > 1 measures that many BACK-TO-BACK reconciles as a
+     * single sample — the deliberately-slowed chain the mutation proof feeds to
+     * the same evaluator.
+     */
+    private fun measureWarmReconcileSamples(
+        count: Int,
+        reconcilesPerSample: Int = 1,
+        beforeEachSample: () -> Unit = {},
+    ): List<WarmReconcile> {
+        val leaseManager = SshLeaseManager(
+            connector = SshLeaseConnector { target -> DefaultSshLeaseConnector().connect(target) },
+        )
+        return leaseManager.use {
+            runBlocking {
+                val gateway = newGateway(leaseManager)
+                val host = shapedHost()
+                suspend fun reconcile(): FolderListResult = gateway.listSessionsWithFolder(
+                    host = host,
+                    keyPath = privateKeyFile.absolutePath,
+                    passphrase = null,
+                    watchedRoots = watchedRoots(),
+                )
+                // Warm-up: dials the transport + primes the fixture's page cache.
+                // Untimed by design — the cold dial is NOT inside the reconcile
+                // window in production either.
+                reconcile()
+                (1..count).map {
+                    beforeEachSample()
+                    val loginsBefore = sshLoginCount()
+                    val startedAt = System.nanoTime()
+                    var result = reconcile()
+                    repeat(reconcilesPerSample - 1) { result = reconcile() }
+                    val elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L
+                    WarmReconcile(
+                        elapsedMs = elapsedMs,
+                        result = result,
+                        extraSshLogins = sshLoginCount() - loginsBefore,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun List<WarmReconcile>.minElapsedMs(): Long = minOf { it.elapsedMs }
+
+    private fun List<WarmReconcile>.medianElapsedMs(): Long =
+        map { it.elapsedMs }.sorted()[size / 2]
+
+    private fun List<WarmReconcile>.report(label: String): String =
+        "$label profile=${DELAY_MS}ms+-${JITTER_MS}ms/loss=$LOSS_RATE " +
+            "(rtt~${2 * DELAY_MS}ms) roots=${WATCHED_ROOT_PATHS.size} " +
+            "samples=${map { it.elapsedMs }} logins=${map { it.extraSshLogins }} " +
+            "minMs=${minElapsedMs()} medianMs=${medianElapsedMs()} " +
+            "budget=$CHAIN_BUDGET_MS bound=${FolderListViewModel.RECONCILE_TIMEOUT_MS}"
+
+    /**
+     * THE assertion, shared by the real measurement and the mutation proof so the
+     * mutation cannot drift away from what production is judged by.
+     *
+     * Three things must hold, and each fails closed:
+     *  1. EVERY sample returns a real tree — a `ConnectFailed`/`Failed` reconcile
+     *     is the user-visible defect itself, and no statistic tolerates one.
+     *  2. The MINIMUM sample fits [CHAIN_BUDGET_MS] — the structural-cost estimate
+     *     (noise on this link is strictly additive, see [CHAIN_SAMPLES]).
+     *  3. The MEDIAN fits the PRODUCTION [FolderListViewModel.RECONCILE_TIMEOUT_MS]
+     *     — the user-visible bound whose breach becomes the "Couldn't refresh the
+     *     project tree" panel, kept in the assertion set rather than replaced by
+     *     the tighter internal budget.
+     */
+    private fun assertChainSamplesFitTheBudget(samples: List<WarmReconcile>, label: String) {
+        val detail = samples.report(label)
+        samples.forEachIndexed { index, sample ->
+            assertTrue(
+                "sample $index must return a real tree, got ${sample.result}; $detail",
+                sample.result is FolderListResult.Sessions,
+            )
+        }
+        assertTrue(
+            "Issue #1876/#2422: the folder-tree reconcile's structural cost " +
+                "(min of ${samples.size} samples) is ${samples.minElapsedMs()}ms over a " +
+                "~${2 * DELAY_MS}ms-RTT / $LOSS_RATE-loss link, past the measured " +
+                "${CHAIN_BUDGET_MS}ms budget. On the device a chain this serial is the " +
+                "ConnectError panel whose Retry re-runs the same chain. $detail",
+            samples.minElapsedMs() < CHAIN_BUDGET_MS,
+        )
+        assertTrue(
+            "Issue #1876: the median reconcile is ${samples.medianElapsedMs()}ms against " +
+                "the production ${FolderListViewModel.RECONCILE_TIMEOUT_MS}ms " +
+                "RECONCILE_TIMEOUT_MS. $detail",
+            samples.medianElapsedMs() < FolderListViewModel.RECONCILE_TIMEOUT_MS,
+        )
+    }
+
+    /**
      * THE reproduction. RED on the pre-fix serial chain, GREEN with the fix.
      *
-     * The bound asserted is the PRODUCTION one
-     * ([FolderListViewModel.RECONCILE_TIMEOUT_MS]); exceeding it is exactly what
-     * turns into `FolderReconcileTimeoutException` -> `ConnectFailed` -> the
-     * "Couldn't refresh the project tree — tap to retry" panel, whose Retry
-     * re-runs the identical chain under the identical bound and therefore fails
-     * forever on a stable mobile link.
+     * Issue #2422 replaced the single wall-clock sample with [CHAIN_SAMPLES]
+     * measurements judged by [assertChainSamplesFitTheBudget]: the structural
+     * cost (the minimum) against the measured [CHAIN_BUDGET_MS], and the median
+     * against the PRODUCTION [FolderListViewModel.RECONCILE_TIMEOUT_MS] —
+     * exceeding which is exactly what turns into
+     * `FolderReconcileTimeoutException` -> `ConnectFailed` -> the "Couldn't
+     * refresh the project tree — tap to retry" panel, whose Retry re-runs the
+     * identical chain under the identical bound and therefore fails forever on a
+     * stable mobile link.
      */
     @Test(timeout = 600_000)
     fun reconcileChainFitsTheProductionReconcileBoundOnAMobileLink() {
-        val (elapsedMs, result) = measureWarmReconcile()
+        val samples = measureWarmReconcileSamples(CHAIN_SAMPLES)
+        println(samples.report("ISSUE1876_RECONCILE_CHAIN"))
+        assertChainSamplesFitTheBudget(samples, "ISSUE1876_RECONCILE_CHAIN")
+    }
+
+    /**
+     * Issue #2422 — the mutation proof that [assertChainSamplesFitTheBudget] is
+     * not vacuous.
+     *
+     * A budget applied to the MINIMUM of N samples is only worth having if a
+     * genuinely slower chain still fails it. The mutation is measured on the SAME
+     * real transport rather than modelled: each sample times TWO back-to-back
+     * reconciles, i.e. a chain with twice the serial round-trip depth — precisely
+     * the #1876 regression shape (its pre-fix serial chain measured 11.2-14.1 s
+     * here) and precisely what a future re-serialisation would look like.
+     *
+     * The same evaluator the real assertion uses must REJECT those samples.
+     */
+    @Test(timeout = 600_000)
+    fun mutationADoubledChainIsRejectedByTheSameBudget() {
+        val doubled = measureWarmReconcileSamples(count = 3, reconcilesPerSample = 2)
+        println(doubled.report("ISSUE2422_MUTATION_DOUBLED_CHAIN"))
+        val verdict = runCatching {
+            assertChainSamplesFitTheBudget(doubled, "ISSUE2422_MUTATION_DOUBLED_CHAIN")
+        }
+        val failure = verdict.exceptionOrNull()
+        assertTrue(
+            "a chain with twice the serial depth must FAIL the budget, otherwise the " +
+                "green in reconcileChainFitsTheProductionReconcileBoundOnAMobileLink " +
+                "proves nothing; got $failure; " +
+                doubled.report("ISSUE2422_MUTATION_DOUBLED_CHAIN"),
+            failure is AssertionError,
+        )
+        assertTrue(
+            "it must be the STRUCTURAL-COST budget that rejects the doubled chain, not " +
+                "an incidental failure of one of the other assertions — otherwise the " +
+                "mutation proves the wrong thing (G6); got ${failure?.message}",
+            failure?.message.orEmpty().contains("past the measured ${CHAIN_BUDGET_MS}ms budget"),
+        )
+    }
+
+    /**
+     * Issue #2422 — a transiently slow REQUIRED landing exec must not cost a
+     * fresh SSH dial.
+     *
+     * This is the real-transport half of the class regression, and the direct
+     * reproduction of the scheduled-CI failure this issue was filed for
+     * (`ISSUE1876_RECONCILE_CHAIN … elapsedMs=12545 bound=12000`, a run that
+     * still returned a COMPLETE tree). At ~400 ms RTT with 5 % loss, 1-3 execs
+     * per reconcile already run into their 3.5 s bound; every one of them is
+     * fail-soft EXCEPT the required landing batch, whose over-run used to be
+     * classified as a poisoned transport — evicting the warm lease, paying a
+     * brand-new TCP+SSH handshake and re-running the whole chain. Measured on
+     * this fixture with the required exec forced to lose, that cost 11.9-16.9 s
+     * against the 12 s bound with 1-2 extra sshd logins.
+     *
+     * [armOneShotSlowListSessions] forces exactly that loss per sample, so the
+     * load-bearing assertion is the SERVER-side login delta — a binary,
+     * timing-free oracle read from sshd itself, not from an app seam.
+     *
+     * The injection is also PROVED to have landed rather than assumed: every
+     * sample must carry the production `folder_list_required_exec_retry`
+     * breadcrumb. Without that check the arm passes vacuously the moment the
+     * fixture stops reaching the required exec — which is exactly what the first
+     * draft of this fixture did (it wrapped a `/usr/bin/tmux` the image does not
+     * ship, so nothing was ever slowed and the samples were indistinguishable
+     * from an un-injected run).
+     */
+    @Test(timeout = 600_000)
+    fun aTransientlySlowRequiredExecCostsNoFreshDialAndKeepsTheTree() {
+        val retries = java.util.concurrent.CopyOnWriteArrayList<Int>()
+        val perSampleRetries = java.util.concurrent.atomic.AtomicInteger(0)
+        DiagnosticEvents.install(
+            object : DiagnosticEventSink {
+                override fun record(category: String, event: String, fields: Map<String, Any?>) {
+                    if (fields["stage"] == FolderListRequiredExec.TRAIL_STAGE_REQUIRED_EXEC_RETRY) {
+                        perSampleRetries.incrementAndGet()
+                    }
+                }
+            },
+        )
+        val samples = try {
+            measureWarmReconcileSamples(count = 3) {
+                retries += perSampleRetries.getAndSet(0)
+                armOneShotSlowListSessions(SLOW_LIST_SESSIONS_SECONDS)
+            }
+        } finally {
+            retries += perSampleRetries.get()
+            DiagnosticEvents.install(DiagnosticEventSink.Noop)
+            disarmSlowListSessions()
+        }
+        // `retries[i]` is the count observed BEFORE sample i was armed, i.e. the
+        // retries of sample i-1; the trailing entry closes the last sample.
+        val retriesPerSample = retries.drop(1)
         println(
-            "ISSUE1876_RECONCILE_CHAIN profile=${DELAY_MS}ms+-${JITTER_MS}ms/loss=$LOSS_RATE " +
-                "(rtt~${2 * DELAY_MS}ms) roots=${WATCHED_ROOT_PATHS.size} " +
-                "elapsedMs=$elapsedMs bound=${FolderListViewModel.RECONCILE_TIMEOUT_MS}",
+            samples.report("ISSUE2422_SLOW_REQUIRED_EXEC") +
+                " slowListSessions=${SLOW_LIST_SESSIONS_SECONDS}s " +
+                "requiredExecRetries=$retriesPerSample",
         )
-        assertTrue(
-            "The reconcile must not have failed outright: $result",
-            result is FolderListResult.Sessions,
-        )
-        assertTrue(
-            "Issue #1876: the folder-tree reconcile chain took ${elapsedMs}ms over a " +
-                "~${2 * DELAY_MS}ms-RTT / $LOSS_RATE-loss link, against the production " +
-                "${FolderListViewModel.RECONCILE_TIMEOUT_MS}ms RECONCILE_TIMEOUT_MS. On the " +
-                "device that is the ConnectError panel whose Retry re-runs the same chain.",
-            elapsedMs < FolderListViewModel.RECONCILE_TIMEOUT_MS,
-        )
+        retriesPerSample.forEachIndexed { index, count ->
+            assertTrue(
+                "sample $index: the fixture must actually have pushed the REQUIRED landing " +
+                    "batch past its ${SshFolderListGateway.EXEC_READ_TIMEOUT_MS}ms bound — no " +
+                    "`${FolderListRequiredExec.TRAIL_STAGE_REQUIRED_EXEC_RETRY}` breadcrumb means " +
+                    "nothing was slowed and this arm proves nothing. " +
+                    "requiredExecRetries=$retriesPerSample",
+                count >= 1,
+            )
+        }
+        samples.forEachIndexed { index, sample ->
+            assertEquals(
+                "sample $index: a required landing exec that over-ran its " +
+                    "${SshFolderListGateway.EXEC_READ_TIMEOUT_MS}ms bound on a link that was " +
+                    "ALIVE the whole time must be retried on the SAME warm lease. Evicting it " +
+                    "and re-dialling re-runs the entire reconcile and is what pushed a healthy " +
+                    "6.5s chain to 12.5s — the #1870/#1876 'Couldn't refresh the project tree' " +
+                    "panel on mobile. ${samples.report("ISSUE2422_SLOW_REQUIRED_EXEC")}",
+                0,
+                sample.extraSshLogins,
+            )
+            val sessions = sample.result as? FolderListResult.Sessions
+                ?: error("sample $index: a slow required exec must still land a tree, got ${sample.result}")
+            val names = sessions.rows.map { it.sessionName }.toSet()
+            assertTrue(
+                "sample $index: the retried required batch must still enumerate every " +
+                    "seeded session; names=$names seeded=$SEEDED_SESSIONS",
+                names.containsAll(SEEDED_SESSIONS.toSet()),
+            )
+        }
+        // Deliberately NO wall-clock assertion here, and the measurement says why:
+        // a reconcile that abandons its required batch measures 12.3-13.2 s with
+        // this fix and 12.5-13.5 s without it, because the wasted
+        // EXEC_READ_TIMEOUT_MS plus the retried batch plus the remaining kind and
+        // decoration work does not fit 12 s either way. Removing the re-dial is
+        // worth ~1-2 s and one SSH handshake; it does NOT make an over-run fit the
+        // user-visible bound. That residue is #1876's unfinished scope item —
+        // render the tree from cache and reconcile in the background so no
+        // user-visible action is gated on the chain at all — and belongs to its own
+        // issue, not to a wall-clock assertion here that would only encode the
+        // current cost as if it were acceptable.
     }
 
     /**
@@ -493,36 +913,44 @@ class Issue1876FolderReconcileMobileRttIntegrationTest {
      * contains that optional failure, so the load-bearing assertions are BOTH
      * the extra login count (read from sshd itself, not from an app seam) and
      * the reconcile still landing inside its production bound with a real tree.
+     *
+     * Issue #2422: the timing half is measured over [SLOW_CLI_SAMPLES] samples
+     * for the same reason as [reconcileChainFitsTheProductionReconcileBoundOnAMobileLink]
+     * — this arm carried the least headroom of the three (10 467 ms against 12 000
+     * ms locally). The per-sample login and content assertions stay per-sample:
+     * they are binary, not timing-derived, and no sample may violate them.
      */
     @Test(timeout = 600_000)
     fun aSlowButAliveHostCliDoesNotCostAFreshDialOrTheWholeTree() {
         setSlowLogsDelay(SLOW_LOGS_SECONDS)
         try {
-            val run = measureWarmReconcileWithLogins()
+            val samples = measureWarmReconcileSamples(SLOW_CLI_SAMPLES)
             println(
-                "ISSUE1876_SLOW_HOST_CLI slowLogs=${SLOW_LOGS_SECONDS}s " +
-                    "elapsedMs=${run.elapsedMs} extraSshLogins=${run.extraSshLogins} " +
-                    "bound=${FolderListViewModel.RECONCILE_TIMEOUT_MS}",
+                samples.report("ISSUE1876_SLOW_HOST_CLI") +
+                    " slowLogs=${SLOW_LOGS_SECONDS}s",
             )
-            assertEquals(
-                "a slow-but-alive host CLI must NOT cost a fresh SSH dial — the warm " +
-                    "lease was still connected, and re-dialling is what turned 'slow' " +
-                    "into 'cannot connect' (#1870)",
-                0,
-                run.extraSshLogins,
-            )
-            val sessions = run.result as? FolderListResult.Sessions
-                ?: error("a slow optional probe must not fail the reconcile, got ${run.result}")
-            val names = sessions.rows.map { it.sessionName }.toSet()
-            assertTrue(
-                "the tree must still contain every seeded session despite the slow probe; " +
-                    "names=$names seeded=$SEEDED_SESSIONS",
-                names.containsAll(SEEDED_SESSIONS.toSet()),
-            )
+            samples.forEachIndexed { index, run ->
+                assertEquals(
+                    "sample $index: a slow-but-alive host CLI must NOT cost a fresh SSH " +
+                        "dial — the warm lease was still connected, and re-dialling is what " +
+                        "turned 'slow' into 'cannot connect' (#1870)",
+                    0,
+                    run.extraSshLogins,
+                )
+                val sessions = run.result as? FolderListResult.Sessions
+                    ?: error("a slow optional probe must not fail the reconcile, got ${run.result}")
+                val names = sessions.rows.map { it.sessionName }.toSet()
+                assertTrue(
+                    "sample $index: the tree must still contain every seeded session despite " +
+                        "the slow probe; names=$names seeded=$SEEDED_SESSIONS",
+                    names.containsAll(SEEDED_SESSIONS.toSet()),
+                )
+            }
             assertTrue(
                 "the reconcile must still fit ${FolderListViewModel.RECONCILE_TIMEOUT_MS}ms " +
-                    "with one ${SLOW_LOGS_SECONDS}s host-CLI probe in it, got ${run.elapsedMs}ms",
-                run.elapsedMs < FolderListViewModel.RECONCILE_TIMEOUT_MS,
+                    "with one ${SLOW_LOGS_SECONDS}s host-CLI probe in it. " +
+                    samples.report("ISSUE1876_SLOW_HOST_CLI"),
+                samples.minElapsedMs() < FolderListViewModel.RECONCILE_TIMEOUT_MS,
             )
         } finally {
             setSlowLogsDelay("0")

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListGateway.kt
@@ -626,7 +626,8 @@ class SshFolderListGateway internal constructor(
                         val required = landingProbeOwner.executeRequired(
                             watchedRoots = watchedRoots,
                             includeEnumeration = false,
-                            exec = { command -> session.execBounded(pathAware(command)) },
+                            // #2422: the ONE exec whose over-run escapes.
+                            exec = { command -> session.execRequiredBounded(pathAware(command)) },
                         )
                         val ports = async { PortScanner.scan(session) }
                         val expansion = async {
@@ -655,7 +656,8 @@ class SshFolderListGateway internal constructor(
                         val required = landingProbeOwner.executeRequired(
                             watchedRoots = watchedRoots,
                             includeEnumeration = true,
-                            exec = { command -> session.execBounded(pathAware(command)) },
+                            // #2422: the ONE exec whose over-run escapes.
+                            exec = { command -> session.execRequiredBounded(pathAware(command)) },
                         )
                         val ports = async { PortScanner.scan(session) }
                         val expansion = async {
@@ -786,6 +788,17 @@ class SshFolderListGateway internal constructor(
         // while never killing a slow-but-alive one.
         throw FolderListExecTimeoutException(command, execReadTimeoutMs)
     }
+
+    /**
+     * Issue #2422 — the REQUIRED landing batch's exec: over-running its bound on a
+     * still-connected transport is answered by ONE retry in place, not by evicting
+     * the warm lease and re-running the whole reconcile on a fresh dial. Rationale,
+     * measurements and the load-bearing negative live in [execRequiredLandingBounded].
+     */
+    private suspend fun SshSession.execRequiredBounded(command: String): ExecResult =
+        execRequiredLandingBounded(command, execReadTimeoutMs) { retried ->
+            execBounded(retried)
+        }
 
     private suspend fun <T> withLeaseSession(
         host: HostEntity,
@@ -1008,7 +1021,8 @@ class SshFolderListGateway internal constructor(
         val required = landingProbeOwner.executeRequired(
             watchedRoots = watchedRoots,
             includeEnumeration = false,
-            exec = { command -> session.execBounded(pathAware(command)) },
+            // Same required batch, same #2422 policy as production.
+            exec = { command -> session.execRequiredBounded(pathAware(command)) },
         )
         ReconcileSideProbes(
             expansion = async {

--- a/app/src/main/java/com/pocketshell/app/projects/FolderListRequiredExec.kt
+++ b/app/src/main/java/com/pocketshell/app/projects/FolderListRequiredExec.kt
@@ -1,0 +1,131 @@
+package com.pocketshell.app.projects
+
+import android.util.Log
+import com.pocketshell.app.diagnostics.ReconnectCauseTrail
+import com.pocketshell.app.ssh.BoundedSessionExec
+import com.pocketshell.core.ssh.ExecResult
+import com.pocketshell.core.ssh.SshSession
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Cause-trail vocabulary for the issue #2422 required-landing-batch retry.
+ *
+ * Lives beside the behaviour rather than in `SshFolderListGateway`'s companion so
+ * the hot gateway file stays under its size ratchet.
+ */
+internal object FolderListRequiredExec {
+    /**
+     * The REQUIRED landing batch over-ran its bound on a still-connected
+     * transport and was retried in place, instead of evicting the warm lease and
+     * re-running the whole reconcile on a fresh dial.
+     */
+    const val TRAIL_STAGE_REQUIRED_EXEC_RETRY: String = "folder_list_required_exec_retry"
+
+    /** Retried in place; the warm transport was kept. */
+    const val TRAIL_OUTCOME_RETRIED_ON_WARM_TRANSPORT: String = "retried_on_warm_transport"
+}
+
+/**
+ * Issue #2422 — run the REQUIRED folder-reconcile landing batch, retrying ONCE on
+ * the SAME warm transport when it over-runs [timeoutMs].
+ *
+ * ## Why this exists
+ *
+ * The required landing batch ([FolderListLandingProbeOwner.executeRequired]) is
+ * the ONLY exec in a reconcile whose failure escapes: every other probe (the
+ * tmuxctl/aplexer enumerator, the foreign-kind guess, the optional host-CLI
+ * decoration, the port scan) is fail-soft and degrades in place. When the required
+ * batch throws [FolderListExecTimeoutException], `isStaleChannelSymptom`
+ * classifies it as a POISONED TRANSPORT, so the lease attempt evicts the warm
+ * lease and the whole chain re-runs on a brand-new SSH dial.
+ *
+ * On a mobile link that response is expensive, and it fires on a link that is
+ * working. Measured on the repo's own netem shaper at ~400 ms RTT / 5 % loss
+ * (`Issue1876FolderReconcileMobileRttIntegrationTest`, three samples each, with
+ * one required-batch over-run forced per sample):
+ *
+ * ```text
+ * no over-run                     5881-8530 ms,  0 extra SSH logins
+ * over-run, evict + fresh dial   15189-17018 ms, 1 extra SSH login   (before)
+ * over-run, retry in place       12322-13223 ms, 0 extra SSH logins  (after)
+ * ```
+ *
+ * At that profile 1-3 execs per reconcile already run into their bound, so which
+ * one loses is luck; the required batch losing used to add ~8 s and a fresh
+ * handshake. That is the scheduled-CI failure this issue was filed for
+ * (`elapsedMs=12545 bound=12000`, on a run that still returned a COMPLETE tree)
+ * and, on a phone, part of #1870's server-side evidence: four successful publickey
+ * authentications in two minutes while the user saw nothing load.
+ *
+ * ## Why a retry, and why on the SAME transport
+ *
+ * [BoundedSessionExec] abandons a slow exec WITHOUT touching the transport, and
+ * records `transportAlive` in the cause trail, precisely because a starved exec is
+ * not evidence of a dead link — its own doc states that "callers get the retryable
+ * timeout and retry on the SAME warm transport". That retry never existed for this
+ * caller; the only recovery on offer was the lease-level heal, which pays a fresh
+ * TCP+SSH handshake and redoes every probe. So a host command that is merely SLOW
+ * (a congested mobile link, a cold host Python CLI) is answered here by one more
+ * attempt on the warm transport.
+ *
+ * ## The load-bearing negative
+ *
+ * Only a SECOND over-run — or a transport sshj already knows is down — falls
+ * through to the UNCHANGED evict-and-re-dial heal, via [retryBoundedExec]'s own
+ * abandon-and-throw. Over-guarding that away would strand a genuinely dead
+ * transport and stop the tree recovering at all, which is strictly worse than the
+ * doubled reconcile this removes; `FolderListGatewayExecTimeoutTest`'s persistent
+ * and transient wedge pair pins both halves.
+ *
+ * The worst case is bounded and no worse than before: two abandoned execs
+ * (2 x [timeoutMs]) instead of one abandoned exec plus a fresh dial and a full
+ * second chain.
+ *
+ * @param retryBoundedExec the caller's ordinary bounded exec — it keeps the
+ *   unchanged abandon + log + [FolderListExecTimeoutException] behaviour, so this
+ *   function never has to re-implement the failure path.
+ */
+internal suspend fun SshSession.execRequiredLandingBounded(
+    command: String,
+    timeoutMs: Long,
+    retryBoundedExec: suspend (String) -> ExecResult,
+): ExecResult {
+    val first = BoundedSessionExec.execBounded(
+        session = this,
+        command = command,
+        timeoutMs = timeoutMs,
+        dispatcher = Dispatchers.IO,
+        callerSite = SshFolderListGateway.TRAIL_CALLER_SITE,
+    )
+    if (first != null) return first
+    if (!isConnected) {
+        // sshj already knows the transport is gone: this is the DEAD case the
+        // lease-level evict-and-re-dial heal owns. Retrying here would only burn
+        // another bound before reaching it.
+        Log.w(
+            SshFolderListGateway.PROBE_LOG_TAG,
+            "required folder-list landing exec over-ran ${timeoutMs}ms on a DISCONNECTED " +
+                "transport; deferring to the lease heal (issue #2422)",
+        )
+        throw FolderListExecTimeoutException(command, timeoutMs)
+    }
+    Log.w(
+        SshFolderListGateway.PROBE_LOG_TAG,
+        "required folder-list landing exec over-ran ${timeoutMs}ms on a still-CONNECTED " +
+            "transport; retrying ONCE on the same warm lease instead of evicting it and " +
+            "re-running the whole reconcile on a fresh dial (issue #2422)",
+    )
+    // The retry must not be invisible: without a breadcrumb an exported diagnostics
+    // report cannot tell "the landing batch over-ran once and recovered in place"
+    // from "the reconcile was simply slow" — the distinction that took a netem
+    // reproduction to establish in the first place.
+    ReconnectCauseTrail.record(
+        stage = FolderListRequiredExec.TRAIL_STAGE_REQUIRED_EXEC_RETRY,
+        outcome = FolderListRequiredExec.TRAIL_OUTCOME_RETRIED_ON_WARM_TRANSPORT,
+        cause = "required_exec_no_result_within_bound",
+        "callerSite" to SshFolderListGateway.TRAIL_CALLER_SITE,
+        "timeoutMs" to timeoutMs,
+        "transportAlive" to true,
+    )
+    return retryBoundedExec(command)
+}

--- a/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayExecTimeoutTest.kt
+++ b/app/src/test/java/com/pocketshell/app/projects/FolderListGatewayExecTimeoutTest.kt
@@ -25,7 +25,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 import java.io.InputStream
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -58,12 +57,16 @@ class FolderListGatewayExecTimeoutTest {
      * The host is PERSISTENTLY wedged (every exec parks), so the #680 heal +
      * retry cannot rescue it and the bounded [FolderListResult.ConnectFailed]
      * must still surface rather than the screen hanging in `Loading` forever.
-     * The bound now costs two attempts instead of one — still bounded, which is
-     * the property #470 actually guarantees.
+     * The bound costs several attempts instead of one — #1641's evict-and-re-dial
+     * heal, and now #2422's same-transport retry inside each lease attempt — but it
+     * is still a fixed multiple of [SshFolderListGateway.EXEC_READ_TIMEOUT_MS],
+     * which is the property #470 actually guarantees.
      *
      * The single-transient-wedge case now HEALS instead of surfacing a scary
-     * banner (that is #680's design, and #1641 made the exec timeout reach it);
-     * see `wedgedExecStillEvictsAndRetriesOnAFreshTransport`.
+     * banner (that is #680's design, #1641 made the exec timeout reach it, and
+     * #2422 made it heal without a fresh dial); see
+     * `transientlyWedgedRequiredExecHealsOnTheSameWarmTransportWithoutAReDial` and
+     * `persistentlyWedgedRequiredExecStillEvictsAndRetriesOnAFreshTransport`.
      */
     @Test
     fun persistentlyWedgedListSessionsReadStillSurfacesBoundedConnectFailed() = runBlocking {
@@ -204,15 +207,23 @@ class FolderListGatewayExecTimeoutTest {
      * the first one wedged. Unlike the deleted `close()`, that eviction goes
      * through `evictIdle`, which is refcount-aware and leaves a transport an
      * ACTIVE session VM still holds alone (#758).
+     *
+     * Issue #2422 narrows WHEN that heal fires: the required landing batch is now
+     * retried once on the SAME warm transport first, so reaching the re-dial takes
+     * a PERSISTENTLY unresponsive required probe ([requiredEnumerationWedges] = 2),
+     * not a single transient over-run. This is the load-bearing negative of #2422 —
+     * over-guarding the retry (never re-dialling) would strand a genuinely dead
+     * transport, which is strictly worse than the doubled reconcile it removed.
      */
     @Test
-    fun wedgedExecStillEvictsAndRetriesOnAFreshTransport() = runBlocking {
+    fun persistentlyWedgedRequiredExecStillEvictsAndRetriesOnAFreshTransport() = runBlocking {
         // Issue #2359: #2348 starts the optional pocketshell enumerator in
         // parallel with the required landing batch. Wedge the required
         // command by its marker, not whichever concurrent child happens to
         // reach the fake first.
         val wedged = WedgingSshSession(
             wedgeRequiredEnumeration = true,
+            requiredEnumerationWedges = 2,
             releaseRequiredEnumerationAfterOptional = true,
         )
         val healthy = WedgingSshSession(wedgeFirstExec = false)
@@ -236,9 +247,10 @@ class FolderListGatewayExecTimeoutTest {
         val observedCommands = wedged.snapshotExecCommands()
         val requiredEnumerationCommands = observedCommands.filter(::isRequiredLandingEnumeration)
         assertEquals(
-            "the fake must observe one required landing enumeration; " +
-                "observed exec commands=$observedCommands",
-            1,
+            "issue #2422: the poisoned transport must see the required landing " +
+                "enumeration TWICE — one over-run plus the same-transport retry — " +
+                "before the lease heal re-dials; observed exec commands=$observedCommands",
+            2,
             requiredEnumerationCommands.size,
         )
         val optionalEnumeratorIndex = observedCommands.indexOfFirst { command ->
@@ -258,7 +270,7 @@ class FolderListGatewayExecTimeoutTest {
             "the required landing enumeration, not the optional concurrent " +
                 "pocketshell enumerator, must be the wedged command; " +
                 "observed exec commands=$observedCommands",
-            requiredEnumerationCommands.single(),
+            requiredEnumerationCommands.first(),
             wedged.wedgedCommand,
         )
         assertEquals(
@@ -277,6 +289,83 @@ class FolderListGatewayExecTimeoutTest {
         // only ever takes a lease at refCount == 0. That guard is pinned by
         // `wedgedExecMustNotYankATransportAnActiveConsumerHolds` below, which is
         // the case the deleted raw `close()` violated.
+    }
+
+    /**
+     * Issue #2422 — a TRANSIENT required-exec over-run must heal on the SAME warm
+     * transport, with NO fresh dial and NO second full chain.
+     *
+     * This is the JVM half of the class regression. On a mobile link the required
+     * landing batch losing its race against [SshFolderListGateway.EXEC_READ_TIMEOUT_MS]
+     * is routine (the netem reproduction records 1-3 abandoned execs per reconcile
+     * at ~400 ms RTT / 5 % loss). Before this fix that over-run was answered by
+     * evicting the warm lease, paying a brand-new TCP+SSH handshake and re-running
+     * every probe — measured on the netem fixture at 15.2-17.0 s with one extra
+     * sshd login, versus 12.3-13.2 s and zero extra logins once the batch is
+     * retried in place, against a 12 s user-visible `RECONCILE_TIMEOUT_MS` and an
+     * un-amplified chain of 5.9-8.5 s. That is the "Couldn't refresh the project
+     * tree" panel on a link that was working the whole time, and the
+     * scheduled-CI failure (`elapsedMs=12545 bound=12000`) this issue was filed
+     * for.
+     *
+     * The fixture wedges the required landing enumeration EXACTLY ONCE, so the
+     * distinguishing observation is the DIAL COUNT: one dial (retry on the warm
+     * transport) versus two (evict + fresh transport). Both variants return
+     * `Sessions`, so the result type alone cannot tell them apart — the dial count
+     * is the load-bearing assertion (G6).
+     */
+    @Test
+    fun transientlyWedgedRequiredExecHealsOnTheSameWarmTransportWithoutAReDial() = runBlocking {
+        val wedged = WedgingSshSession(
+            wedgeRequiredEnumeration = true,
+            requiredEnumerationWedges = 1,
+            releaseRequiredEnumerationAfterOptional = true,
+        )
+        val fresh = WedgingSshSession(wedgeFirstExec = false)
+        val connector = SequenceConnector(listOf(wedged, fresh))
+        val gateway = SshFolderListGateway(
+            reposRemoteSource = ReposRemoteSource(ReposJsonParser()),
+            activeTmuxClients = ActiveTmuxClients(),
+            sshLeaseManager = SshLeaseManager(connector = connector, idleTtlMillis = 0L),
+            sessionListParser = com.pocketshell.app.sessions.HostTmuxSessionListParser(),
+            execReadTimeoutMs = 250L,
+        )
+
+        val result = gateway.listSessionsWithFolder(
+            host = HOST,
+            keyPath = KEY_PATH,
+            passphrase = null,
+            watchedRoots = WATCHED_ROOTS,
+        )
+
+        assertTrue("the required exec must have wedged once", wedged.wedgedExecStarted.isCompleted)
+        assertEquals(
+            "issue #2422: a transient required-exec over-run must be retried on the " +
+                "SAME warm transport — evicting it and re-dialling is what doubled the " +
+                "reconcile past its 12s bound on a link that was alive the whole time",
+            1,
+            connector.dialCount,
+        )
+        assertEquals(
+            "the same warm transport must have carried BOTH the over-run and the retry; " +
+                "observed exec commands=${wedged.snapshotExecCommands()}",
+            2,
+            wedged.snapshotExecCommands().count(::isRequiredLandingEnumeration),
+        )
+        assertTrue(
+            "no work may be re-run on a fresh transport; the second session must be " +
+                "untouched, observed=${fresh.snapshotExecCommands()}",
+            fresh.execCommands.isEmpty(),
+        )
+        assertTrue(
+            "the reconcile must still land a complete Sessions result, got $result",
+            result is FolderListResult.Sessions,
+        )
+        // NOTE: `wedged.closed` is not asserted here. This lease manager runs with
+        // `idleTtlMillis = 0`, so the pool legitimately closes the transport as
+        // soon as the reconcile releases it — that is lease-pool lifecycle, not the
+        // retry. "A slow exec must not close a transport a consumer holds" is
+        // pinned by `wedgedExecMustNotYankATransportAnActiveConsumerHolds`.
     }
 
     /**
@@ -411,6 +500,14 @@ class FolderListGatewayExecTimeoutTest {
          */
         private val wedgeRequiredEnumeration: Boolean = false,
         /**
+         * Issue #2422: how many required landing enumerations wedge before the
+         * fake starts answering. The required batch is now retried ONCE on the
+         * SAME warm transport before the lease-level evict-and-re-dial heal, so
+         * `1` is a TRANSIENT over-run (must heal in place, no re-dial) and `2` is
+         * a PERSISTENTLY unresponsive required probe (must still reach the heal).
+         */
+        private val requiredEnumerationWedges: Int = 1,
+        /**
          * Test-only barrier that records the optional JSON command before the
          * required command proceeds. This makes the old first-call mutant
          * deterministically select the wrong concurrent command without a
@@ -420,7 +517,7 @@ class FolderListGatewayExecTimeoutTest {
     ) : SshSession {
         val execCommands: MutableList<String> = java.util.Collections.synchronizedList(mutableListOf<String>())
         val wedgedExecStarted = CompletableDeferred<Unit>()
-        private val markerWedgeSelected = AtomicBoolean(false)
+        private val requiredEnumerationWedgeCount = java.util.concurrent.atomic.AtomicInteger(0)
         private val selectedWedgeCommand = AtomicReference<String?>(null)
         private val optionalEnumeratorStarted = CompletableDeferred<Unit>()
         val wedgedCommand: String?
@@ -451,7 +548,7 @@ class FolderListGatewayExecTimeoutTest {
             }
             val selectedByRequiredMarker = wedgeRequiredEnumeration &&
                 isRequiredEnumeration &&
-                markerWedgeSelected.compareAndSet(false, true)
+                requiredEnumerationWedgeCount.getAndIncrement() < requiredEnumerationWedges
             val shouldWedge = wedgeEveryExec ||
                 (index == 0 && wedgeFirstExec) ||
                 selectedByRequiredMarker

--- a/docs/ci-pitfalls.md
+++ b/docs/ci-pitfalls.md
@@ -263,6 +263,33 @@ the recovered/CLEAN ones — and diff the notice count against the pre-change
 script for each; "the case I built it for changed and nothing else did" is a
 claim that needs the table, not an assumption.
 
+## One wall-clock sample against a hard bound is a coin flip, and hides a mode
+
+A timing assertion of the form "this run took N ms, N must be under BOUND" is
+only a measurement when the quantity has a light tail. Over a shaped/lossy link
+(or on a shared runner) the noise is STRICTLY ADDITIVE — TCP loss recovery with
+exponential backoff, CPU steal, a retry the code takes internally — so a sample
+is `structural cost + non-negative noise`, and one sample says almost nothing
+about the structure it claims to constrain. Issue #2422's chain measured 12 545 ms
+against a hard 12 000 ms bound on a scheduled run, then 6 496 ms on the very next
+measurement of the SAME commit, JVM, container and shaper.
+
+Two lessons, and the second matters more:
+
+- Judge such an assertion on the MINIMUM of N samples (the maximum-likelihood
+  estimate of a cost with one-sided noise), record the observed distribution next
+  to the constant, and add a mutation arm proving a genuinely slower run still
+  fails. A budget applied to the minimum can then be TIGHTER than the production
+  bound — strictly stronger than the single-sample form it replaces, not a
+  widened band.
+- Before re-baselining, check whether the outlier is a TAIL or a separate MODE.
+  #2422's was a mode: forcing the failing condition put the chain in a
+  15.2-17.0 s band with no overlap against the 5.9-8.5 s healthy band, because
+  one over-run exec made production evict a warm SSH lease and re-run the whole
+  chain on a fresh dial. "Flaky test, widen the bound" would have closed the
+  issue and kept shipping the defect. If the outlier band is disjoint from the
+  healthy band, you have a bug, not noise.
+
 See also [worktrees.md](worktrees.md) for merge-mechanics pitfalls and
 [review-standards.md](review-standards.md) for reviewer-side acceptance
 bars this catalogue feeds into.


### PR DESCRIPTION
Closes #2422

Root cause, fix, and full review evidence are on the issue: https://github.com/alexeygrigorev/pocketshell/issues/2422#issuecomment-5467677746

This is the last item on the day-long D36 episode tracked at #2373. Once this merges and a scheduled full-suite run confirms green, that freeze can close.

Note: this changes production code (`FolderListGateway.kt` + new `FolderListRequiredExec.kt`), which the issue originally listed as a non-goal on a premise the investigation disproved — see the issue thread for the corrected record and reviewer's explicit judgment that the override was warranted, not a process violation.