### PR TITLE
Fix host-key-trust gap in 9 E2E emulator journey test fixtures

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentNoReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentNoReconnectE2eTest.kt
@@ -117,9 +117,9 @@ class AttachmentNoReconnectE2eTest {
                 runBlocking {
                     val key = readFixtureKey()
                     seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
+                    val trustedFingerprint = waitForSshFixtureReady(SshKey.Pem(key))
                     seedTmuxSession(key)
-                    seededHostRowTag = seedDockerHost(key)
+                    seededHostRowTag = seedDockerHost(key, trustedFingerprint)
                 }
                 base.evaluate()
             }
@@ -447,7 +447,7 @@ class AttachmentNoReconnectE2eTest {
             .commit()
     }
 
-    private suspend fun seedDockerHost(key: String): String {
+    private suspend fun seedDockerHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -469,6 +469,29 @@ class AttachmentNoReconnectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    // Regression (audit-fixes #4b5be0d8 / host-key trust enforcement):
+                    // `LeaseBackedHostSessionOpener` now requires a pre-verified
+                    // fingerprint before the app's own SSH connect (and the silent
+                    // background reprobe) will proceed — an unset fingerprint is
+                    // treated as a first-use probe that ALWAYS fails and routes the
+                    // user to the FirstHostTestConnect trust screen via
+                    // `HostKeyTrustPromptRouter`, hijacking navigation away from the
+                    // host list before this journey can ever tap the seeded host row.
+                    trustedHostKeySha256 = trustedHostKeySha256,
+                    // Companion fixture gap: with the fingerprint fixed, the host's
+                    // pocketshell-CLI setup state is still `Unknown` (only
+                    // tmuxInstalled is seeded), so `HostListViewModel.
+                    // reprobeUnknownHostsOnce()` fires a real background SSH probe
+                    // (`checkTmux`/`checkServerSetup`) that holds the per-host
+                    // `probeLock` for well over a minute against this fixture,
+                    // blocking the foreground tap-to-open behind it. Pre-seeding a
+                    // fresh, compatible pocketshell result (matching what a real host
+                    // looks like after FirstHostTestConnect/bootstrap already ran)
+                    // resolves `HostSetupState` away from `Unknown` so neither the
+                    // reprobe nor the foreground open re-probes at all.
+                    pocketshellInstalled = true,
+                    pocketshellVersionCompatible = true,
+                    pocketshellLastDetectedAt = System.currentTimeMillis(),
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1700StaleFlushJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1700StaleFlushJourneyE2eTest.kt
@@ -90,9 +90,9 @@ class Issue1700StaleFlushJourneyE2eTest {
     private suspend fun seedBeforeLaunch() {
         clearLastSessionPrefs()
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        val trustedFingerprint = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedInteractiveSession(fixtureKey)
-        hostRowTag = seedDockerHost(fixtureKey)
+        hostRowTag = seedDockerHost(fixtureKey, trustedFingerprint)
     }
 
     @After
@@ -320,7 +320,7 @@ class Issue1700StaleFlushJourneyE2eTest {
         InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
 
-    private suspend fun seedDockerHost(key: String): String {
+    private suspend fun seedDockerHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -342,6 +342,26 @@ class Issue1700StaleFlushJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    // Regression (audit-fixes #4b5be0d8 / host-key trust enforcement):
+                    // an unset fingerprint is a first-use probe that ALWAYS fails and
+                    // routes the user to the FirstHostTestConnect trust screen via
+                    // `HostKeyTrustPromptRouter`, hijacking navigation away from the
+                    // host list before this journey can ever tap the seeded host row.
+                    trustedHostKeySha256 = trustedHostKeySha256,
+                    // Companion fixture gap: with the fingerprint fixed, the host's
+                    // pocketshell-CLI setup state is still `Unknown` (only
+                    // tmuxInstalled is seeded), so `HostListViewModel.
+                    // reprobeUnknownHostsOnce()` fires a real background SSH probe
+                    // (`checkTmux`/`checkServerSetup`) that holds the per-host
+                    // `probeLock` for well over a minute against this fixture,
+                    // blocking the foreground tap-to-open behind it. Pre-seeding a
+                    // fresh, compatible pocketshell result (matching what a real host
+                    // looks like after FirstHostTestConnect/bootstrap already ran)
+                    // resolves `HostSetupState` away from `Unknown` so neither the
+                    // reprobe nor the foreground open re-probes at all.
+                    pocketshellInstalled = true,
+                    pocketshellVersionCompatible = true,
+                    pocketshellLastDetectedAt = System.currentTimeMillis(),
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue895SwitchWhileBlackBandJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue895SwitchWhileBlackBandJourneyE2eTest.kt
@@ -94,9 +94,9 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
                 runBlocking {
                     val key = readFixtureKey()
                     seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
+                    val trustedFingerprint = waitForSshFixtureReady(SshKey.Pem(key))
                     seedTmuxSession(key)
-                    seededHostRowTag = seedDockerHost(key)
+                    seededHostRowTag = seedDockerHost(key, trustedFingerprint)
                 }
                 base.evaluate()
             }
@@ -426,7 +426,7 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
             .bufferedReader()
             .use { it.readText() }
 
-    private suspend fun seedDockerHost(key: String): String {
+    private suspend fun seedDockerHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -448,6 +448,26 @@ class Issue895SwitchWhileBlackBandJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    // Regression (audit-fixes #4b5be0d8 / host-key trust enforcement):
+                    // an unset fingerprint is a first-use probe that ALWAYS fails and
+                    // routes the user to the FirstHostTestConnect trust screen via
+                    // `HostKeyTrustPromptRouter`, hijacking navigation away from the
+                    // host list before this journey can ever tap the seeded host row.
+                    trustedHostKeySha256 = trustedHostKeySha256,
+                    // Companion fixture gap: with the fingerprint fixed, the host's
+                    // pocketshell-CLI setup state is still `Unknown` (only
+                    // tmuxInstalled is seeded), so `HostListViewModel.
+                    // reprobeUnknownHostsOnce()` fires a real background SSH probe
+                    // (`checkTmux`/`checkServerSetup`) that holds the per-host
+                    // `probeLock` for well over a minute against this fixture,
+                    // blocking the foreground tap-to-open behind it. Pre-seeding a
+                    // fresh, compatible pocketshell result (matching what a real host
+                    // looks like after FirstHostTestConnect/bootstrap already ran)
+                    // resolves `HostSetupState` away from `Unknown` so neither the
+                    // reprobe nor the foreground open re-probes at all.
+                    pocketshellInstalled = true,
+                    pocketshellVersionCompatible = true,
+                    pocketshellLastDetectedAt = System.currentTimeMillis(),
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/LifecycleReattachGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/LifecycleReattachGoneSessionNoResurrectE2eTest.kt
@@ -153,12 +153,12 @@ class LifecycleReattachGoneSessionNoResurrectE2eTest {
         BackgroundGraceTestOverride.setForTest(null)
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        val trustedFingerprint = waitForSshFixtureReady(SshKey.Pem(key))
         // Seed the target AND a keepalive so the server survives the target kill.
         seedTmuxSessions(key)
         assertTrue("seeded target session must be alive", sessionAlive(key, TARGET_SESSION))
         assertTrue("seeded keepalive session must be alive", sessionAlive(key, KEEPALIVE_SESSION))
-        hostRowTag = seedDockerHost(key)
+        hostRowTag = seedDockerHost(key, trustedFingerprint)
     }
 
     private fun clearProcessScopedStalePrompt() {
@@ -416,7 +416,7 @@ class LifecycleReattachGoneSessionNoResurrectE2eTest {
             .commit()
     }
 
-    private suspend fun seedDockerHost(key: String): String {
+    private suspend fun seedDockerHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -438,6 +438,26 @@ class LifecycleReattachGoneSessionNoResurrectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    // Regression (audit-fixes #4b5be0d8 / host-key trust enforcement):
+                    // an unset fingerprint is a first-use probe that ALWAYS fails and
+                    // routes the user to the FirstHostTestConnect trust screen via
+                    // `HostKeyTrustPromptRouter`, hijacking navigation away from the
+                    // host list before this journey can ever tap the seeded host row.
+                    trustedHostKeySha256 = trustedHostKeySha256,
+                    // Companion fixture gap: with the fingerprint fixed, the host's
+                    // pocketshell-CLI setup state is still `Unknown` (only
+                    // tmuxInstalled is seeded), so `HostListViewModel.
+                    // reprobeUnknownHostsOnce()` fires a real background SSH probe
+                    // (`checkTmux`/`checkServerSetup`) that holds the per-host
+                    // `probeLock` for well over a minute against this fixture,
+                    // blocking the foreground tap-to-open behind it. Pre-seeding a
+                    // fresh, compatible pocketshell result (matching what a real host
+                    // looks like after FirstHostTestConnect/bootstrap already ran)
+                    // resolves `HostSetupState` away from `Unknown` so neither the
+                    // reprobe nor the foreground open re-probes at all.
+                    pocketshellInstalled = true,
+                    pocketshellVersionCompatible = true,
+                    pocketshellLastDetectedAt = System.currentTimeMillis(),
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SendNoReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SendNoReconnectE2eTest.kt
@@ -107,9 +107,9 @@ class SendNoReconnectE2eTest {
                 runBlocking {
                     val key = readFixtureKey()
                     seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
+                    val trustedFingerprint = waitForSshFixtureReady(SshKey.Pem(key))
                     seedTmuxSession(key)
-                    seededHostRowTag = seedDockerHost(key)
+                    seededHostRowTag = seedDockerHost(key, trustedFingerprint)
                 }
                 base.evaluate()
             }
@@ -408,7 +408,7 @@ class SendNoReconnectE2eTest {
             .commit()
     }
 
-    private suspend fun seedDockerHost(key: String): String {
+    private suspend fun seedDockerHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -430,6 +430,26 @@ class SendNoReconnectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    // Regression (audit-fixes #4b5be0d8 / host-key trust enforcement):
+                    // an unset fingerprint is a first-use probe that ALWAYS fails and
+                    // routes the user to the FirstHostTestConnect trust screen via
+                    // `HostKeyTrustPromptRouter`, hijacking navigation away from the
+                    // host list before this journey can ever tap the seeded host row.
+                    trustedHostKeySha256 = trustedHostKeySha256,
+                    // Companion fixture gap: with the fingerprint fixed, the host's
+                    // pocketshell-CLI setup state is still `Unknown` (only
+                    // tmuxInstalled is seeded), so `HostListViewModel.
+                    // reprobeUnknownHostsOnce()` fires a real background SSH probe
+                    // (`checkTmux`/`checkServerSetup`) that holds the per-host
+                    // `probeLock` for well over a minute against this fixture,
+                    // blocking the foreground tap-to-open behind it. Pre-seeding a
+                    // fresh, compatible pocketshell result (matching what a real host
+                    // looks like after FirstHostTestConnect/bootstrap already ran)
+                    // resolves `HostSetupState` away from `Unknown` so neither the
+                    // reprobe nor the foreground open re-probes at all.
+                    pocketshellInstalled = true,
+                    pocketshellVersionCompatible = true,
+                    pocketshellLastDetectedAt = System.currentTimeMillis(),
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/StableWifiNoSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StableWifiNoSpuriousReconnectE2eTest.kt
@@ -126,9 +126,9 @@ class StableWifiNoSpuriousReconnectE2eTest {
                 runBlocking {
                     val key = readFixtureKey()
                     seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
+                    val trustedFingerprint = waitForSshFixtureReady(SshKey.Pem(key))
                     seedTmuxSession(key)
-                    seededHostRowTag = seedDockerHost(key)
+                    seededHostRowTag = seedDockerHost(key, trustedFingerprint)
                 }
                 base.evaluate()
             }
@@ -703,7 +703,7 @@ class StableWifiNoSpuriousReconnectE2eTest {
             .bufferedReader()
             .use { it.readText() }
 
-    private suspend fun seedDockerHost(key: String): String {
+    private suspend fun seedDockerHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -725,6 +725,26 @@ class StableWifiNoSpuriousReconnectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    // Regression (audit-fixes #4b5be0d8 / host-key trust enforcement):
+                    // an unset fingerprint is a first-use probe that ALWAYS fails and
+                    // routes the user to the FirstHostTestConnect trust screen via
+                    // `HostKeyTrustPromptRouter`, hijacking navigation away from the
+                    // host list before this journey can ever tap the seeded host row.
+                    trustedHostKeySha256 = trustedHostKeySha256,
+                    // Companion fixture gap: with the fingerprint fixed, the host's
+                    // pocketshell-CLI setup state is still `Unknown` (only
+                    // tmuxInstalled is seeded), so `HostListViewModel.
+                    // reprobeUnknownHostsOnce()` fires a real background SSH probe
+                    // (`checkTmux`/`checkServerSetup`) that holds the per-host
+                    // `probeLock` for well over a minute against this fixture,
+                    // blocking the foreground tap-to-open behind it. Pre-seeding a
+                    // fresh, compatible pocketshell result (matching what a real host
+                    // looks like after FirstHostTestConnect/bootstrap already ran)
+                    // resolves `HostSetupState` away from `Unknown` so neither the
+                    // reprobe nor the foreground open re-probes at all.
+                    pocketshellInstalled = true,
+                    pocketshellVersionCompatible = true,
+                    pocketshellLastDetectedAt = System.currentTimeMillis(),
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/StaleRenderHealOnLiveTransportJourneyE2eTest.kt
@@ -149,10 +149,10 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
     fun staleRenderHealsWhileTransportStaysConnectedAcrossAllKinds() { runBlocking {
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        val trustedFingerprint = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
 
-        val hostRowTag = seedDockerHost(key)
+        val hostRowTag = seedDockerHost(key, trustedFingerprint)
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
         attachSeededTmuxSession(hostRowTag)
 
@@ -1080,7 +1080,7 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
         InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
 
-    private suspend fun seedDockerHost(key: String): String {
+    private suspend fun seedDockerHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -1102,6 +1102,26 @@ class StaleRenderHealOnLiveTransportJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    // Regression (audit-fixes #4b5be0d8 / host-key trust enforcement):
+                    // an unset fingerprint is a first-use probe that ALWAYS fails and
+                    // routes the user to the FirstHostTestConnect trust screen via
+                    // `HostKeyTrustPromptRouter`, hijacking navigation away from the
+                    // host list before this journey can ever tap the seeded host row.
+                    trustedHostKeySha256 = trustedHostKeySha256,
+                    // Companion fixture gap: with the fingerprint fixed, the host's
+                    // pocketshell-CLI setup state is still `Unknown` (only
+                    // tmuxInstalled is seeded), so `HostListViewModel.
+                    // reprobeUnknownHostsOnce()` fires a real background SSH probe
+                    // (`checkTmux`/`checkServerSetup`) that holds the per-host
+                    // `probeLock` for well over a minute against this fixture,
+                    // blocking the foreground tap-to-open behind it. Pre-seeding a
+                    // fresh, compatible pocketshell result (matching what a real host
+                    // looks like after FirstHostTestConnect/bootstrap already ran)
+                    // resolves `HostSetupState` away from `Unknown` so neither the
+                    // reprobe nor the foreground open re-probes at all.
+                    pocketshellInstalled = true,
+                    pocketshellVersionCompatible = true,
+                    pocketshellLastDetectedAt = System.currentTimeMillis(),
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SwitchStaleCaptureSessionBodyJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SwitchStaleCaptureSessionBodyJourneyE2eTest.kt
@@ -340,7 +340,7 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
         val key = readFixtureKey()
         seededKey = key
         try {
-            waitForSshFixtureReady(SshKey.Pem(key))
+            val trustedFingerprint = waitForSshFixtureReady(SshKey.Pem(key))
 
             // Seed A (idle marker) + B (idle marker). A's continuous stream is
             // STARTED AFTER attach (a sidecar trigger) so the picker enumeration
@@ -348,7 +348,7 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
             // picker-time stalls the in-emulator `list-sessions` enumeration (#470),
             // which is setup noise, not the device-truth assertion we want to test.
             seedStreamingAndTargetSessions(key)
-            seededHostRowTag = seedDockerHost(key)
+            seededHostRowTag = seedDockerHost(key, trustedFingerprint)
             forceFlatHostDetailViewMode()
         } catch (t: Throwable) {
             runCatching { cleanupSeededSessions(key) }
@@ -356,7 +356,7 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
         }
     }
 
-    private suspend fun seedDockerHost(key: String): String {
+    private suspend fun seedDockerHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -378,6 +378,26 @@ class SwitchStaleCaptureSessionBodyJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    // Regression (audit-fixes #4b5be0d8 / host-key trust enforcement):
+                    // an unset fingerprint is a first-use probe that ALWAYS fails and
+                    // routes the user to the FirstHostTestConnect trust screen via
+                    // `HostKeyTrustPromptRouter`, hijacking navigation away from the
+                    // host list before this journey can ever tap the seeded host row.
+                    trustedHostKeySha256 = trustedHostKeySha256,
+                    // Companion fixture gap: with the fingerprint fixed, the host's
+                    // pocketshell-CLI setup state is still `Unknown` (only
+                    // tmuxInstalled is seeded), so `HostListViewModel.
+                    // reprobeUnknownHostsOnce()` fires a real background SSH probe
+                    // (`checkTmux`/`checkServerSetup`) that holds the per-host
+                    // `probeLock` for well over a minute against this fixture,
+                    // blocking the foreground tap-to-open behind it. Pre-seeding a
+                    // fresh, compatible pocketshell result (matching what a real host
+                    // looks like after FirstHostTestConnect/bootstrap already ran)
+                    // resolves `HostSetupState` away from `Unknown` so neither the
+                    // reprobe nor the foreground open re-probes at all.
+                    pocketshellInstalled = true,
+                    pocketshellVersionCompatible = true,
+                    pocketshellLastDetectedAt = System.currentTimeMillis(),
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue2155ConversationRebindsAfterInSessionRelaunchDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue2155ConversationRebindsAfterInSessionRelaunchDockerTest.kt
@@ -232,9 +232,9 @@ class Issue2155ConversationRebindsAfterInSessionRelaunchDockerTest {
         val key = readFixtureKey()
         seededKey = key
         clearLastSessionPrefs()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        val trustedFingerprint = waitForSshFixtureReady(SshKey.Pem(key))
         seededSessionName = seedFirstAgentSession(key)
-        seededHostRowTag = persistHost(key)
+        seededHostRowTag = persistHost(key, trustedFingerprint)
     }
 
     /**
@@ -452,7 +452,7 @@ class Issue2155ConversationRebindsAfterInSessionRelaunchDockerTest {
         compose.waitForIdle()
     }
 
-    private suspend fun persistHost(key: String): String {
+    private suspend fun persistHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         var hostRowTag = ""
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
@@ -475,6 +475,26 @@ class Issue2155ConversationRebindsAfterInSessionRelaunchDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    // Regression (audit-fixes #4b5be0d8 / host-key trust enforcement):
+                    // an unset fingerprint is a first-use probe that ALWAYS fails and
+                    // routes the user to the FirstHostTestConnect trust screen via
+                    // `HostKeyTrustPromptRouter`, hijacking navigation away from the
+                    // host list before this journey can ever tap the seeded host row.
+                    trustedHostKeySha256 = trustedHostKeySha256,
+                    // Companion fixture gap: with the fingerprint fixed, the host's
+                    // pocketshell-CLI setup state is still `Unknown` (only
+                    // tmuxInstalled is seeded), so `HostListViewModel.
+                    // reprobeUnknownHostsOnce()` fires a real background SSH probe
+                    // (`checkTmux`/`checkServerSetup`) that holds the per-host
+                    // `probeLock` for well over a minute against this fixture,
+                    // blocking the foreground tap-to-open behind it. Pre-seeding a
+                    // fresh, compatible pocketshell result (matching what a real host
+                    // looks like after FirstHostTestConnect/bootstrap already ran)
+                    // resolves `HostSetupState` away from `Unknown` so neither the
+                    // reprobe nor the foreground open re-probes at all.
+                    pocketshellInstalled = true,
+                    pocketshellVersionCompatible = true,
+                    pocketshellLastDetectedAt = System.currentTimeMillis(),
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId


### PR DESCRIPTION
Last thing blocking \`main\`'s Emulator journey lane for the v0.4.47 release. Full review: https://github.com/alexeygrigorev/pocketshell/issues/2451

Same class of gap as #2445/#2446 (host-key trust, \`4b5be0d8\`), surfacing via a background reprobe path this time — test-fixture-only, no production code touched.

Re-verified by reviewer: full JVM gate 604/604, RED→GREEN driven on the real emulator with logcat proof, shard-2's 5 classes 8/8, the one flagged flaky-looking test traced to a reproduction-methodology artifact (not a real flake — CI's actual per-class isolated invocation passes clean).

Closes #2451