### PR TITLE
Fix attach-timeout budget nesting by shrinking the inner stage, not the ceiling

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdDialUnderBandwidthLimitE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdDialUnderBandwidthLimitE2eTest.kt
@@ -4,10 +4,12 @@ import android.os.SystemClock
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pocketshell.app.MainActivity
+import com.pocketshell.app.projects.FOLDER_LIST_CONTENT_TAG
 import com.pocketshell.app.projects.FOLDER_LIST_ERROR_TAG
 import com.pocketshell.app.projects.FOLDER_LIST_RETRY_TAG
 import kotlinx.coroutines.runBlocking
@@ -93,11 +95,28 @@ class ColdDialUnderBandwidthLimitE2eTest : NetworkFaultProofBase() {
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
 
         // The cold dial: host-row tap -> folder/session enumeration -> tmux attach,
-        // every connect riding the degraded link. attachToSession throws if the
+        // every connect riding the degraded link. openSessionFromList throws if the
         // picker wedges (session row never lists) or the terminal never attaches
         // (dial aborted) — so a green attach IS the within-budget proof.
+        //
+        // Issue #2409 (round 2): this used to call attachToSession(), whose
+        // enumeration wait has no tolerance for the app's OWN retryable
+        // folder-list panel. Reproduced on this box: at this severity (350 ±200 ms
+        // one-way, RTT 0.7–1.1 s) the FolderListGateway bounded exec — a hard
+        // 3.5 s TOTAL budget for ~2–3 round-trips — sits ON its cliff, so the
+        // enumeration intermittently lands on "Couldn't refresh the project tree —
+        // tap to retry" and this DIAL proof died in setup with
+        // `folder-list:content=0`, never reaching the thing it asserts. That is a
+        // second, distinct #2409 recurrence mechanism for this same class. The
+        // enumeration is not what #1064 proves, so heal it through the app's own
+        // Retry affordance and RECORD the taps (see [settleFolderListToleratingRetry]).
         val dialStart = SystemClock.elapsedRealtime()
-        attachToSession(hostRowTag, hostName, sessionName)
+        waitForHostRow(hostRowTag)
+        compose.onNodeWithText(hostName, useUnmergedTree = true).assertExists()
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+        val folderListRetryTaps = settleFolderListToleratingRetry()
+        recordTiming("cold_dial_folder_list_retry_taps", folderListRetryTaps.toLong())
+        openSessionFromList(hostName, sessionName)
         val coldDialMs = SystemClock.elapsedRealtime() - dialStart
         recordTiming("cold_dial_attach_ms", coldDialMs)
 
@@ -147,9 +166,140 @@ class ColdDialUnderBandwidthLimitE2eTest : NetworkFaultProofBase() {
                 "toxics=latency ${COLD_DIAL_LATENCY_MS}ms +/-${COLD_DIAL_JITTER_MS}ms both dirs, " +
                     "bandwidth ${COLD_DIAL_BANDWIDTH_KBPS}KB/s downstream",
                 "cold_dial_attach_ms=$coldDialMs",
+                "cold_dial_folder_list_retry_taps=$folderListRetryTaps",
                 "budget=SshConnection.DEFAULT_TIMEOUT_MS=30000ms, " +
                     "SshLeaseManager.DEFAULT_CONNECT_TIMEOUT_MILLIS=35000ms",
                 "expectation=slow-but-progressing cold dial completes within budget, no Disconnected band, usable",
+            ),
+        )
+        Unit
+    } }
+
+    /**
+     * (1b) Issue #2409 — the SEED-LADDER-SATURATED cold attach.
+     *
+     * [coldDialUnderBufferbloatCompletesWithinBudget] above reproduced the
+     * defect on the nightly emulator but PASSED on a fast dev box, because at
+     * its severity the pre-reveal seed ladder happened to land its `capture-pane`
+     * on the 3rd of 4 attempts (measured locally: panes-ready in 10.07 s against
+     * the then-12 s ceiling — 84 % of budget, i.e. green by 1.9 s of luck). A
+     * proof whose verdict depends on which host runs it is not a proof; per
+     * D32-G10 the fixture that creates the non-happy state has to be part of it.
+     *
+     * So this case PINS the state instead of hoping for it. The dial and folder
+     * enumeration ride the WiFi-baseline severity ([SETUP_ONE_WAY_LATENCY_MS],
+     * RTT ≈ 150 ms — that constant's KDoc explains why it is NOT the cold-dial
+     * severity), and the link is retuned IN PLACE to [ATTACH_SEED_LATENCY_MS] at
+     * the last possible moment — after the picker has settled, immediately before
+     * the session row is tapped. At that severity an exec-lane round-trip costs
+     * ≈4 s, which is deterministically:
+     *
+     *  - ABOVE the seed `capture-pane` ceiling (`SEED_CAPTURE_TIMEOUT_MS`, 2.5 s),
+     *    so EVERY seed attempt times out; and
+     *  - BELOW the reconcile ceiling (`RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS`, 6 s),
+     *    so `list-panes` still SUCCEEDS and the link is genuinely
+     *    slow-but-progressing, never wedged.
+     *
+     * Before the fix the pre-reveal seed took the FULL
+     * `SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS` force-heal ladder, so one
+     * `reconcilePanes()` cost ≈14 s of honest, budgeted work inside a flat 12 s
+     * `ATTACH_PANES_READY_TIMEOUT_MS`: the app cancelled it mid-flight and went
+     * `Attaching -> Unreachable` with "Tap Reconnect to retry" — the exact
+     * nightly failure. With the pre-reveal seed bounded to
+     * `ATTACH_ACTIVE_PANE_SEED_ATTEMPTS` (and the ceiling now DERIVED from that,
+     * still 12 s), the same attach fits and completes — while the never-reveal-
+     * black gate and the #662 blank-pane net keep healing the pane afterwards,
+     * outside the ceiling.
+     *
+     * The elapsed-time assertion below is the anti-vacuous pin: the attach still
+     * has to take longer than a clean-link attach possibly could, so a fixture
+     * that stopped applying its severity fails here rather than passing for the
+     * wrong reason.
+     */
+    @Test
+    fun coldAttachWhoseSeedLadderIsSaturatedStillCompletesInsteadOfSurrendering() { runBlocking {
+        assumeNetworkFaultProofsEnabled()
+
+        val key = readFixtureKey()
+        val marker = "cq${System.currentTimeMillis().toString(36).takeLast(5)}"
+        val sessionName = "issue2409-seed-$marker"
+        val hostName = "Issue2409 Seed $marker"
+
+        prepareProxyAndRemoteSession(
+            key = key,
+            sessionName = sessionName,
+            readyText = "ISSUE2409-SEED-READY-$marker",
+        )
+        val hostRowTag = seedNetworkFaultHost(key, hostName)
+
+        // SETUP severity — see [SETUP_ONE_WAY_LATENCY_MS]. A toxic IS installed
+        // (so the attach-phase retune below is an in-place update on the live
+        // link, never a clean window), but at the WiFi baseline, which is the
+        // documented ZERO-bounded-exec-overrun extreme.
+        val proxy = toxiproxy()
+        proxy.addSymmetricLatency(oneWayMs = SETUP_ONE_WAY_LATENCY_MS)
+        recordTiming("setup_one_way_latency_ms", SETUP_ONE_WAY_LATENCY_MS.toLong())
+
+        launchedActivity = ActivityScenario.launch(MainActivity::class.java)
+
+        waitForHostRow(hostRowTag)
+        compose.onNodeWithTag(hostRowTag, useUnmergedTree = true).performClick()
+
+        // Settle the enumeration BEFORE the attach severity is raised, healing a
+        // retryable folder-list failure through the app's own Retry affordance
+        // (see [settleFolderListToleratingRetry]). Recorded, never silent.
+        val folderListRetryTaps = settleFolderListToleratingRetry()
+        recordTiming("folder_list_retry_taps", folderListRetryTaps.toLong())
+
+        val attachStart = SystemClock.elapsedRealtime()
+        var attachSeverityAppliedAtMs = 0L
+        openSessionFromList(hostName, sessionName) {
+            // The fixture: retune the LIVE toxic in place (no clean window) so the
+            // attach — and only the attach — rides the seed-saturating severity.
+            proxy.updateJitterLatency(latencyMs = ATTACH_SEED_LATENCY_MS, jitterMs = 0)
+            attachSeverityAppliedAtMs = SystemClock.elapsedRealtime()
+            recordTiming("attach_seed_latency_ms", ATTACH_SEED_LATENCY_MS.toLong())
+        }
+        val attachMs = SystemClock.elapsedRealtime() - attachSeverityAppliedAtMs
+        recordTiming("saturated_seed_attach_ms", attachMs)
+        recordTiming("saturated_seed_total_ms", SystemClock.elapsedRealtime() - attachStart)
+
+        // LOAD-BEARING: the app must not surrender a healthy attach. openSessionFromList
+        // throws with the VM's real connection status if the terminal never attached
+        // (#2409's harness fix), and a settled Failed band is the rendered form of the
+        // same give-up.
+        assertNoDisconnectBand("cold-attach-with-saturated-seed-ladder")
+
+        // Anti-vacuous: the retune genuinely engaged. At ${ATTACH_SEED_LATENCY_MS}ms
+        // one way an exec round-trip costs ≈4s, and the attach pays several of them
+        // (-CC connect, list-panes, the seed capture that must time out, the reveal
+        // gate's re-captures). A clean-link attach here is ~1s, so a value under
+        // this floor means the toxic never applied — the exact way the sibling above
+        // passed on a fast box while failing nine nightly runs.
+        assertTrue(
+            "expected the ${ATTACH_SEED_LATENCY_MS}ms one-way retune to make the attach take at " +
+                "least ${SATURATED_ATTACH_MIN_EXPECTED_MS}ms (that is what makes this a " +
+                "regression pin rather than a clean-link attach); attach took ${attachMs}ms",
+            attachMs >= SATURATED_ATTACH_MIN_EXPECTED_MS,
+        )
+
+        waitForClientCountAtMost(key, sessionName, max = 1, label = "saturated-seed live session")
+
+        writeSummary(
+            testName = "ColdDialUnderBandwidthLimitE2eTest#saturatedSeedLadder",
+            lines = listOf(
+                "session=$sessionName",
+                "marker=$marker",
+                "scenario=dial + enumeration at the WiFi baseline " +
+                    "(${SETUP_ONE_WAY_LATENCY_MS}ms one-way), then retune the " +
+                    "LIVE toxic to ${ATTACH_SEED_LATENCY_MS}ms one-way immediately before the " +
+                    "session-row tap so every seed capture-pane exceeds its 2.5s ceiling while " +
+                    "list-panes stays under its 6s ceiling",
+                "setup_one_way_latency_ms=$SETUP_ONE_WAY_LATENCY_MS",
+                "folder_list_retry_taps=$folderListRetryTaps",
+                "saturated_seed_attach_ms=$attachMs",
+                "expectation=the attach completes; the app must NOT go Attaching -> Unreachable " +
+                    "on a link that is merely slow (#2409)",
             ),
         )
         Unit
@@ -226,6 +376,48 @@ class ColdDialUnderBandwidthLimitE2eTest : NetworkFaultProofBase() {
         Unit
     } }
 
+    /**
+     * Issue #2409 (round 2) — settle the host-detail folder list to CONTENT,
+     * healing a RETRYABLE enumeration failure through the app's own Retry
+     * affordance, and report how many taps that took.
+     *
+     * The enumeration is explicitly NOT what this case proves (the attach is),
+     * and `FolderListGateway`'s bounded exec is a hard 3.5 s TOTAL budget
+     * (`BoundedSessionExec.execBounded`, #1641) with NO auto-retry behind it:
+     * once it abandons, the picker parks on [FOLDER_LIST_ERROR_TAG] until a
+     * human (or this helper) taps Retry. On a contended emulator the cold-start
+     * JIT/first-compose of `FolderListScreen` can starve that read's IO worker
+     * long enough to blow the budget on its own — which reddens the ATTACH proof
+     * in its SETUP, producing an artifact indistinguishable from a fixture
+     * outage. Healing it here keeps the failure signal of this test attributable
+     * to the attach.
+     *
+     * This tolerates only the app's OWN advertised recovery path, bounded to
+     * [FOLDER_LIST_MAX_RETRY_TAPS] taps, and the count is recorded as
+     * `folder_list_retry_taps` in the timings + summary — so a fixture that
+     * starts needing retries is VISIBLE in the artifact rather than silently
+     * masked. The retryability of that panel is itself owned (and asserted) by
+     * [stalledColdDialFailsCleanlyToRetryablePickerWithoutWedge] below.
+     */
+    private fun settleFolderListToleratingRetry(): Int {
+        var retryTaps = 0
+        val deadline = SystemClock.elapsedRealtime() + FOLDER_LIST_SETTLE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (hasTag(FOLDER_LIST_CONTENT_TAG)) return retryTaps
+            if (hasTag(FOLDER_LIST_ERROR_TAG) && retryTaps < FOLDER_LIST_MAX_RETRY_TAPS) {
+                compose.onNodeWithTag(FOLDER_LIST_RETRY_TAG, useUnmergedTree = true).performClick()
+                retryTaps++
+            }
+            SystemClock.sleep(FOLDER_LIST_SETTLE_POLL_MS)
+        }
+        // Deliberately NOT an assertion: openSessionFromList's own diagnostic
+        // wait runs next and produces the richer failure report (tag/text probes).
+        return retryTaps
+    }
+
+    private fun hasTag(tag: String): Boolean =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().isNotEmpty()
+
     private fun waitForHostRow(hostRowTag: String) {
         compose.waitUntil(timeoutMillis = TerminalTestTimeouts.screenRenderPresenceTimeoutMs()) {
             compose.onAllNodesWithTag(hostRowTag, useUnmergedTree = true)
@@ -258,5 +450,100 @@ class ColdDialUnderBandwidthLimitE2eTest : NetworkFaultProofBase() {
         // out and surfaced its clean failure, but well under the 300s per-test
         // ci-journey watchdog.
         const val STALL_FAIL_TIMEOUT_MS: Long = 60_000L
+
+        /**
+         * Issue #2409 — one-way latency applied to the ATTACH phase only (see
+         * [coldAttachWhoseSeedLadderIsSaturatedStillCompletesInsteadOfSurrendering]).
+         *
+         * An exec-lane round-trip is roughly `3 x RTT + fixed` = `6 x latency +
+         * ~0.4s`. Measured at the cold-dial 350ms severity a seed capture costs
+         * ≈2.5s — right ON the seed ceiling, which is exactly why the outcome
+         * flipped with the host. 600ms puts it at ≈4s: unambiguously ABOVE the
+         * 2.5s seed ceiling (every seed attempt times out) and unambiguously
+         * BELOW the 6s reconcile ceiling (`list-panes` still succeeds, so the
+         * link is slow, not wedged). Jitter is 0 on purpose — this fixture must
+         * be deterministic, not realistic; the sibling case above owns realism.
+         */
+        const val ATTACH_SEED_LATENCY_MS: Int = 600
+
+        /**
+         * Issue #2409 (round 2) — the SETUP-phase one-way latency for
+         * [coldAttachWhoseSeedLadderIsSaturatedStillCompletesInsteadOfSurrendering],
+         * i.e. why its dial + enumeration run at the WiFi baseline rather than at
+         * the cold-dial severity.
+         *
+         * Round 1 applied `addJitterLatency(350ms ±200ms)` before the activity
+         * launch, mirroring the sibling. That made the case ~57 % red on the
+         * emulator — and every failure was in SETUP, in the folder/session
+         * enumeration, before the fault under test was applied:
+         *
+         * ```
+         * W/PsFolderProbe: folder-list SSH exec read made no progress within 3500ms; ABANDONING
+         * AssertionError: Timed out ... waiting for host-detail folder list ... folder-list:content=0
+         * ```
+         *
+         * `FolderListGateway.execBounded` is a 3.5 s TOTAL budget for a
+         * channel-open + exec + read, i.e. ~2–3 round-trips plus fixed cost —
+         * `ToxiproxyControl.addMobileProfile`'s KDoc pins exactly this
+         * arithmetic. At 350 ±200 ms one-way the RTT is 0.7–1.1 s, so that exec
+         * costs ~2.5–3.5 s: sitting ON the cliff, with the cold-start
+         * JIT/first-compose of `FolderListScreen` (13 MB of compiler allocation
+         * in the failing logcat) enough to tip it over. The setup severity was
+         * therefore an undeclared second fault, racing a budget this case does
+         * not test.
+         *
+         * [ToxiproxyControl.WIFI_ONE_WAY_LATENCY_MS] is the documented
+         * under-threshold extreme of that same variable (RTT ≈ 150 ms, "a
+         * classify at this RTT never overruns the 3.5 s bound"): the enumeration
+         * exec costs a few hundred ms against a 3.5 s budget, ~10× of margin. A
+         * toxic is still INSTALLED, which matters — the attach-phase
+         * `updateJitterLatency` retunes it IN PLACE on the established link, so
+         * there is still no clean window for the round-trip under test to slip
+         * through (that was round 1's reason for the in-place update, and it is
+         * preserved).
+         *
+         * Dropping the setup toxic to zero would have been the other option; a
+         * live-but-benign toxic keeps the in-place-retune property and is
+         * strictly closer to the original intent.
+         */
+        const val SETUP_ONE_WAY_LATENCY_MS: Int = ToxiproxyControl.WIFI_ONE_WAY_LATENCY_MS
+
+        /**
+         * Issue #2409 (round 2) — bound for [settleFolderListToleratingRetry].
+         * Comfortably covers two 3.5 s bounded-exec attempts plus the app's own
+         * evict-and-retry, and stays well under the 300 s per-test ci-journey
+         * watchdog. Matches the picker budget `openSessionFromList` uses next.
+         */
+        const val FOLDER_LIST_SETTLE_TIMEOUT_MS: Long = 60_000L
+
+        /** Poll cadence for [settleFolderListToleratingRetry]. */
+        const val FOLDER_LIST_SETTLE_POLL_MS: Long = 250L
+
+        /**
+         * At most two taps on the app's own Retry affordance. Enough to absorb a
+         * cold-start stall; too few to hide a genuinely broken enumeration (which
+         * would exhaust them and fall through to `openSessionFromList`'s
+         * diagnostic failure).
+         */
+        const val FOLDER_LIST_MAX_RETRY_TAPS: Int = 2
+
+        /**
+         * Issue #2409 — anti-vacuous floor for the saturated-seed case: the
+         * attach phase measured from the in-place toxic retune.
+         *
+         * At [ATTACH_SEED_LATENCY_MS] one-way an exec-lane round-trip costs ≈4 s
+         * and the attach pays several serially (`-CC` connect, `list-panes`, the
+         * seed capture that must reach its 2.5 s ceiling, then the reveal gate's
+         * re-captures), so it cannot come in near a clean-link attach (~1 s here)
+         * unless the toxic silently failed to apply. Measured 15–40 s on the
+         * emulator with the fix in place, so this floor has real margin and is a
+         * fixture-engagement check, not a timing race.
+         *
+         * It is deliberately NOT "the attach must exceed the old 12 s ceiling":
+         * the fix SHRINKS the pre-reveal seed, so the panes-ready stage now
+         * finishes well inside that ceiling. Asserting the old shape would pin the
+         * defect, not the fix.
+         */
+        const val SATURATED_ATTACH_MIN_EXPECTED_MS: Long = 12_000L
     }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NetworkFaultProofBase.kt
@@ -268,7 +268,18 @@ abstract class NetworkFaultProofBase {
      * Splits out of [attachToSession] so multi-session switch proofs can open a
      * second session without re-navigating from the host list.
      */
-    protected fun openSessionFromList(hostName: String, sessionName: String) {
+    protected fun openSessionFromList(
+        hostName: String,
+        sessionName: String,
+        /**
+         * Issue #2409 — run right before the session row is tapped, i.e. with
+         * the picker fully settled and the ATTACH about to start. Lets a proof
+         * scope a fault to the attach phase alone (raising link severity here
+         * leaves the dial/enumeration at their own, separately-budgeted
+         * severity). Default no-op, so every existing caller is unchanged.
+         */
+        beforeSessionRowTap: () -> Unit = {},
+    ) {
         val pickerTimeoutMs = TerminalTestTimeouts.terminalVisibilityTimeoutMs()
         waitUntilWithDiagnostics(
             label = "host-detail folder list for $hostName",
@@ -290,6 +301,7 @@ abstract class NetworkFaultProofBase {
             timeoutMillis = pickerTimeoutMs,
         )
         val sessionRowTag = folderDetailRowTestTag(folderPath, sessionName)
+        beforeSessionRowTap()
         compose.onNodeWithTag(sessionRowTag, useUnmergedTree = true).performClick()
         compose.onNodeWithTag(TMUX_SESSION_SCREEN_TAG, useUnmergedTree = true).assertExists()
         waitForTerminalViewAttached()
@@ -974,8 +986,54 @@ abstract class NetworkFaultProofBase {
     private suspend fun capturePane(client: TmuxClient): CommandResponse =
         client.sendCommand("capture-pane -p")
 
+    /**
+     * Issue #2409 — wait for the attach to actually reach a live TerminalView.
+     *
+     * This used to be a bare `compose.waitUntil(timeoutMillis = 30_000)`. Two
+     * things were wrong with that, and together they hid a real app defect for
+     * nine consecutive nightly runs:
+     *
+     *  1. **The ceiling sat AT the app's own contract, not above it.** 30 s is
+     *     exactly `SshConnection.DEFAULT_TIMEOUT_MS` — the budget for the dial
+     *     ALONE — with nothing left for the tmux `-CC` attach, the
+     *     [ATTACH_PANES_READY_TIMEOUT_MS] panes-ready reconcile, or the
+     *     swiftshader compose of the terminal surface. A harness must never be
+     *     the first thing to give up; if it is, it converts every app-side
+     *     result into the same opaque timeout.
+     *  2. **It threw a bare `ComposeTimeoutException`.** The nightly artifact
+     *     said only "Condition still not satisfied after 30000 ms" while the
+     *     app had already logged `Attaching -> Unreachable`. The verdict the
+     *     gate needed was in logcat, not in the failure.
+     *
+     * The budget is now the cohort's [TERMINAL_ATTACH_BUDGET_MS] (comfortably
+     * above the app's whole dial + attach contract, still far under the 300 s
+     * per-test watchdog, and early-exiting the instant the view attaches), and
+     * a miss reports the VM's real [TmuxSessionViewModel.ConnectionStatus] —
+     * so "the app surrendered" and "the app is still working" can never again
+     * look identical in the artifact.
+     */
     private fun waitForTerminalViewAttached() {
-        compose.waitUntil(timeoutMillis = 30_000) { terminalViewAttached() }
+        val attached = runCatching {
+            compose.waitUntil(timeoutMillis = TERMINAL_ATTACH_BUDGET_MS) { terminalViewAttached() }
+            true
+        }.getOrDefault(false)
+        if (attached) return
+        val status = currentConnectionStatusName()
+        val diagnostics = buildString {
+            appendLine("terminal_attached=false")
+            appendLine("budget_ms=$TERMINAL_ATTACH_BUDGET_MS")
+            appendLine("vm_connection_status=$status")
+            appendLine("disconnect_bands=${disconnectBandCount()}")
+            appendLine("attaching_hold=${hasTag(TMUX_SWITCHING_LOADING_TAG)}")
+            appendLine("connecting_progress_row=${hasTag(TMUX_CONNECTING_PROGRESS_TAG)}")
+        }
+        artifactFile("failure-terminal-attach.txt").writeText(diagnostics)
+        throw AssertionError(
+            "the terminal never attached within ${TERMINAL_ATTACH_BUDGET_MS}ms. The app's own " +
+                "connection status was '$status' — a give-up status (Unreachable/Gone/Failed) " +
+                "means the APP abandoned the attach, not that the harness was impatient " +
+                "(#2409). See failure-terminal-attach.txt:\n$diagnostics",
+        )
     }
 
     private fun terminalViewAttached(): Boolean {
@@ -1206,6 +1264,29 @@ abstract class NetworkFaultProofBase {
          * ladder auto-recovery on the slow emulator, under the 300s watchdog.
          */
         const val TERMINAL_INPUT_READY_TIMEOUT_MS: Long = 90_000L
+
+        /**
+         * Issue #2409 — budget for the tmux attach to reach a live TerminalView
+         * on the fault-proof lane (see [waitForTerminalViewAttached]).
+         *
+         * This MUST stay above the app's own end-to-end attach contract, or the
+         * harness gives up first and every app-side outcome — succeeded slowly,
+         * surrendered to Unreachable, wedged — collapses into one opaque
+         * timeout. The app's contract on this path is the dial
+         * (`SshConnection.DEFAULT_TIMEOUT_MS` 30s / `SshLeaseManager.
+         * DEFAULT_CONNECT_TIMEOUT_MILLIS` 35s) plus the panes-ready reconcile
+         * (`ATTACH_PANES_READY_TIMEOUT_MS`, 12s) plus the never-reveal-black
+         * gate's own re-captures plus the swiftshader compose
+         * of the terminal surface. The superseded value was a flat 30s — the
+         * DIAL budget alone, with nothing left over — which is why #2409's real
+         * `Attaching -> Unreachable` defect surfaced as a bare
+         * `ComposeTimeoutException` for nine nightly runs.
+         *
+         * 90s matches this cohort's other #1676 slow-link budgets and early-exits
+         * the instant the view attaches, so a healthy attach pays nothing; it
+         * stays well under the 300s per-test ci-journey watchdog.
+         */
+        const val TERMINAL_ATTACH_BUDGET_MS: Long = 90_000L
 
         /** Issue #1681 — the un-proxied sentinel exec-ping cadence. */
         const val SENTINEL_INTERVAL_MS: Long = 3_000L

--- a/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
+++ b/app/src/debug/java/com/pocketshell/app/proof/ToxiproxyControl.kt
@@ -203,6 +203,33 @@ class ToxiproxyControl(
         )
     }
 
+    /**
+     * Issue #2409 — RETUNE the already-installed latency toxic IN PLACE via
+     * toxiproxy's per-toxic update endpoint.
+     *
+     * [addJitterLatency] / [addSymmetricLatency] pin fixed toxic names, so a
+     * second `add` is a 409, and
+     * `clearToxics()` + re-add leaves the link briefly CLEAN — long enough on a
+     * fast box for the very round-trip under test to slip through unimpeded,
+     * which is precisely the vacuous pass a severity-change fixture must not
+     * have. Updating in place changes the delay applied to the ESTABLISHED
+     * connection with no clean window at all.
+     *
+     * Used by the #2409 cold-attach proof to raise severity for the ATTACH phase
+     * only, leaving the dial/enumeration at the benign [WIFI_ONE_WAY_LATENCY_MS]
+     * baseline so neither the app's separate 30/35 s dial budget nor the
+     * `FolderListGateway` 3.5 s bounded-exec budget is the thing under test.
+     */
+    fun updateJitterLatency(latencyMs: Int, jitterMs: Int) {
+        listOf("latency_upstream", "latency_downstream").forEach { name ->
+            transport.request(
+                "POST",
+                "/proxies/$PROXY_NAME/toxics/$name",
+                """{"attributes":{"latency":$latencyMs,"jitter":$jitterMs}}""",
+            )
+        }
+    }
+
     fun clearToxics() {
         KNOWN_TOXICS.forEach { name ->
             runCatching { transport.request("DELETE", "/proxies/$PROXY_NAME/toxics/$name", null) }

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionSupport.kt
@@ -435,25 +435,100 @@ internal const val MaxAgentEvents: Int = 500
  */
 internal const val SYNC_DETACH_TIMEOUT_MS: Long = 600L
 internal const val CODEX_AGENT_SUBMIT_DELAY_MS: Long = 250L
-// Issue #1316: the OUTER attach-reveal ceiling. Was 30 s — the maintainer's
-// "it took forever to attach / wouldn't let me touch" felt-freeze while the
-// `list-panes` reconcile head-of-line-blocked behind a busy sibling's `-CC`
-// burst. With the reconcile now on the dedicated exec lane it returns in ms, so
-// this bound only ever fires on a genuinely stuck attach; a much shorter
-// ceiling turns that into a fast user-visible "Tap Reconnect to retry" escape
-// (→ evict lease → fresh-transport runConnect) instead of a tens-of-seconds
-// input-gated overlay. The reconcile itself is separately bounded by
-// [RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS].
-internal const val ATTACH_PANES_READY_TIMEOUT_MS: Long = 12_000L
-internal const val ATTACH_PANES_READY_RETRY_MS: Long = 100L
 
 // Issue #1316: per-reconcile exec ceiling for the attach/switch/refresh
 // `list-panes` on the dedicated exec lane. Healthy reconciles return in
 // milliseconds; this is the safety bound so a genuinely wedged/half-open
 // transport surfaces a `Failed` fast (→ retryable attach error) rather than
-// parking the reveal. Well under the outer [ATTACH_PANES_READY_TIMEOUT_MS] so
-// the reconcile-level escape fires first.
+// parking the reveal. Strictly smaller than the outer
+// [ATTACH_PANES_READY_TIMEOUT_MS] (which is DERIVED from it below) so the
+// reconcile-level escape fires first.
 internal const val RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS: Long = 6_000L
+
+/**
+ * Issue #2409: how many `capture-pane` attempts the **synchronous, pre-reveal**
+ * active-pane seed gets — the one
+ * `TmuxSessionViewModel.preloadVisibleContentForNewPanes` runs INSIDE every
+ * attach `reconcilePanes()`, i.e. INSIDE [ATTACH_PANES_READY_TIMEOUT_MS].
+ *
+ * ## What went wrong without this bound
+ *
+ * That seed used the general force-heal ladder:
+ * [SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS] round-trips, each capped at
+ * [SEED_CAPTURE_TIMEOUT_MS], spaced by [SEED_CAPTURE_EMPTY_RETRY_DELAY_MS] —
+ * ≈10.4 s worst case. Put the [RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS]
+ * `list-panes` in front of it and ONE reconcile legitimately cost ≈16.4 s while
+ * the outer ceiling wrapping it was a flat 12 s. On a slow-but-PROGRESSING link
+ * (congested cellular, or the nightly's bufferbloat fixture) every inner ceiling
+ * is genuinely reached, so the outer bound cancelled the very first reconcile
+ * MID-FLIGHT and the app surrendered a perfectly healthy attach to "Tap
+ * Reconnect to retry" — the exact opposite of what #1316's short ceiling was
+ * for.
+ *
+ * ## Why SHRINK the inner stage rather than GROW the ceiling
+ *
+ * Nothing is lost by retrying less HERE, because the retries are duplicated
+ * immediately afterwards OUTSIDE the ceiling: `awaitActivePaneSeededOrLoading`
+ * — the #693/#661 never-reveal-black gate that runs between panes-ready and the
+ * surface flip — re-captures this same pane up to
+ * [ACTIVE_PANE_REVEAL_SEED_ATTEMPTS] more times while it still reads blank, and
+ * after reveal the #662 blank-pane net (`reseedBlankVisiblePanes`) and the
+ * render-heal watchdog keep their FULL unshortened ladder. The active pane
+ * therefore still gets 1 + [ACTIVE_PANE_REVEAL_SEED_ATTEMPTS] pre-reveal
+ * captures; only the first one is charged to the attach ceiling. Off-screen
+ * panes are unaffected (they are background-seeded with the full ladder).
+ *
+ * Growing [ATTACH_PANES_READY_TIMEOUT_MS] to ≈19 s instead was tried and
+ * reverted: it moved back toward the tens-of-seconds input-gated overlay #1316
+ * deleted, and it stretched every rung of the reconnect ladder
+ * `ReconnectStormLivelockE2eTest` walks past that proof's 300 s watchdog (4/4
+ * red). Shrinking here keeps both ceilings — and so that ladder's wall time —
+ * byte-for-byte what they were.
+ */
+internal const val ATTACH_ACTIVE_PANE_SEED_ATTEMPTS: Int = 1
+
+/**
+ * Issue #2409: worst-case wall time of the pre-reveal active-pane seed —
+ * [ATTACH_ACTIVE_PANE_SEED_ATTEMPTS] captures at the [SEED_CAPTURE_TIMEOUT_MS]
+ * ceiling with a [SEED_CAPTURE_EMPTY_RETRY_DELAY_MS] backoff between them. Every
+ * one of those ceilings is reachable on a slow-but-progressing link, so this is
+ * real budgeted work the outer attach ceiling must be able to wait out — not a
+ * pathological case.
+ */
+internal const val ATTACH_ACTIVE_PANE_SEED_WORST_CASE_MS: Long =
+    ATTACH_ACTIVE_PANE_SEED_ATTEMPTS * SEED_CAPTURE_TIMEOUT_MS +
+        (ATTACH_ACTIVE_PANE_SEED_ATTEMPTS - 1) * SEED_CAPTURE_EMPTY_RETRY_DELAY_MS
+
+/**
+ * Issue #2409: headroom the outer attach ceiling keeps ON TOP of the inner
+ * stages it wraps — the `seedIoDispatcher` → `applyOnMain` dispatcher hops, the
+ * `list-panes` row parse/apply, the [ATTACH_PANES_READY_RETRY_MS] poll cadence,
+ * and a contended emulator's coroutine-dispatch overhead.
+ */
+internal const val ATTACH_PANES_READY_HEADROOM_MS: Long = 3_500L
+
+/**
+ * The OUTER attach-reveal ceiling (`awaitPanesReadyForAttach`).
+ *
+ * Issue #1316 replaced a flat 30 s with a flat 12 s: the maintainer's "it took
+ * forever to attach / wouldn't let me touch" felt-freeze came from the
+ * `list-panes` reconcile head-of-line-blocking behind a busy sibling's `-CC`
+ * burst, and a short ceiling turns that into a fast user-visible "Tap Reconnect
+ * to retry" escape (→ evict lease → fresh-transport runConnect) instead of a
+ * tens-of-seconds input-gated overlay.
+ *
+ * Issue #2409 keeps that 12 s **value** but stops it being an independently
+ * tuned literal: it is now DERIVED from the stages it wraps, so it can never
+ * again end up smaller than its own bounded inner work (see
+ * [ATTACH_ACTIVE_PANE_SEED_ATTEMPTS] for the full failure story), and shrinking
+ * an inner bound shrinks this one with it.
+ */
+internal const val ATTACH_PANES_READY_TIMEOUT_MS: Long =
+    RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS +
+        ATTACH_ACTIVE_PANE_SEED_WORST_CASE_MS +
+        ATTACH_PANES_READY_HEADROOM_MS
+
+internal const val ATTACH_PANES_READY_RETRY_MS: Long = 100L
 
 /**
  * Issue #552 / #685 (Bug A): a passive tmux reader EOF during a brief foreground
@@ -504,6 +579,31 @@ internal const val PASSIVE_REATTACH_DIAL_HANDSHAKE_TIMEOUT_MS: Long = 15_000L
  * Issue #1539/#1331: the ATTACH + PANES-READY budget for one rung, applied to an ALREADY-
  * HANDSHAKEN transport. A completed SSH handshake is proof the link is up, so a slow attach is
  * a reason to RETRY THE ATTACH over the same transport — never to close it and redial.
+ *
+ * ## Issue #2409 — why this stays BELOW [ATTACH_PANES_READY_TIMEOUT_MS], deliberately
+ *
+ * This wraps an `awaitPanesReadyForAttach` whose own ceiling is 12 s, so at 10 s it is the
+ * bound that actually fires on a slow rung. That looks like the same inverted nesting #2409
+ * fixed for the cold attach, and it is NOT, because the two exits mean opposite things:
+ *
+ *  - the COLD attach's ceiling firing is TERMINAL — it throws
+ *    `TmuxAttachPanesReadyException`, the user gets "Tap Reconnect to retry", and the attach
+ *    is abandoned. An outer bound smaller than the work it wraps therefore DESTROYS a healthy
+ *    attach, which is exactly the defect #2409 reports.
+ *  - this rung's ceiling firing is a RETRY — `ready == false` routes through
+ *    [shouldEvictTransportAfterStageFailure], which KEEPS a vouched-alive transport (#1539/
+ *    #1653) and lets the grace loop run the next rung over it. A shorter leash here means
+ *    "re-attempt sooner", not "give up".
+ *
+ * The rung's reachable inner work is also much smaller than the cold attach's: a passive
+ * reattach re-lists panes that ALREADY EXIST in `paneRows`, so `applyParsedPanes` reports no
+ * new panes and the pre-reveal seed ([ATTACH_ACTIVE_PANE_SEED_ATTEMPTS]) does not run at all —
+ * the stage is the `-CC` `connect()` plus one
+ * [RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS]-bounded `list-panes`.
+ *
+ * Widening this to sit above the cold-attach ceiling was tried in #2411 (10 s → 24.36 s) and
+ * reverted: it multiplied every failing rung of the reconnect ladder that
+ * `ReconnectStormLivelockE2eTest` walks and blew that proof's 300 s watchdog 4/4.
  */
 internal const val PASSIVE_REATTACH_ATTACH_TIMEOUT_MS: Long = 10_000L
 

--- a/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
+++ b/app/src/main/java/com/pocketshell/app/tmux/TmuxSessionViewModel.kt
@@ -10851,10 +10851,10 @@ public class TmuxSessionViewModel @Inject constructor(
         // The active pane is the head of the reconciled list (panes are sorted
         // by window index, so the lowest-window pane is page 0 — what the screen
         // renders first). Seed it synchronously here so the #640 seed-before-
-        // reveal contract still holds for the pane the user actually sees:
-        // [awaitPanesReadyForAttach] only returns (and the caller reveals) after
-        // this function returns, so the active pane's capture has landed before
-        // the first painted frame.
+        // reveal contract holds for the pane the user sees. Issue #2409 bounds
+        // it to [ATTACH_ACTIVE_PANE_SEED_ATTEMPTS]: the full ladder outlasts
+        // the attach ceiling wrapping it, and the never-reveal-black gate
+        // re-tries this same pane outside that ceiling.
         //
         // The remaining (off-screen / other-window) panes are background-seeded
         // in [bridgeScope] AFTER reveal — the user can't see them yet, and the
@@ -10869,10 +10869,10 @@ public class TmuxSessionViewModel @Inject constructor(
             } else if (
                 healActivePaneIfStaleRender(
                     client, activePane, refreshGuard, force = true, recordMilestone = true,
+                    maxAttempts = ATTACH_ACTIVE_PANE_SEED_ATTEMPTS,
                 ) != HealOutcome.Healed
             ) {
-                // Issue #468: a failed/empty active-pane capture must still open
-                // the seed gate so buffered live %output flushes in order.
+                // Issue #468: a failed/empty capture still opens the seed gate.
                 activePane.terminalState.openSeedGateWithoutSeed()
             }
         } catch (t: Throwable) {

--- a/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/FakeTmuxClient.kt
@@ -204,6 +204,64 @@ internal open class FakeTmuxClient(
 
     var suspendForeverOnBestEffortCommandPrefix: String? = null
 
+    // ---- Issue #2409: slow-but-ALIVE link fixture ---------------------------
+    //
+    // The nightly bufferbloat fault (350ms±200 latency + a 120 KB/s cap) makes
+    // every attach round-trip take SECONDS while the transport stays perfectly
+    // healthy. A test double that answers instantly can never reproduce a
+    // budget-nesting defect, because no inner ceiling is ever reached — which is
+    // exactly why the #2409 attach-budget inversion survived every JVM test and
+    // only surfaced on the toxiproxy nightly. These seams let a unit test spend
+    // the REAL inner budgets on the virtual clock.
+
+    /**
+     * Issue #2409: wall time each [listPanesViaExec] round-trip costs before it
+     * answers. Bounded by the caller's `timeoutMs` exactly like the real exec
+     * lane: a latency at or above the ceiling burns the ceiling and throws the
+     * real client's timeout [TmuxClientException] instead of answering.
+     */
+    @Volatile
+    var listPanesViaExecLatencyMs: Long = 0L
+
+    /**
+     * Issue #2409: wall time each [captureWithCursor] seed/heal round-trip costs.
+     * Modelled on `RealTmuxClient.captureWithCursor`: the exec lane is bounded by
+     * the caller's short seed ceiling (`SEED_CAPTURE_TIMEOUT_MS`), and a
+     * round-trip that outlasts it burns the full ceiling and throws
+     * `TmuxClientException("tmux capture-pane (exec heal lane) timed out …")`.
+     */
+    @Volatile
+    var captureWithCursorLatencyMs: Long = 0L
+
+    /**
+     * Issue #2409: every [captureWithCursor] the slow-link fixture served, as
+     * `"<paneId>@<timeoutMs>"`, so a test can hard-assert the seed really did
+     * pay its bounded retries (never a vacuous pass where the capture was
+     * skipped and the attach "succeeded" for the wrong reason).
+     */
+    val slowLinkCaptureAttempts: MutableList<String> = mutableListOf()
+
+    /** Issue #2409: [listPanesViaExec] round-trips the slow-link fixture served. */
+    val slowLinkListPanesAttempts: MutableList<String> = mutableListOf()
+
+    private val defaultExecLaneCeilingMs: Long = 10_000L
+
+    /**
+     * Mirror of `RealTmuxClient`'s bounded exec lane: burn `min(latency, ceiling)`
+     * of the (virtual) clock, then report a timeout when the latency reached the
+     * ceiling. Returns `true` when the round-trip completed inside its bound.
+     */
+    private suspend fun runFakeBoundedExecLane(latencyMs: Long, timeoutMs: Long?): Boolean {
+        val ceiling = timeoutMs?.coerceIn(1L, defaultExecLaneCeilingMs) ?: defaultExecLaneCeilingMs
+        if (latencyMs <= 0L) return true
+        if (latencyMs < ceiling) {
+            delay(latencyMs)
+            return true
+        }
+        delay(ceiling)
+        return false
+    }
+
     /**
      * Issue #1533: the #927 "busy ≠ dead" reader-activity clock the restore
      * ride-through vouch reads. Default [Long.MAX_VALUE] = no reader activity known
@@ -356,6 +414,17 @@ internal open class FakeTmuxClient(
     ): com.pocketshell.core.tmux.CaptureWithCursor {
         lastCaptureThreadName = Thread.currentThread().name
         lastCaptureTimeoutMs = timeoutMs
+        // Issue #2409: the slow-but-alive link. Pay the round-trip on the clock
+        // and, when it outlasts the caller's short seed ceiling, throw exactly
+        // what the real exec lane throws.
+        if (captureWithCursorLatencyMs > 0L) {
+            slowLinkCaptureAttempts += "$paneId@$timeoutMs"
+            if (!runFakeBoundedExecLane(captureWithCursorLatencyMs, timeoutMs)) {
+                throw TmuxClientException(
+                    "tmux capture-pane (exec heal lane) timed out after ${timeoutMs}ms",
+                )
+            }
+        }
         val parkedOnGate = captureWithCursorGate
         parkedOnGate?.await()
         if (parkedOnGate != null) {
@@ -391,6 +460,28 @@ internal open class FakeTmuxClient(
             lastListPanesThreadName = Thread.currentThread().name
         }
         return handleCommand(cmd, bestEffort = false)
+    }
+
+    /**
+     * Issue #2409: the attach/switch reconcile's dedicated exec lane. The
+     * interface default delegates to `sendCommand`, which answers instantly;
+     * this override lets a test spend [listPanesViaExecLatencyMs] of the caller's
+     * `timeoutMs` budget the way a congested link does, while keeping the
+     * existing canned-[responses] plumbing for the rows themselves.
+     */
+    override suspend fun listPanesViaExec(
+        listPanesCommand: String,
+        timeoutMs: Long?,
+    ): CommandResponse {
+        if (listPanesViaExecLatencyMs > 0L) {
+            slowLinkListPanesAttempts += "$listPanesCommand@$timeoutMs"
+            if (!runFakeBoundedExecLane(listPanesViaExecLatencyMs, timeoutMs)) {
+                throw TmuxClientException(
+                    "tmux list-panes (exec lane) timed out after ${timeoutMs}ms",
+                )
+            }
+        }
+        return sendCommand(listPanesCommand)
     }
 
     /**

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue2409AttachBudgetNestingTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue2409AttachBudgetNestingTest.kt
@@ -1,0 +1,222 @@
+package com.pocketshell.app.tmux
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2409 — the DURABLE class guard for attach budget NESTING.
+ *
+ * ## The class
+ *
+ * The attach path is a stack of nested `withTimeout*` wrappers, each with its
+ * own independently-chosen constant:
+ *
+ * ```
+ * withTimeoutOrNull(PASSIVE_REATTACH_ATTACH_TIMEOUT_MS)   // passive silent-reattach rung
+ *   awaitPanesReadyForAttach
+ *     withTimeoutOrNull(ATTACH_PANES_READY_TIMEOUT_MS)    // outer attach-reveal ceiling
+ *       reconcilePanes
+ *         listPanesViaExec(RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS)
+ *         preloadVisibleContentForNewPanes
+ *           healActivePaneIfStaleRender(force = true, maxAttempts = ATTACH_ACTIVE_PANE_SEED_ATTEMPTS)
+ *             maxAttempts x captureWithCursor(SEED_CAPTURE_TIMEOUT_MS)
+ *               + SEED_CAPTURE_EMPTY_RETRY_DELAY_MS backoff between attempts
+ * ```
+ *
+ * **An outer ceiling smaller than the worst case of the bounded work it wraps
+ * is always a bug**, and a silent one: on a fast link no inner ceiling is ever
+ * reached, so every unit test, every emulator journey and every happy-path
+ * fixture stays green. It only fires on a slow-but-progressing link — where
+ * each inner stage genuinely spends its budget — and then it fires
+ * DETERMINISTICALLY, killing healthy work mid-flight and surfacing a
+ * user-visible "Tap Reconnect to retry" on a link that was merely slow.
+ *
+ * ## The reported instance (#2409)
+ *
+ * `ATTACH_PANES_READY_TIMEOUT_MS` was a flat 12 s while one `reconcilePanes()`
+ * could legitimately cost `6 s (list-panes) + ~10.4 s (the FULL force-heal seed
+ * ladder) ≈ 16.4 s`. On the nightly's bufferbloat fault fixture the very first
+ * reconcile was cancelled at 12 s and the app gave up a perfectly healthy attach
+ * to `Unreachable` — `ColdDialUnderBandwidthLimitE2eTest` red for 9 nightly runs
+ * (streak 4). The ~10.4 s seed worst case was not even new: #1353's render-heal
+ * audit measured it and #1539 used it to move the reseed OUT of a 5 s wrapper —
+ * nobody noticed the SAME seed also runs inside `awaitPanesReadyForAttach`.
+ *
+ * ## Why this guard exists rather than a comment
+ *
+ * The constants live in several places and are tuned by different issues
+ * (#640/#662/#693 seed retries, #926 seed ceiling, #1316 reconcile + attach
+ * ceilings, #1539 passive rung). Nothing made their RELATION checkable, so it
+ * drifted into inversion and stayed inverted. These assertions fail the moment
+ * any of them is retuned into an inverted nesting again — which is the whole
+ * class, not just the one instance that was reported.
+ *
+ * ## And why it also pins the ceilings DOWNWARD
+ *
+ * The first attempt at this fix resolved the inversion by GROWING the two outer
+ * ceilings (12 s -> 19.36 s and 10 s -> 24.36 s). It was approved and merged, and
+ * had to be reverted: those same ceilings bound every rung of the reconnect
+ * ladder `ReconnectStormLivelockE2eTest#slowTailOnAProvenLink...` walks, and that
+ * proof — already at 234 s of its 300 s watchdog — timed out 4/4. So the
+ * no-growth direction is a first-class invariant here too, not just an
+ * implementation detail.
+ */
+class Issue2409AttachBudgetNestingTest {
+
+    @Test
+    fun activePaneSeedWorstCaseMatchesItsOwnRetryLadder() {
+        // Anchor the derived worst case to the ladder it models, so a change to
+        // the attempt count/backoff cannot silently stop being accounted for.
+        val expected =
+            ATTACH_ACTIVE_PANE_SEED_ATTEMPTS * SEED_CAPTURE_TIMEOUT_MS +
+                (ATTACH_ACTIVE_PANE_SEED_ATTEMPTS - 1) * SEED_CAPTURE_EMPTY_RETRY_DELAY_MS
+        assertEquals(
+            "the pre-reveal active-pane seed worst case must be " +
+                "$ATTACH_ACTIVE_PANE_SEED_ATTEMPTS x ${SEED_CAPTURE_TIMEOUT_MS}ms captures plus " +
+                "${ATTACH_ACTIVE_PANE_SEED_ATTEMPTS - 1} x ${SEED_CAPTURE_EMPTY_RETRY_DELAY_MS}ms " +
+                "backoff",
+            expected,
+            ATTACH_ACTIVE_PANE_SEED_WORST_CASE_MS,
+        )
+    }
+
+    /**
+     * Member 1 of the class — the reported #2409 instance. RED whenever the
+     * pre-reveal seed is allowed the full [SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS]
+     * force-heal ladder again (6_000 + 10_360 = 16_360 > 12_000).
+     */
+    @Test
+    fun attachRevealCeilingCoversOneWholeReconcileIncludingItsSeedRetries() {
+        val innerWorstCaseMs =
+            RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS + ATTACH_ACTIVE_PANE_SEED_WORST_CASE_MS
+        assertTrue(
+            "ATTACH_PANES_READY_TIMEOUT_MS (${ATTACH_PANES_READY_TIMEOUT_MS}ms) must be able to " +
+                "wait out ONE whole reconcilePanes(): a ${RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS}ms " +
+                "list-panes exec plus the ${ATTACH_ACTIVE_PANE_SEED_WORST_CASE_MS}ms pre-reveal " +
+                "active-pane seed = ${innerWorstCaseMs}ms. A smaller outer ceiling cancels a " +
+                "HEALTHY attach mid-flight on any slow-but-progressing link and surfaces " +
+                "\"Tap Reconnect to retry\" (#2409).",
+            ATTACH_PANES_READY_TIMEOUT_MS > innerWorstCaseMs,
+        )
+        assertTrue(
+            "the ceiling must keep REAL headroom over its inner stages (dispatcher hops, the " +
+                "list-panes row parse/apply, the ${ATTACH_PANES_READY_RETRY_MS}ms poll cadence, a " +
+                "contended emulator) — a ceiling that only just covers the inner worst case is " +
+                "one scheduling hiccup away from the same defect",
+            ATTACH_PANES_READY_TIMEOUT_MS - innerWorstCaseMs >= ATTACH_PANES_READY_HEADROOM_MS,
+        )
+    }
+
+    /**
+     * The pre-reveal seed must be STRICTLY cheaper than the general force-heal
+     * ladder, because it is the only one charged to the attach ceiling. This is
+     * the invariant that makes member 1 satisfiable without growing any ceiling.
+     */
+    @Test
+    fun preRevealSeedIsCheaperThanTheGeneralForceHealLadderItIsCarvedOutOf() {
+        assertTrue(
+            "the pre-reveal attach seed ($ATTACH_ACTIVE_PANE_SEED_ATTEMPTS attempt(s)) must stay " +
+                "below the general force-heal ladder ($SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS) — the " +
+                "post-reveal heals (reveal gate, #662 blank-pane net, render-heal watchdog) keep " +
+                "the full ladder; only the attach-ceiling-charged one is bounded (#2409)",
+            ATTACH_ACTIVE_PANE_SEED_ATTEMPTS < SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS,
+        )
+        assertTrue(
+            "the pre-reveal seed must still make at least ONE capture attempt, or #640's " +
+                "seed-before-reveal contract is gone entirely",
+            ATTACH_ACTIVE_PANE_SEED_ATTEMPTS >= 1,
+        )
+        assertTrue(
+            "the active pane must still get MORE pre-reveal capture attempts overall than the " +
+                "attach ceiling pays for: the never-reveal-black gate " +
+                "(awaitActivePaneSeededOrLoading) re-tries it up to " +
+                "$ACTIVE_PANE_REVEAL_SEED_ATTEMPTS more times OUTSIDE the ceiling, which is why " +
+                "bounding the inner ladder costs no black-pane robustness (#693/#661)",
+            ACTIVE_PANE_REVEAL_SEED_ATTEMPTS > ATTACH_ACTIVE_PANE_SEED_ATTEMPTS,
+        )
+    }
+
+    /**
+     * Member 2 of the class — the passive silent-reattach rung wraps the SAME
+     * `awaitPanesReadyForAttach` call in a second, independently-chosen ceiling.
+     *
+     * Unlike member 1 this rung is deliberately the SHORTER leash, because its
+     * expiry is a RETRY (`ready == false` -> keep a vouched-alive transport,
+     * next rung) and not the terminal "Tap Reconnect to retry" the cold attach
+     * produces. What it must still cover is the work it can actually reach: a
+     * passive reattach re-lists panes that already exist, so no pre-reveal seed
+     * runs and the stage is `connect()` + one bounded `list-panes`.
+     */
+    @Test
+    fun passiveReattachRungCoversTheWorkItCanActuallyReach() {
+        assertTrue(
+            "PASSIVE_REATTACH_ATTACH_TIMEOUT_MS (${PASSIVE_REATTACH_ATTACH_TIMEOUT_MS}ms) must " +
+                "cover a whole ${RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS}ms list-panes plus the " +
+                "-CC connect()/observer-swap preamble that runs inside the same " +
+                "withTimeoutOrNull, or the rung fails identically forever on a slow link (the " +
+                "#1610 constant-budget-vs-constant-latency pathology)",
+            PASSIVE_REATTACH_ATTACH_TIMEOUT_MS >=
+                RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS + ATTACH_PANES_READY_HEADROOM_MS,
+        )
+    }
+
+    /**
+     * The inner escape must still fire FIRST, or the outer ceiling becomes the
+     * only signal and the fast retryable `Failed` #1316 built disappears. Guards
+     * the other direction, so "fix the inversion" can never be done by widening
+     * an inner ceiling past its wrapper.
+     */
+    @Test
+    fun everyInnerStageCeilingStaysStrictlyBelowItsWrapper() {
+        assertTrue(
+            "the list-panes exec ceiling (${RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS}ms) must fire " +
+                "before the attach-reveal ceiling (${ATTACH_PANES_READY_TIMEOUT_MS}ms) so a wedged " +
+                "reconcile still surfaces its fast retryable Failed (#1316)",
+            RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS < ATTACH_PANES_READY_TIMEOUT_MS,
+        )
+        assertTrue(
+            "the seed capture ceiling (${SEED_CAPTURE_TIMEOUT_MS}ms) must fire before the " +
+                "attach-reveal ceiling (${ATTACH_PANES_READY_TIMEOUT_MS}ms)",
+            SEED_CAPTURE_TIMEOUT_MS < ATTACH_PANES_READY_TIMEOUT_MS,
+        )
+    }
+
+    /**
+     * #1316's fast-escape property, and the reconnect-ladder watchdog margin the
+     * first attempt at this fix destroyed, expressed as a no-growth ratchet.
+     *
+     * `ReconnectStormLivelockE2eTest#slowTailOnAProvenLinkNeitherKillsHandshaken
+     * TransportsNorSpinsForever` manufactures a FAILING attach on every rung of a
+     * reconnect storm, so its wall time scales directly with these two ceilings.
+     * It sat at 234 s of a 300 s per-test watchdog BEFORE #2409 was first
+     * attempted; growing the ceilings to 19.36 s / 24.36 s timed it out 4/4 and
+     * forced a full revert. Any future retune that grows either ceiling must
+     * re-derive that proof's headroom in the same change — this assertion is the
+     * tripwire that makes that impossible to forget.
+     */
+    @Test
+    fun neitherOuterCeilingGrewPastTheValueTheReconnectLadderWasProvenAgainst() {
+        assertTrue(
+            "ATTACH_PANES_READY_TIMEOUT_MS (${ATTACH_PANES_READY_TIMEOUT_MS}ms) must not exceed " +
+                "the ${PROVEN_ATTACH_CEILING_MS}ms #1316 chose and ReconnectStormLivelockE2eTest " +
+                "was measured against (234s of its 300s watchdog). Growing it re-opens both the " +
+                "#1316 felt-freeze and that proof's timeout — shrink an inner stage instead.",
+            ATTACH_PANES_READY_TIMEOUT_MS <= PROVEN_ATTACH_CEILING_MS,
+        )
+        assertTrue(
+            "PASSIVE_REATTACH_ATTACH_TIMEOUT_MS (${PASSIVE_REATTACH_ATTACH_TIMEOUT_MS}ms) must not " +
+                "exceed the ${PROVEN_PASSIVE_RUNG_CEILING_MS}ms every rung of the reconnect storm " +
+                "ladder was measured against",
+            PASSIVE_REATTACH_ATTACH_TIMEOUT_MS <= PROVEN_PASSIVE_RUNG_CEILING_MS,
+        )
+    }
+
+    private companion object {
+        /** #1316's attach-reveal ceiling, the value the reconnect ladder is proven against. */
+        const val PROVEN_ATTACH_CEILING_MS: Long = 12_000L
+
+        /** #1539's passive-rung attach ceiling, likewise. */
+        const val PROVEN_PASSIVE_RUNG_CEILING_MS: Long = 10_000L
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/Issue2409SlowLinkAttachBudgetTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/Issue2409SlowLinkAttachBudgetTest.kt
@@ -1,0 +1,280 @@
+package com.pocketshell.app.tmux
+
+import com.pocketshell.core.tmux.CommandResponse
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #2409 — a COLD ATTACH over a slow-but-progressing link must complete,
+ * not surrender to "Tap Reconnect to retry".
+ *
+ * ## The reported symptom
+ *
+ * `ColdDialUnderBandwidthLimitE2eTest#coldDialUnderBufferbloatCompletesWithinBudget`
+ * failed on 9 nightly fault-injection runs (streak 4, first seen 2026-08-20)
+ * with a bare `ComposeTimeoutException`. The authoritative logcat from
+ * https://github.com/alexeygrigorev/pocketshell/actions/runs/33232540342 shows
+ * the app — not the harness — gave up:
+ *
+ * ```
+ * tmux-list-panes-start   ... elapsedMs=2835
+ * captureWithCursor exec timed out >2500ms (heal lane)   x3
+ * tmux-connect-failed     ... elapsedMs=14838
+ *   cause=TmuxAttachPanesReadyException: Timed out waiting for tmux panes ...
+ * PsConnEffectDriver: state Attaching -> Unreachable
+ * ```
+ *
+ * `14838 - 2835 = 12003ms` — the outer [ATTACH_PANES_READY_TIMEOUT_MS] fired
+ * while the FIRST `reconcilePanes()` was still inside its OWN bounded work.
+ *
+ * ## The mechanism these tests pin
+ *
+ * One `reconcilePanes()` costs [RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS] (the
+ * `list-panes` exec lane) plus the seed-before-reveal `capture-pane` ladder that
+ * `preloadVisibleContentForNewPanes` runs SYNCHRONOUSLY. While that ladder was
+ * the full [SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS] x [SEED_CAPTURE_TIMEOUT_MS]
+ * force-heal budget (≈10.4s), one reconcile could cost ≈16.4s inside a 12s outer
+ * ceiling. On a fast link no inner ceiling is ever reached, which is why this
+ * defect was invisible to every test double that answers instantly.
+ * [FakeTmuxClient]'s `#2409` slow-link seams therefore spend the REAL inner
+ * budgets on the virtual clock, exactly the way the nightly's bufferbloat toxic
+ * does on the wire.
+ *
+ * ## Class coverage (G2)
+ *
+ * The seed ladder burns its budget through three DISTINCT failure modes on a
+ * degraded link, all handled by the same retry loop — a capture that outlasts
+ * its ceiling (the nightly's shape), one that comes back as a tmux error, and
+ * one that comes back empty (#693/#662's flaky-link shape). Each is exercised
+ * below, because a fix that only covered the timeout branch would leave the
+ * other two able to blow the same outer ceiling. A fourth case guards the
+ * OPPOSITE direction: a genuinely wedged `list-panes` must still fail fast
+ * through #1316's reconcile-level escape.
+ *
+ * These compile and run against the UNFIXED tree (they reference no constant the
+ * fix introduces), so they are the red→green pin for the fix itself.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class Issue2409SlowLinkAttachBudgetTest : TmuxSessionViewModelTestBase() {
+
+    /**
+     * Failure mode 1 — every seed `capture-pane` OUTLASTS the short seed
+     * ceiling and the exec lane throws. This is the nightly's exact shape
+     * (`captureWithCursor exec timed out >2500ms (heal lane)`).
+     */
+    @Test
+    fun coldAttachCompletesWhenEverySeedCaptureOutlastsItsCeilingOnASlowLink() =
+        runTest(scheduler) {
+            val client = slowLinkClient().apply {
+                // At the ceiling => the exec lane burns the full ceiling and throws,
+                // exactly like RealTmuxClient.captureWithCursor.
+                captureWithCursorLatencyMs = SEED_CAPTURE_TIMEOUT_MS
+            }
+            assertSlowLinkAttachSucceeds(client, "seed captures timing out")
+        }
+
+    /**
+     * Failure mode 2 — the seed `capture-pane` answers INSIDE its ceiling but
+     * with a tmux error, so the ladder retries and still spends most of the
+     * budget on a slow link.
+     */
+    @Test
+    fun coldAttachCompletesWhenEverySeedCaptureErrorsOnASlowLink() =
+        runTest(scheduler) {
+            val client = slowLinkClient().apply {
+                captureWithCursorLatencyMs = SEED_CAPTURE_TIMEOUT_MS - 100L
+                defaultCaptureResponse = CommandResponse(
+                    number = 0L,
+                    output = listOf("can't find pane"),
+                    isError = true,
+                )
+            }
+            assertSlowLinkAttachSucceeds(client, "seed captures erroring")
+        }
+
+    /**
+     * Failure mode 3 — the seed `capture-pane` answers inside its ceiling but
+     * EMPTY (#693/#662's degraded-but-connected channel). Same ladder, same
+     * budget, same outer ceiling.
+     */
+    @Test
+    fun coldAttachCompletesWhenEverySeedCaptureComesBackEmptyOnASlowLink() =
+        runTest(scheduler) {
+            val client = slowLinkClient().apply {
+                captureWithCursorLatencyMs = SEED_CAPTURE_TIMEOUT_MS - 100L
+                // No canned capture response => the fake serves an EMPTY success,
+                // which the heal loop scores CaptureEmpty and retries.
+            }
+            assertSlowLinkAttachSucceeds(client, "seed captures coming back empty")
+        }
+
+    /**
+     * The reconcile's OWN escape must survive the fix: a `list-panes` that
+     * genuinely outlasts [RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS] still has to
+     * surface the fast retryable attach error #1316 built, rather than parking
+     * the user until the outer ceiling. Guards the other direction — shrinking
+     * the pre-reveal seed must not turn a wedged link into a slow one.
+     */
+    @Test
+    fun aWedgedListPanesStillFailsFastViaTheReconcileEscapeNotTheOuterCeiling() =
+        runTest(scheduler) {
+            val vm = newVm()
+            val client = slowLinkClient().apply {
+                // Past the reconcile exec ceiling => the exec lane throws and the
+                // reconcile reports Failed immediately.
+                listPanesViaExecLatencyMs = RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS
+            }
+
+            val startedAt = scheduler.currentTime
+            val attach = startAttach(vm, client)
+            pumpUntilComplete(attach)
+            val elapsedMs = scheduler.currentTime - startedAt
+
+            val status = vm.connectionStatus.value
+            assertTrue(
+                "a wedged list-panes must still surface a retryable Failed, got $status",
+                status is TmuxSessionViewModel.ConnectionStatus.Failed,
+            )
+            assertTrue(
+                "the reconcile-level escape must fire at its own " +
+                    "${RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS}ms ceiling, well before the outer " +
+                    "${ATTACH_PANES_READY_TIMEOUT_MS}ms attach ceiling — otherwise a wedged " +
+                    "attach just feels slower; took ${elapsedMs}ms",
+                elapsedMs < ATTACH_PANES_READY_TIMEOUT_MS,
+            )
+            assertTrue("Reconnect must stay available", vm.canReconnect.value)
+        }
+
+    // ---- helpers ---------------------------------------------------------
+
+    /**
+     * A tmux client on a congested-but-healthy link: `list-panes` answers in
+     * ~3 s (the nightly's measured value, comfortably inside its own 6 s exec
+     * ceiling) with one real pane row.
+     */
+    private fun slowLinkClient(): FakeTmuxClient = FakeTmuxClient().apply {
+        listPanesViaExecLatencyMs = SLOW_LINK_LIST_PANES_MS
+        repeat(LIST_PANES_RESPONSES) {
+            responses += CommandResponse(
+                number = (it + 1).toLong(),
+                output = listOf("%0\t@0\t\$0\twork\tshell\t0"),
+                isError = false,
+            )
+        }
+    }
+
+    private fun TestScope.startAttach(vm: TmuxSessionViewModel, client: FakeTmuxClient): Deferred<Unit> =
+        async {
+            vm.attachClientWithReadinessForTest(
+                hostId = 1L,
+                hostName = "alpha",
+                host = "alpha.example",
+                port = 22,
+                user = "alex",
+                keyPath = "/keys/a",
+                sessionName = "work",
+                client = client,
+            )
+        }.also { runCurrent() }
+
+    /**
+     * Bounded virtual-clock pump. Deliberately NOT `advanceUntilIdle()`: the
+     * revealed session arms watchdog loops, and an unbounded drain would hang
+     * this test rather than fail it.
+     */
+    private fun TestScope.pumpUntilComplete(attach: Deferred<Unit>) {
+        var advancedMs = 0L
+        while (!attach.isCompleted && advancedMs < PUMP_CEILING_MS) {
+            advanceTimeBy(PUMP_STEP_MS)
+            runCurrent()
+            advancedMs += PUMP_STEP_MS
+        }
+        assertTrue(
+            "the attach never settled within ${PUMP_CEILING_MS}ms of virtual time",
+            attach.isCompleted,
+        )
+    }
+
+    private fun TestScope.assertSlowLinkAttachSucceeds(
+        client: FakeTmuxClient,
+        label: String,
+    ) {
+        val vm = newVm()
+        val startedAt = scheduler.currentTime
+        val attach = startAttach(vm, client)
+        pumpUntilComplete(attach)
+        val elapsedMs = scheduler.currentTime - startedAt
+
+        // Anti-vacuous #1: the pre-reveal seed really ran, and really was bounded by
+        // the SHORT seed ceiling. Without this a "green" could mean the capture was
+        // skipped entirely and the attach was never slow in the first place.
+        assertTrue(
+            "precondition ($label): the pre-reveal seed must have issued at least one " +
+                "capture round-trip, got ${client.slowLinkCaptureAttempts}",
+            client.slowLinkCaptureAttempts.isNotEmpty(),
+        )
+        assertTrue(
+            "precondition ($label): the seed must be bounded by the SHORT seed ceiling " +
+                "(${SEED_CAPTURE_TIMEOUT_MS}ms), got ${client.slowLinkCaptureAttempts.take(4)}",
+            client.slowLinkCaptureAttempts.all { it.endsWith("@$SEED_CAPTURE_TIMEOUT_MS") },
+        )
+        // Anti-vacuous #2: the reconcile really rode the dedicated exec lane with
+        // its own ceiling threaded through.
+        assertTrue(
+            "precondition ($label): the reconcile must ride the exec lane bounded by " +
+                "${RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS}ms, got ${client.slowLinkListPanesAttempts}",
+            client.slowLinkListPanesAttempts.isNotEmpty() &&
+                client.slowLinkListPanesAttempts
+                    .all { it.endsWith("@$RECONCILE_LIST_PANES_EXEC_TIMEOUT_MS") },
+        )
+        // Anti-vacuous #3: the link really was slow — the attach had to pay BOTH inner
+        // ceilings (a full `list-panes` round-trip plus a full seed capture) before it
+        // could settle. Deliberately a floor, not a band: it holds on the UNFIXED tree
+        // too (where the attach is cut at the 12s ceiling), so the assertion that goes
+        // red on base is the LOAD-BEARING one below, never this scaffolding (G6).
+        assertTrue(
+            "precondition ($label): the fixture must make the attach pay both inner " +
+                "ceilings (${SLOW_LINK_LIST_PANES_MS}ms list-panes + ${SEED_CAPTURE_TIMEOUT_MS}ms " +
+                "seed capture) or it is not reproducing a slow link at all; took ${elapsedMs}ms",
+            elapsedMs >= SLOW_LINK_LIST_PANES_MS + SEED_CAPTURE_TIMEOUT_MS,
+        )
+
+        // LOAD-BEARING: the app must NOT surrender a healthy attach.
+        val status = vm.connectionStatus.value
+        assertTrue(
+            "a cold attach over a slow-but-progressing link ($label) must complete instead of " +
+                "surrendering to the retryable attach error — the #2409 symptom is exactly " +
+                "`TmuxAttachPanesReadyException: Timed out waiting for tmux panes` -> Unreachable " +
+                "on a link that was merely slow. Took ${elapsedMs}ms, status=$status",
+            status is TmuxSessionViewModel.ConnectionStatus.Connected,
+        )
+        assertEquals(
+            "the attach must reveal the reconciled pane ($label)",
+            listOf("%0"),
+            vm.panes.value.map { it.paneId },
+        )
+    }
+
+    private companion object {
+        /**
+         * The nightly measured `tmux-list-panes-start` -> first heal-capture
+         * timeout at ~3.1 s on the bufferbloat fixture: slow, but comfortably
+         * inside the reconcile's own 6 s exec ceiling.
+         */
+        const val SLOW_LINK_LIST_PANES_MS: Long = 3_000L
+
+        /** Enough canned rows for the reconcile poll loop plus any post-reveal refresh. */
+        const val LIST_PANES_RESPONSES: Int = 8
+
+        const val PUMP_STEP_MS: Long = 250L
+        const val PUMP_CEILING_MS: Long = 180_000L
+    }
+}

--- a/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
+++ b/app/src/test/java/com/pocketshell/app/tmux/TmuxSessionWarmOpenTest.kt
@@ -1576,7 +1576,12 @@ class TmuxSessionWarmOpenTest {
             "empty active-pane reveal must stay bounded to the non-reveal seed " +
                 "passes plus one capture per reveal-gate attempt; got " +
                 client.sentCommands.filter { it.startsWith("capture-pane") },
-            (SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS * 3) + ACTIVE_PANE_REVEAL_SEED_ATTEMPTS,
+            // Issue #2409: the pre-reveal ATTACH seed pays only
+            // ATTACH_ACTIVE_PANE_SEED_ATTEMPTS captures (it is the one pass charged
+            // to ATTACH_PANES_READY_TIMEOUT_MS); the two post-reveal reseed passes
+            // keep the full SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS ladder.
+            (SEED_CAPTURE_EMPTY_RETRY_ATTEMPTS * 2) + ATTACH_ACTIVE_PANE_SEED_ATTEMPTS +
+                ACTIVE_PANE_REVEAL_SEED_ATTEMPTS,
             captureCount,
         )
     }


### PR DESCRIPTION
Closes #2409

This is a redo of a fix that was previously merged (6e1286a6), regressed ReconnectStormLivelockE2eTest's 300s watchdog, and was reverted (3b597fc6). Full history, root cause, chosen strategy, and reviewer's independent verification (including re-running both load-bearing emulator tests by hand) are on the issue: https://github.com/alexeygrigorev/pocketshell/issues/2409#issuecomment-5470622147

Release-blocking: this is the sole failure on the D37 nightly release gate for the current release candidate (see https://github.com/alexeygrigorev/pocketshell/issues/2409#issuecomment-5469940163). This PR fixes the underlying user-visible defect without moving either outer timeout ceiling, so it does not carry the same regression risk as the reverted attempt.

Emulator/journey evidence per docs/review-standards.md was gathered during review, not on this PR's own CI (the load-bearing ReconnectStormLivelockE2eTest and ColdDialUnderBandwidthLimitE2eTest classes are heavy and not part of the PR-level journey-smoke subset) — see the linked comment for elapsed times and logcat evidence from both the implementer and an independent reviewer re-run.