### PR TITLE
Fix remaining host-key-trust gap across 121 androidTest fixtures

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/bootstrap/HostBootstrapScenarioSuiteTest.kt
@@ -19,6 +19,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.hosts.HOST_LIST_APP_UPDATE_WARNING_TAG
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.projects.FOLDER_LIST_BACK_TAG
@@ -423,7 +424,12 @@ class HostBootstrapScenarioSuiteTest {
         withTimeout(60_000) {
             context.resetRemote()
             try {
-                context.seedAppDatabase()
+                // Issue #2446: `tapSeededHost()` below drives the REAL
+                // production bootstrap flow (SshLeaseManager-backed), which
+                // enforces host-key trust — capture the presented fingerprint
+                // for this scenario's port before seeding the HostEntity.
+                val trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key), port = definition.port)
+                context.seedAppDatabase(trustedHostKeySha256)
                 context.block()
             } finally {
                 context.recordTiming("scenario_elapsed_ms", SystemClock.elapsedRealtime() - scenarioStartMs)
@@ -444,7 +450,7 @@ class HostBootstrapScenarioSuiteTest {
         private var keyId: Long? = null
         private val timings = mutableListOf<String>()
 
-        fun seedAppDatabase() {
+        fun seedAppDatabase(trustedHostKeySha256: String) {
             val appContext = InstrumentationRegistry.getInstrumentation().targetContext
             val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
                 .fallbackToDestructiveMigration(dropAllTables = true)
@@ -465,6 +471,7 @@ class HostBootstrapScenarioSuiteTest {
                             port = definition.port,
                             username = DEFAULT_USER,
                             keyId = storedKey.id,
+                            trustedHostKeySha256 = trustedHostKeySha256,
                         ),
                     )
                 }

--- a/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionJournalHostPullJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/diagnostics/ConnectionJournalHostPullJourneyDockerTest.kt
@@ -73,6 +73,7 @@ import java.security.MessageDigest
  */
 @RunWith(AndroidJUnit4::class)
 class ConnectionJournalHostPullJourneyDockerTest {
+    private lateinit var trustedHostKeySha256: String
     val compose = createAndroidComposeRule<MainActivity>()
 
     @get:Rule
@@ -310,7 +311,7 @@ class ConnectionJournalHostPullJourneyDockerTest {
         clearLastSessionPrefs()
         fixtureKey = readFixtureKey()
         markerPrefix = "issue1710-${System.currentTimeMillis().toString(36)}"
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedRemoteSession()
         hostRowTag = seedDockerHost()
         SettingsRepository(InstrumentationRegistry.getInstrumentation().targetContext)
@@ -557,6 +558,7 @@ class ConnectionJournalHostPullJourneyDockerTest {
                     pocketshellVersionCompatible = true,
                     pocketshellDaemonRunning = true,
                     pocketshellDaemonEnabled = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             "$HOST_ROW_TAG_PREFIX$hostId"

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerTabsMainActivityJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerTabsMainActivityJourneyDockerTest.kt
@@ -78,6 +78,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class FileViewerTabsMainActivityJourneyDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     // JOURNEY_HARNESS_JUSTIFIED: #1715 must finish and cold-launch a second
     // MainActivity in one instrumentation test to prove a fresh ViewModel
@@ -265,7 +266,7 @@ class FileViewerTabsMainActivityJourneyDockerTest {
         clearLastSessionPrefs()
         val keyText = readFixtureKeyText()
         fixtureKey = SshKey.Pem(keyText)
-        waitForSshFixtureReady(fixtureKey, port = DAEMON_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(fixtureKey, port = DAEMON_PORT)
 
         val suffix = if (externalProcessPhase() != null) {
             externalProcessNamespace()
@@ -302,7 +303,7 @@ class FileViewerTabsMainActivityJourneyDockerTest {
     private suspend fun seedExistingExternalProcessFixture() {
         clearLastSessionPrefs()
         fixtureKey = SshKey.Pem(readFixtureKeyText())
-        waitForSshFixtureReady(fixtureKey, port = DAEMON_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(fixtureKey, port = DAEMON_PORT)
         val phaseOne = readExternalProcessArtifact(phase = 1)
         sessionName = phaseOne.getValue("producer_session_name")
         pathA = phaseOne.getValue("path_a")
@@ -337,6 +338,7 @@ class FileViewerTabsMainActivityJourneyDockerTest {
                 keyId = storedKey.id,
                 tmuxInstalled = true,
                 lastBootstrapAt = System.currentTimeMillis(),
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
     }

--- a/app/src/androidTest/java/com/pocketshell/app/hosts/DefaultHostLaunchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/hosts/DefaultHostLaunchE2eTest.kt
@@ -12,9 +12,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.MainActivity
 import com.pocketshell.app.proof.PreGrantPermissionsRule
+import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.projects.FOLDER_LIST_BACK_TAG
 import com.pocketshell.app.projects.FOLDER_LIST_SCREEN_TAG
 import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.entity.HostEntity
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.runBlocking
@@ -127,6 +129,11 @@ class DefaultHostLaunchE2eTest {
                 content = key,
             )
             keyId = storedKey.id
+            // Issue #2446: the FolderList-opens assertion below requires a
+            // real successful production connect (not the "Trust and
+            // connect" screen), so the seeded host needs a pre-verified
+            // fingerprint like every other real-fixture seed helper.
+            val trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             hostId = db.hostDao().insert(
                 HostEntity(
                     name = hostName,
@@ -138,6 +145,7 @@ class DefaultHostLaunchE2eTest {
                     pocketshellInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
                     pocketshellLastDetectedAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
         }

--- a/app/src/androidTest/java/com/pocketshell/app/nav/Issue1831SessionEntryPathBackE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/nav/Issue1831SessionEntryPathBackE2eTest.kt
@@ -100,6 +100,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class Issue1831SessionEntryPathBackE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -121,7 +122,7 @@ class Issue1831SessionEntryPathBackE2eTest {
             clearLastSessionPrefs()
             val key = readFixtureKey()
             fixtureKey = key
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedTmuxSession(key)
             hostId = seedDockerHost(key)
             forceFlatHostDetailViewMode()
@@ -443,6 +444,7 @@ class Issue1831SessionEntryPathBackE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
         } finally {

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNetworkRideThroughE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNetworkRideThroughE2eTest.kt
@@ -69,6 +69,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class ForwardingNetworkRideThroughE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createEmptyComposeRule()
 
@@ -109,7 +110,7 @@ class ForwardingNetworkRideThroughE2eTest {
     @Test
     fun cellularHandoffLossRestoreRidesThroughWhenTunnelSurvived_redialsWhenDead() {
         val key = readFixtureKey()
-        runBlocking { waitForSshFixtureReady(SshKey.Pem(key)) }
+        trustedHostKeySha256 = runBlocking { waitForSshFixtureReady(SshKey.Pem(key)) }
 
         // 1. Seed an ENABLED host pointing at the agents fixture into the real
         //    singleton DB (the same instance the running app flows observe),
@@ -133,6 +134,7 @@ class ForwardingNetworkRideThroughE2eTest {
                     username = DEFAULT_USER,
                     keyId = storedKey.id,
                     enabled = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
         }

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationDurableStopE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationDurableStopE2eTest.kt
@@ -86,7 +86,7 @@ class ForwardingNotificationDurableStopE2eTest {
     @Test
     fun notificationStopDisablesEveryPersistedHost_andRelaunchCannotResumeForwarding() {
         val fixtureKey = readFixtureKey()
-        runBlocking { waitForSshFixtureReady(SshKey.Pem(fixtureKey)) }
+        val trustedHostKeySha256 = runBlocking { waitForSshFixtureReady(SshKey.Pem(fixtureKey)) }
 
         val db = entryPoint().appDatabase()
         lateinit var firstSeededBeforeBootstrap: HostEntity
@@ -110,6 +110,7 @@ class ForwardingNotificationDurableStopE2eTest {
                     enabled = true,
                     maxAutoPort = 4_321,
                     skipPortsBelow = 1_234,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             firstSeededBeforeBootstrap = requireNotNull(db.hostDao().getById(firstId))
@@ -127,6 +128,7 @@ class ForwardingNotificationDurableStopE2eTest {
                 enabled = true,
                 maxAutoPort = 9_876,
                 skipPortsBelow = 2_345,
+                trustedHostKeySha256 = trustedHostKeySha256,
             )
         }
 

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationE2eTest.kt
@@ -101,6 +101,7 @@ import kotlinx.coroutines.runBlocking
  */
 @RunWith(AndroidJUnit4::class)
 class ForwardingNotificationE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val permissions = PreGrantPermissionsRule()
@@ -519,7 +520,7 @@ class ForwardingNotificationE2eTest {
         val fixtureKey = SshKey.Pem(
             instrumentation.context.assets.open("test_key").bufferedReader().use { it.readText() },
         )
-        waitForSshFixtureReady(fixtureKey, port = DEFAULT_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(fixtureKey, port = DEFAULT_PORT)
         cleanupRemoteEchoFixture(fixtureKey)
         val forwardingSession = SshConnection.connect(
             host = DEFAULT_HOST,
@@ -546,6 +547,7 @@ class ForwardingNotificationE2eTest {
                     maxAutoPort = remotePort,
                     skipPortsBelow = remotePort - 1,
                     scanIntervalSec = 1,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
                 keyPath = "",
                 passphrase = null,

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationObserverGenerationE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingNotificationObserverGenerationE2eTest.kt
@@ -117,6 +117,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 @RunWith(AndroidJUnit4::class)
 class ForwardingNotificationObserverGenerationE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     private val context: Context = ApplicationProvider.getApplicationContext()
@@ -264,7 +265,7 @@ class ForwardingNotificationObserverGenerationE2eTest {
         val fixtureKey = SshKey.Pem(
             instrumentation.context.assets.open("test_key").bufferedReader().use { it.readText() },
         )
-        waitForSshFixtureReady(fixtureKey, port = DEFAULT_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(fixtureKey, port = DEFAULT_PORT)
         startRemoteEchoFixture(fixtureKey)
 
         // Pin the service instance for the whole journey (see the class KDoc):
@@ -524,6 +525,7 @@ class ForwardingNotificationObserverGenerationE2eTest {
                 maxAutoPort = REMOTE_PORT,
                 skipPortsBelow = REMOTE_PORT - 1,
                 scanIntervalSec = 1,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
             keyPath = "",
             passphrase = null,

--- a/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingResumeOnLaunchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/portfwd/ForwardingResumeOnLaunchE2eTest.kt
@@ -69,6 +69,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ForwardingResumeOnLaunchE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createEmptyComposeRule()
 
@@ -108,7 +109,7 @@ class ForwardingResumeOnLaunchE2eTest {
     @Test
     fun persistedEnabledHost_resumesForwardingAndShowsIndicatorOnLaunch() {
         val key = readFixtureKey()
-        runBlocking { waitForSshFixtureReady(SshKey.Pem(key)) }
+        trustedHostKeySha256 = runBlocking { waitForSshFixtureReady(SshKey.Pem(key)) }
 
         // 1. Seed an ENABLED host pointing at the agents fixture into the real
         //    singleton DB (the same instance the app's running flows observe),
@@ -136,6 +137,7 @@ class ForwardingResumeOnLaunchE2eTest {
                     keyId = storedKey.id,
                     // The persisted intent that origin/main never read back.
                     enabled = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
         }

--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchCommandDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentLaunchCommandDockerTest.kt
@@ -52,6 +52,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class AgentLaunchCommandDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -75,7 +76,7 @@ class AgentLaunchCommandDockerTest {
             instrumentation.targetContext.getExternalFilesDir(null),
             "agent-launch-command",
         ).apply { mkdirs() }
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -258,5 +259,6 @@ class AgentLaunchCommandDockerTest {
         port = DEFAULT_PORT,
         username = DEFAULT_USER,
         keyId = 1L,
+        trustedHostKeySha256 = trustedHostKeySha256,
     )
 }

--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentRecordedKindReadBackDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentRecordedKindReadBackDockerTest.kt
@@ -41,6 +41,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class AgentRecordedKindReadBackDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -59,7 +60,7 @@ class AgentRecordedKindReadBackDockerTest {
             FileOutputStream(this).use { it.write(keyText.toByteArray()) }
             setReadable(true, true)
         }
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -198,6 +199,7 @@ class AgentRecordedKindReadBackDockerTest {
         port = DEFAULT_PORT,
         username = DEFAULT_USER,
         keyId = 1L,
+        trustedHostKeySha256 = trustedHostKeySha256,
     )
 
     private fun shellQuote(value: String): String =

--- a/app/src/androidTest/java/com/pocketshell/app/projects/AgentStateReadBackDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/AgentStateReadBackDockerTest.kt
@@ -51,6 +51,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class AgentStateReadBackDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -69,7 +70,7 @@ class AgentStateReadBackDockerTest {
             FileOutputStream(this).use { it.write(keyText.toByteArray()) }
             setReadable(true, true)
         }
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -383,6 +384,7 @@ class AgentStateReadBackDockerTest {
         port = DEFAULT_PORT,
         username = DEFAULT_USER,
         keyId = 1L,
+        trustedHostKeySha256 = trustedHostKeySha256,
     )
 
     private fun shellQuote(value: String): String =

--- a/app/src/androidTest/java/com/pocketshell/app/projects/EngineAvailabilityPickerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/EngineAvailabilityPickerDockerTest.kt
@@ -59,6 +59,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class EngineAvailabilityPickerDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createComposeRule()
@@ -82,7 +83,7 @@ class EngineAvailabilityPickerDockerTest {
         }
 
         val engines = runBlocking {
-            waitForSshFixtureReady(sshKey)
+            trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
             val leaseManager = SshLeaseManager(connector = DefaultSshLeaseConnector())
             try {
                 val host = HostEntity(
@@ -92,6 +93,7 @@ class EngineAvailabilityPickerDockerTest {
                     port = DEFAULT_PORT,
                     username = DEFAULT_USER,
                     keyId = 2276L,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 )
                 val result = withTimeout(30_000) {
                     SshEnginesGateway(leaseManager).listEngines(

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListBootstrapSkipTreeLoadsDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListBootstrapSkipTreeLoadsDockerTest.kt
@@ -79,6 +79,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListBootstrapSkipTreeLoadsDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private val compose = createAndroidComposeRule<MainActivity>()
     private var hostRowTag: String = ""
@@ -134,7 +135,7 @@ class FolderListBootstrapSkipTreeLoadsDockerTest {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         // Confirm the fixture is reachable + really old (rejects `tree`).
-        waitForSshFixtureReady(SshKey.Pem(keyText), port = OLD_CLI_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(keyText), port = OLD_CLI_PORT)
         withTimeout(20_000) {
             SshConnection.connect(
                 host = DEFAULT_HOST,
@@ -175,6 +176,7 @@ class FolderListBootstrapSkipTreeLoadsDockerTest {
                     // old CLI drives the "Host setup needed" sheet.
                     tmuxInstalled = null,
                     lastBootstrapAt = null,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListClientCacheInstantRenderDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListClientCacheInstantRenderDockerTest.kt
@@ -80,6 +80,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListClientCacheInstantRenderDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -111,7 +112,7 @@ class FolderListClientCacheInstantRenderDockerTest {
             .allowMainThreadQueries()
             .build()
         cache = TreeClientCache(context)
-        waitForSshFixtureReady(sshKey, port = fixturePort)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = fixturePort)
     } }
 
     @After
@@ -223,6 +224,7 @@ class FolderListClientCacheInstantRenderDockerTest {
                 port = fixturePort,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = db.hostDao().getById(hostId)!!
@@ -332,7 +334,7 @@ class FolderListClientCacheInstantRenderDockerTest {
     @Test
     fun lastSessionEmptySurvivesColdOwnerRecreationBeforeUnavailableReconcile() {
         runBlocking {
-            waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
+            trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         val sessionName = "issue2243-last-$suffix"
         val folder = "/tmp/$sessionName"
@@ -347,6 +349,7 @@ class FolderListClientCacheInstantRenderDockerTest {
                 port = DAEMON_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = requireNotNull(db.hostDao().getById(hostId))

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListDurableTreeDaemonDockerTest.kt
@@ -116,6 +116,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListDurableTreeDaemonDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createComposeRule()
@@ -156,7 +157,7 @@ class FolderListDurableTreeDaemonDockerTest {
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()
             .build()
-        waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
     } }
 
     @After
@@ -256,6 +257,7 @@ class FolderListDurableTreeDaemonDockerTest {
                 port = DAEMON_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         // Persist the watched root so the live tree buckets the two sessions under
@@ -466,6 +468,7 @@ class FolderListDurableTreeDaemonDockerTest {
                 port = DAEMON_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         db.projectRootDao().insert(
@@ -730,6 +733,7 @@ class FolderListDurableTreeDaemonDockerTest {
                 port = DAEMON_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         db.projectRootDao().insert(

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListGatewayDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListGatewayDockerTest.kt
@@ -55,6 +55,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListGatewayDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -79,7 +80,7 @@ class FolderListGatewayDockerTest {
             FileOutputStream(this).use { it.write(keyText.toByteArray()) }
             setReadable(true, true)
         }
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -141,6 +142,7 @@ class FolderListGatewayDockerTest {
             port = DEFAULT_PORT,
             username = DEFAULT_USER,
             keyId = 1L,
+            trustedHostKeySha256 = trustedHostKeySha256,
         )
         val result = gateway.listSessionsWithFolder(
             host = host,

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListGatewayStaleChannelHealDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListGatewayStaleChannelHealDockerTest.kt
@@ -65,6 +65,7 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListGatewayStaleChannelHealDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -86,7 +87,7 @@ class FolderListGatewayStaleChannelHealDockerTest {
             FileOutputStream(this).use { it.write(keyText.toByteArray()) }
             setReadable(true, true)
         }
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -231,14 +232,19 @@ class FolderListGatewayStaleChannelHealDockerTest {
         }
     }
 
-    private companion object {
-        val HOST: HostEntity = HostEntity(
+    // Issue #2446: was a companion-object `val` initialized eagerly at class
+    // load, before `trustedHostKeySha256` is known — moved to an
+    // instance-level computed property so every access (all from inside
+    // `@Test` methods, which run after `setUp()` has captured the real
+    // presented fingerprint) rebuilds it with the current trust binding.
+    private val HOST: HostEntity
+        get() = HostEntity(
             id = 1L,
             name = "issue680-heal-test",
             hostname = DEFAULT_HOST,
             port = DEFAULT_PORT,
             username = DEFAULT_USER,
             keyId = 1L,
+            trustedHostKeySha256 = trustedHostKeySha256,
         )
-    }
 }

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListHostOutdatedTreeVersionDaemonDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListHostOutdatedTreeVersionDaemonDockerTest.kt
@@ -90,6 +90,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListHostOutdatedTreeVersionDaemonDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -117,7 +118,7 @@ class FolderListHostOutdatedTreeVersionDaemonDockerTest {
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()
             .build()
-        waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
     } }
 
     @After
@@ -178,6 +179,7 @@ class FolderListHostOutdatedTreeVersionDaemonDockerTest {
                 port = DAEMON_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = db.hostDao().getById(hostId)!!

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillSessionDockerTest.kt
@@ -63,6 +63,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListKillSessionDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -95,7 +96,7 @@ class FolderListKillSessionDockerTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -163,6 +164,7 @@ class FolderListKillSessionDockerTest {
                 port = DEFAULT_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = db.hostDao().getById(hostId)!!

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillWindowDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillWindowDockerTest.kt
@@ -65,6 +65,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListKillWindowDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -93,7 +94,7 @@ class FolderListKillWindowDockerTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -167,6 +168,7 @@ class FolderListKillWindowDockerTest {
                 port = DEFAULT_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = db.hostDao().getById(hostId)!!

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOldCliHydrateDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOldCliHydrateDockerTest.kt
@@ -67,6 +67,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListOldCliHydrateDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -101,7 +102,7 @@ class FolderListOldCliHydrateDockerTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
-        waitForSshFixtureReady(sshKey, port = OLD_CLI_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = OLD_CLI_PORT)
     } }
 
     @After
@@ -177,6 +178,7 @@ class FolderListOldCliHydrateDockerTest {
                 port = OLD_CLI_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = db.hostDao().getById(hostId)!!

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOutOfBandSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListOutOfBandSessionDockerTest.kt
@@ -76,6 +76,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListOutOfBandSessionDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -106,7 +107,7 @@ class FolderListOutOfBandSessionDockerTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -172,6 +173,7 @@ class FolderListOutOfBandSessionDockerTest {
                 port = DEFAULT_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = db.hostDao().getById(hostId)!!

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionResumeDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListSessionResumeDockerTest.kt
@@ -69,6 +69,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListSessionResumeDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -98,7 +99,7 @@ class FolderListSessionResumeDockerTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -160,6 +161,7 @@ class FolderListSessionResumeDockerTest {
                 port = DEFAULT_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = db.hostDao().getById(hostId)!!

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListTreeStopSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListTreeStopSessionDockerTest.kt
@@ -50,6 +50,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListTreeStopSessionDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -77,7 +78,7 @@ class FolderListTreeStopSessionDockerTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -141,6 +142,7 @@ class FolderListTreeStopSessionDockerTest {
                 port = DEFAULT_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = db.hostDao().getById(hostId)!!

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListWindowCloseAfterStopPollingDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListWindowCloseAfterStopPollingDockerTest.kt
@@ -76,6 +76,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class FolderListWindowCloseAfterStopPollingDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -106,7 +107,7 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
         ).allowMainThreadQueries().build()
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -170,6 +171,7 @@ class FolderListWindowCloseAfterStopPollingDockerTest {
                 port = DEFAULT_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         val host = db.hostDao().getById(hostId)!!

--- a/app/src/androidTest/java/com/pocketshell/app/projects/Issue1876FolderListMobileRttDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/Issue1876FolderListMobileRttDockerTest.kt
@@ -47,6 +47,7 @@ class Issue1876FolderListMobileRttDockerTest {
     private lateinit var db: AppDatabase
     private val viewModelStore = ViewModelStore()
     private val createdSessions = mutableListOf<String>()
+    private lateinit var trustedHostKeySha256: String
 
     @Before
     fun setUp(): Unit { runBlocking {
@@ -68,8 +69,11 @@ class Issue1876FolderListMobileRttDockerTest {
 
         // Hard preconditions, never self-skips: both the direct seed route and
         // shaped app route must be alive or this gated journey fails.
+        // The seeded HostEntity below targets MOBILE_PORT (the throttled
+        // clone the app actually connects through), so only its probe's
+        // fingerprint is threaded onto the fixture (issue #2446).
         waitForSshFixtureReady(sshKey, port = DEFAULT_PORT)
-        waitForSshFixtureReady(sshKey, port = MOBILE_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = MOBILE_PORT)
     } }
 
     @After
@@ -142,6 +146,7 @@ class Issue1876FolderListMobileRttDockerTest {
                 port = MOBILE_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         roots.forEachIndexed { index, path ->

--- a/app/src/androidTest/java/com/pocketshell/app/projects/Issue1973AgentLaunchStateFolderIsolationDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/Issue1973AgentLaunchStateFolderIsolationDockerTest.kt
@@ -42,6 +42,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class Issue1973AgentLaunchStateFolderIsolationDockerTest {
+    private lateinit var trustedHostKeySha256: String
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
     private val liveSessions = linkedSetOf<String>()
@@ -59,7 +60,7 @@ class Issue1973AgentLaunchStateFolderIsolationDockerTest {
             FileOutputStream(this).use { it.write(keyText.toByteArray()) }
             setReadable(true, true)
         }
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -416,6 +417,7 @@ class Issue1973AgentLaunchStateFolderIsolationDockerTest {
         port = DEFAULT_PORT,
         username = DEFAULT_USER,
         keyId = 1L,
+        trustedHostKeySha256 = trustedHostKeySha256,
     )
 
     private fun shellQuote(value: String): String =

--- a/app/src/androidTest/java/com/pocketshell/app/projects/ManualKindWriterDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/ManualKindWriterDockerTest.kt
@@ -47,6 +47,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ManualKindWriterDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -69,7 +70,7 @@ class ManualKindWriterDockerTest {
     @Test
     fun foreignSessionStartsUnknownThenManualPickAndChangeAreDurable(): Unit { runBlocking {
         bootstrapKey()
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
 
         val suffix = System.currentTimeMillis().toString().takeLast(8)
         val session = "issue821-manual-$suffix"
@@ -107,6 +108,7 @@ class ManualKindWriterDockerTest {
             port = DEFAULT_PORT,
             username = DEFAULT_USER,
             keyId = 1L,
+            trustedHostKeySha256 = trustedHostKeySha256,
         )
 
         // (1) Foreign session reads back with NO recorded kind — the Unknown

--- a/app/src/androidTest/java/com/pocketshell/app/projects/ProfileChipRelaunchDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/ProfileChipRelaunchDockerTest.kt
@@ -53,6 +53,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ProfileChipRelaunchDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -74,7 +75,7 @@ class ProfileChipRelaunchDockerTest {
     @Test
     fun zaiSessionRelaunchedAsDefaultClaudeDropsTheStaleProfileChip(): Unit { runBlocking {
         bootstrapKey()
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
 
         val suffix = System.currentTimeMillis().toString().takeLast(8)
         val session = "issue889-git-pocketshell-$suffix"
@@ -91,6 +92,7 @@ class ProfileChipRelaunchDockerTest {
             port = DEFAULT_PORT,
             username = DEFAULT_USER,
             keyId = 1L,
+            trustedHostKeySha256 = trustedHostKeySha256,
         )
         val tree = HostTreeModel()
         tree.bindHost(host.id)

--- a/app/src/androidTest/java/com/pocketshell/app/projects/ProfileDiscoveryPickerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/ProfileDiscoveryPickerDockerTest.kt
@@ -57,6 +57,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ProfileDiscoveryPickerDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
@@ -73,7 +74,7 @@ class ProfileDiscoveryPickerDockerTest {
             FileOutputStream(this).use { it.write(keyText.toByteArray()) }
             setReadable(true, true)
         }
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @Test
@@ -87,6 +88,7 @@ class ProfileDiscoveryPickerDockerTest {
             port = DEFAULT_PORT,
             username = DEFAULT_USER,
             keyId = 1L,
+            trustedHostKeySha256 = trustedHostKeySha256,
         )
 
         // --- 1 + 2: REAL host discovery (must NOT false-green) ---

--- a/app/src/androidTest/java/com/pocketshell/app/projects/SiblingSuffixExactTargetDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/SiblingSuffixExactTargetDockerTest.kt
@@ -106,19 +106,27 @@ class SiblingSuffixExactTargetDockerTest {
     private lateinit var sshKey: SshKey.Pem
     private lateinit var keyFile: File
     private val createdSessions = mutableListOf<String>()
+    private lateinit var trustedHostKeySha256: String
 
     private val gateway = SshFolderListGateway()
 
     private val clientScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    private val host = HostEntity(
-        id = 1L,
-        name = "issue1820-sibling-suffix",
-        hostname = DEFAULT_HOST,
-        port = DEFAULT_PORT,
-        username = DEFAULT_USER,
-        keyId = 1L,
-    )
+    // Issue #2446: was an eagerly-initialized `val`, constructed before
+    // `trustedHostKeySha256` is known (property initializers run before
+    // `@Before`) — a computed property so every access (all from `@Test`
+    // methods, after `setUp()` captured the real presented fingerprint)
+    // rebuilds it with the current trust binding.
+    private val host: HostEntity
+        get() = HostEntity(
+            id = 1L,
+            name = "issue1820-sibling-suffix",
+            hostname = DEFAULT_HOST,
+            port = DEFAULT_PORT,
+            username = DEFAULT_USER,
+            keyId = 1L,
+            trustedHostKeySha256 = trustedHostKeySha256,
+        )
 
     @Before
     fun setUp() { runBlocking {
@@ -138,7 +146,7 @@ class SiblingSuffixExactTargetDockerTest {
             FileOutputStream(this).use { it.write(keyText.toByteArray()) }
             setReadable(true, true)
         }
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentAltScreenPartialBlackHealJourneyE2eTest.kt
@@ -85,6 +85,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class AgentAltScreenPartialBlackHealJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788/#848: `createAndroidComposeRule<MainActivity>()` (NOT
     // `createEmptyComposeRule()` + a hand-rolled `ActivityScenario.launch`) so the
@@ -126,7 +127,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
         BackgroundGraceTestOverride.setForTest(null)
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedAltScreenSession(key)
         hostRowTag = seedDockerHost(key)
     }
@@ -880,6 +881,7 @@ class AgentAltScreenPartialBlackHealJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AgentSubmitAckJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AgentSubmitAckJourneyE2eTest.kt
@@ -83,6 +83,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class AgentSubmitAckJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -119,7 +120,7 @@ class AgentSubmitAckJourneyE2eTest {
                 runBlocking {
                     val key = readFixtureKey()
                     seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
+                    trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
                     seedFakeAgentSession(key)
                     seededHostRowTag = seedDockerHost(key)
                 }
@@ -629,6 +630,7 @@ class AgentSubmitAckJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentDropReconnectRecoversE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/AttachmentDropReconnectRecoversE2eTest.kt
@@ -94,6 +94,7 @@ import com.pocketshell.app.proof.signals.readAuthoritativeTmuxSessionIdentity
  */
 @RunWith(AndroidJUnit4::class)
 class AttachmentDropReconnectRecoversE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788/#848: createAndroidComposeRule<MainActivity>() + the shared
     // SeedBeforeLaunchRule own the harness — the durable launch-owned shape the CI
@@ -133,7 +134,7 @@ class AttachmentDropReconnectRecoversE2eTest {
         clearLastSessionPrefs()
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
         seededHostRowTag = seedDockerHost(key)
     }
@@ -748,6 +749,7 @@ class AttachmentDropReconnectRecoversE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackThenOpenSecondSessionReusesWarmLeaseE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackThenOpenSecondSessionReusesWarmLeaseE2eTest.kt
@@ -108,6 +108,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class BackThenOpenSecondSessionReusesWarmLeaseE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788: createAndroidComposeRule<MainActivity>() so the Compose test
     // clock drives the SAME foreground activity the Termux TerminalView interop
@@ -156,7 +157,7 @@ class BackThenOpenSecondSessionReusesWarmLeaseE2eTest {
         SshFolderListGateway.forcedStaleChannelSymptoms.set(0)
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSessions(key)
         // Seed a watched root so the picker discovery poll ALWAYS runs the
         // SSH-lease path (the watched-root expansion), which is the lease the
@@ -409,6 +410,7 @@ class BackThenOpenSecondSessionReusesWarmLeaseE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             // One watched root so the picker's discovery poll ALWAYS runs the

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundGraceReconnectE2eTest.kt
@@ -67,6 +67,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class BackgroundGraceReconnectE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788: createAndroidComposeRule<MainActivity>() so the Compose test
     // clock drives the SAME foreground activity the Termux TerminalView interop
@@ -131,7 +132,7 @@ class BackgroundGraceReconnectE2eTest {
         BackgroundGraceTestOverride.setForTest(null)
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
         hostRowTag = seedDockerHost(key)
     }
@@ -1372,6 +1373,7 @@ class BackgroundGraceReconnectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundResumeSocketDeathE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BackgroundResumeSocketDeathE2eTest.kt
@@ -117,6 +117,7 @@ import com.pocketshell.app.proof.signals.readAuthoritativeTmuxSessionIdentity
  */
 @RunWith(AndroidJUnit4::class)
 class BackgroundResumeSocketDeathE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // The #173 reproduction needs MANUAL ActivityScenario lifecycle control (moveToState
     // STARTED -> kill -> RESUMED) to drive the pause-only socket-death sequence;
@@ -155,7 +156,7 @@ class BackgroundResumeSocketDeathE2eTest {
     @Test
     fun socketDeathDuringPauseDoesNotCrashOnResume() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         // Seed the tmux session before the app attaches so the picker has
         // it ready and the test is hermetic against earlier runs.
@@ -435,6 +436,7 @@ class BackgroundResumeSocketDeathE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BareNetworkLossRestoreReconnectE2eTest.kt
@@ -102,6 +102,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class BareNetworkLossRestoreReconnectE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -123,7 +124,7 @@ class BareNetworkLossRestoreReconnectE2eTest {
                 runBlocking {
                     val key = readFixtureKey()
                     seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
+                    trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
                     seedTmuxSession(key)
                     seededHostRowTag = seedDockerHost(key)
                 }
@@ -735,6 +736,7 @@ class BareNetworkLossRestoreReconnectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/BoundedGraceSessionHoldJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/BoundedGraceSessionHoldJourneyE2eTest.kt
@@ -93,6 +93,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class BoundedGraceSessionHoldJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -249,7 +250,7 @@ class BoundedGraceSessionHoldJourneyE2eTest {
         clearBackgroundGraceSetting()
         BackgroundGraceTestOverride.setForTest(WITHIN_GRACE_MS)
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedTmuxSession(fixtureKey)
         hostRowTag = seedDockerHost(fixtureKey)
     }
@@ -670,6 +671,7 @@ class BoundedGraceSessionHoldJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/CleanOutageReattachResilienceE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/CleanOutageReattachResilienceE2eTest.kt
@@ -81,6 +81,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class CleanOutageReattachResilienceE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -102,7 +103,7 @@ class CleanOutageReattachResilienceE2eTest {
                 runBlocking {
                     val key = readFixtureKey()
                     seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
+                    trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
                     seedTmuxSession(key)
                     seededHostRowTag = seedDockerHost(key)
                 }
@@ -479,6 +480,7 @@ class CleanOutageReattachResilienceE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/CodexOverflowNoReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/CodexOverflowNoReconnectE2eTest.kt
@@ -64,6 +64,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class CodexOverflowNoReconnectE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -97,7 +98,7 @@ class CodexOverflowNoReconnectE2eTest {
     fun codexStyleTerminalFloodWithComposerSendKeysDoesNotShowReconnect() { runBlocking<Unit> {
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         seedCodexOverflowSession(key)
         val hostRowTag = seedDockerHost(key, "Issue576 Codex Overflow")
@@ -469,6 +470,7 @@ class CodexOverflowNoReconnectE2eTest {
                     pocketshellVersionCompatible = true,
                     pocketshellDaemonRunning = true,
                     pocketshellDaemonEnabled = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ColdRestoreGoneSessionNoResurrectE2eTest.kt
@@ -109,6 +109,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ColdRestoreGoneSessionNoResurrectE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788: createAndroidComposeRule<MainActivity>() so the Compose test
     // clock drives the SAME foreground activity the Termux TerminalView interop
@@ -165,7 +166,7 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
     private suspend fun seedBeforeLaunch() {
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         // The prompt is process-scoped by design. Reset it before each seeded
         // launch so a failed preceding journey cannot cover the next test's
         // cold-restore/create path with an old host/session prompt.
@@ -2051,6 +2052,7 @@ class ColdRestoreGoneSessionNoResurrectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ComposerAlwaysPresentSwitchJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ComposerAlwaysPresentSwitchJourneyE2eTest.kt
@@ -92,6 +92,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ComposerAlwaysPresentSwitchJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -120,7 +121,7 @@ class ComposerAlwaysPresentSwitchJourneyE2eTest {
     @Test
     fun composerLauncherPresentAndContainedAfterEverySwitchAcrossAgentAndShell() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         // Seed: A = agent-detected (claude in /workspace/pocketshell), B + C =
         // plain shells. So the journey exercises the composer presence in BOTH
@@ -295,6 +296,7 @@ class ComposerAlwaysPresentSwitchJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/DeepLinkSessionSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/DeepLinkSessionSwitchE2eTest.kt
@@ -75,6 +75,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class DeepLinkSessionSwitchE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -97,7 +98,7 @@ class DeepLinkSessionSwitchE2eTest {
     @Test
     fun deepLinkAttachShowsCorrectSessionContentWithoutPickerAndSwitchesCleanly() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSessions(key)
 
         val seeded = seedDockerHost(key, "Issue470 DeepLink")
@@ -228,6 +229,7 @@ class DeepLinkSessionSwitchE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             SeededHost(

--- a/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorDockerSshSmokeTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorDockerSshSmokeTest.kt
@@ -74,6 +74,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class EmulatorDockerSshSmokeTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createEmptyComposeRule()
 
@@ -102,7 +103,7 @@ class EmulatorDockerSshSmokeTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         withTimeout(20_000) {
             val connection = SshConnection.connect(
@@ -259,7 +260,7 @@ class EmulatorDockerSshSmokeTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         val marker = "pswalkthrough${System.currentTimeMillis()}"
         val tmpDir = "/tmp/pocketshell-$marker"
         val sessionName = "pocketshell-$marker"
@@ -301,6 +302,7 @@ class EmulatorDockerSshSmokeTest {
                     // UsageScheduler emit no host-list banners/strip in
                     // this tmux-only walkthrough.
                     usageCommandOverride = "printf ''",
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorWorkflowE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/EmulatorWorkflowE2eTest.kt
@@ -55,6 +55,7 @@ import java.util.Locale
  */
 @RunWith(AndroidJUnit4::class)
 class EmulatorWorkflowE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -113,7 +114,7 @@ class EmulatorWorkflowE2eTest {
         // assertion tolerates the soft wrap — and only the soft wrap. A missing
         // byte still fails, which is exactly how #1845 was caught.
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         val marker = "t${System.currentTimeMillis().toString(36).takeLast(5)}"
         val sessionName = "claude-main"
         val hostRowTag = seedDockerHost(key, "Workflow Tmux Docker $marker")
@@ -187,6 +188,7 @@ class EmulatorWorkflowE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/FastResumeReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/FastResumeReconnectE2eTest.kt
@@ -101,6 +101,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class FastResumeReconnectE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -139,7 +140,7 @@ class FastResumeReconnectE2eTest {
     @Test
     fun resumeAfterBackgroundRestoresCachedViewFastThenReconnects() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
 
         val hostRowTag = seedDockerHost(key)
@@ -288,6 +289,7 @@ class FastResumeReconnectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/IdleClaudeFragmentsOverBlackRecoveryJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/IdleClaudeFragmentsOverBlackRecoveryJourneyE2eTest.kt
@@ -109,6 +109,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class IdleClaudeFragmentsOverBlackRecoveryJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -539,7 +540,7 @@ class IdleClaudeFragmentsOverBlackRecoveryJourneyE2eTest {
         val key = readFixtureKey()
         seededKey = key
         try {
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedTmuxSessions(key)
             seededHostRowTag = seedDockerHost(key)
         } catch (t: Throwable) {
@@ -570,6 +571,7 @@ class IdleClaudeFragmentsOverBlackRecoveryJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1078DeadSocketHandoffRedialJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1078DeadSocketHandoffRedialJourneyE2eTest.kt
@@ -120,6 +120,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class Issue1078DeadSocketHandoffRedialJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788/#848: createAndroidComposeRule<MainActivity>() + the shared
     // SeedBeforeLaunchRule own the harness — the durable launch-owned shape the CI
@@ -143,7 +144,7 @@ class Issue1078DeadSocketHandoffRedialJourneyE2eTest {
         clearLastSessionPrefs()
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
         seededHostRowTag = seedDockerHost(key)
     }
@@ -551,6 +552,7 @@ class Issue1078DeadSocketHandoffRedialJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest.kt
@@ -108,6 +108,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -383,7 +384,7 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
         val key = readFixtureKey()
         seededKey = key
         try {
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedTwoSessions(key)
             seededHostRowTag = seedDockerHost(key)
             forceFlatHostDetailViewMode()
@@ -419,6 +420,7 @@ class Issue1206PrewarmEmptyCaptureSeedRetryJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1831BackFromRestoredSessionJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1831BackFromRestoredSessionJourneyE2eTest.kt
@@ -94,6 +94,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class Issue1831BackFromRestoredSessionJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788: createAndroidComposeRule<MainActivity>() so the Compose test
     // clock drives the SAME foreground activity the Termux TerminalView interop
@@ -127,7 +128,7 @@ class Issue1831BackFromRestoredSessionJourneyE2eTest {
     private suspend fun seedBeforeLaunch() {
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         clearLastSessionPrefs()
         seedTmuxSession(key)
         hostRowTag = seedDockerHost(key)
@@ -365,6 +366,7 @@ class Issue1831BackFromRestoredSessionJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1845TypedSemicolonReachesPaneDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1845TypedSemicolonReachesPaneDockerTest.kt
@@ -78,6 +78,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class Issue1845TypedSemicolonReachesPaneDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788 harness: the compose rule owns MainActivity's launch, and the
     // remote tmux session + DB host row are seeded BEFORE that launch.
@@ -283,7 +284,7 @@ class Issue1845TypedSemicolonReachesPaneDockerTest {
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         marker = "m${System.currentTimeMillis().toString(36).takeLast(5)}"
         clearLastSessionPrefs()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
 
         val setup = SshConnection.connect(
             host = DEFAULT_HOST,
@@ -328,6 +329,7 @@ class Issue1845TypedSemicolonReachesPaneDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue1854TypedNewlineCommitReachesPaneDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue1854TypedNewlineCommitReachesPaneDockerTest.kt
@@ -111,6 +111,7 @@ import java.io.File
 // and `Issue1854PasteFramingSourceGuardTest`, all in the required Unit job.
 @RunWith(AndroidJUnit4::class)
 class Issue1854TypedNewlineCommitReachesPaneDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788 harness: the compose rule owns MainActivity's launch, and the
     // remote tmux session + DB host row are seeded BEFORE that launch.
@@ -319,7 +320,7 @@ class Issue1854TypedNewlineCommitReachesPaneDockerTest {
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         marker = "m${System.currentTimeMillis().toString(36).takeLast(5)}"
         clearLastSessionPrefs()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
 
         val setup = SshConnection.connect(
             host = DEFAULT_HOST,
@@ -367,6 +368,7 @@ class Issue1854TypedNewlineCommitReachesPaneDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2124HostAckDeliveryJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2124HostAckDeliveryJourneyE2eTest.kt
@@ -114,6 +114,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class Issue2124HostAckDeliveryJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -156,7 +157,7 @@ class Issue2124HostAckDeliveryJourneyE2eTest {
         // cache namespace; the journey still exercises the real host/port path.
         fixtureHostName = "$HOST_NAME_PREFIX ${testName.methodName} ${System.currentTimeMillis()}"
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey), port = seededPort)
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey), port = seededPort)
         seedFramedFakeAgentSession(fixtureKey, seededPort)
         hostRowTag = seedDockerHost(fixtureKey, seededPort)
     }
@@ -785,6 +786,7 @@ class Issue2124HostAckDeliveryJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2178TypedEchoSurvivesReseedE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2178TypedEchoSurvivesReseedE2eTest.kt
@@ -116,6 +116,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class Issue2178TypedEchoSurvivesReseedE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788/#848: launch-owned rule so the Compose clock and the real
     // TerminalView interop child share one MainActivity, with the Docker tmux
@@ -133,7 +134,7 @@ class Issue2178TypedEchoSurvivesReseedE2eTest {
 
     private suspend fun seedBeforeLaunch() {
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedTmuxSessions(fixtureKey)
         hostRowTag = seedDockerHost(fixtureKey, "Issue2178 Reseed")
         forceFlatHostDetailViewMode()
@@ -420,6 +421,7 @@ class Issue2178TypedEchoSurvivesReseedE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2189HostAckExactlyOnceAcrossFlapE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2189HostAckExactlyOnceAcrossFlapE2eTest.kt
@@ -66,6 +66,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class Issue2189HostAckExactlyOnceAcrossFlapE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -87,7 +88,7 @@ class Issue2189HostAckExactlyOnceAcrossFlapE2eTest {
             AppSettings.DEFAULT_OUTBOUND_DELIVERY_AUTHORITY,
         )
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedFakeAgentSession(fixtureKey)
         hostRowTag = seedDockerHost(fixtureKey)
     }
@@ -427,6 +428,7 @@ class Issue2189HostAckExactlyOnceAcrossFlapE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2189HostAckSendHealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2189HostAckSendHealJourneyE2eTest.kt
@@ -64,6 +64,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class Issue2189HostAckSendHealJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -86,7 +87,7 @@ class Issue2189HostAckSendHealJourneyE2eTest {
         BackgroundGraceTestOverride.setForTest(null)
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedFullFrameSession(key)
         hostRowTag = seedDockerHost(key)
     }
@@ -557,6 +558,7 @@ class Issue2189HostAckSendHealJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2189HostAckSubmitJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2189HostAckSubmitJourneyE2eTest.kt
@@ -58,6 +58,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class Issue2189HostAckSubmitJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -81,7 +82,7 @@ class Issue2189HostAckSubmitJourneyE2eTest {
             AppSettings.DEFAULT_OUTBOUND_DELIVERY_AUTHORITY,
         )
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedFakeAgentSession(fixtureKey)
         hostRowTag = seedDockerHost(fixtureKey)
     }
@@ -448,6 +449,7 @@ class Issue2189HostAckSubmitJourneyE2eTest {
                     pocketshellVersionCompatible = true,
                     pocketshellDaemonRunning = true,
                     pocketshellDaemonEnabled = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2192ComposerLauncherAfterReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2192ComposerLauncherAfterReconnectE2eTest.kt
@@ -77,6 +77,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class Issue2192ComposerLauncherAfterReconnectE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -97,7 +98,7 @@ class Issue2192ComposerLauncherAfterReconnectE2eTest {
 
     private suspend fun seedBeforeLaunch() {
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         baselineSshdPids = listSshdPidsForTestuser(fixtureKey)
         seedTmuxSessions(fixtureKey)
         hostRowTag = seedDockerHost(fixtureKey, "Issue2192 Launcher")
@@ -563,6 +564,7 @@ class Issue2192ComposerLauncherAfterReconnectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/Issue2338SecondLaunchTerminalAttachJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/Issue2338SecondLaunchTerminalAttachJourneyE2eTest.kt
@@ -79,6 +79,7 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class Issue2338SecondLaunchTerminalAttachJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788/#848: launch-owned `createAndroidComposeRule<MainActivity>()` with
     // seed-before-launch via the RuleChain — NOT `createEmptyComposeRule()` + a hand-rolled
@@ -99,7 +100,7 @@ class Issue2338SecondLaunchTerminalAttachJourneyE2eTest {
         TmuxSessionLatencyTelemetry.resetForTest()
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedShellSession(key)
         hostRowTag = seedDockerHost(key)
     }
@@ -249,6 +250,7 @@ class Issue2338SecondLaunchTerminalAttachJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/LastSessionProcessRestartProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/LastSessionProcessRestartProofTest.kt
@@ -224,7 +224,15 @@ class LastSessionProcessRestartProofTest {
             .bufferedReader()
             .use { it.readText() }
         val sshKey = SshKey.Pem(keyText)
-        waitForSshFixtureReady(sshKey, port = PRODUCER_PORT)
+        // Issue #2446: `listProductionNavigationTarget` below feeds this
+        // `fixture.host` through `SshHostTmuxSessionsGateway.listSessions`,
+        // the real production trust-checked path — capture the presented
+        // fingerprint. (Phase 2's `readPhaseOneArtifact` reconstructs its OWN
+        // `HostEntity` from the artifact file, but that copy only ever
+        // reaches the raw `connectToFixture`/`TEST_ACCEPT_ALL_HOST_KEYS`
+        // cleanup helper, never a trust-checked production path, so it needs
+        // no fingerprint.)
+        val trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = PRODUCER_PORT)
 
         val keyFile = File(context.cacheDir, "issue2264-$namespace-key").apply {
             parentFile?.mkdirs()
@@ -239,6 +247,7 @@ class LastSessionProcessRestartProofTest {
                 port = PRODUCER_PORT,
                 username = DEFAULT_USER,
                 keyId = PRODUCER_KEY_ID,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
             keyPath = keyFile.absolutePath,
             sessionName = "issue2264-$namespace",

--- a/app/src/androidTest/java/com/pocketshell/app/proof/LaunchNoMainThreadRoomReadE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/LaunchNoMainThreadRoomReadE2eTest.kt
@@ -13,6 +13,7 @@ import com.pocketshell.app.diagnostics.StrictModeInstaller
 import com.pocketshell.app.hosts.SshKeyStorage
 import com.pocketshell.app.projects.FOLDER_LIST_SCREEN_TAG
 import com.pocketshell.app.testaccess.TestAccessEntryPoint
+import com.pocketshell.core.ssh.SshKey
 import com.pocketshell.core.storage.entity.HostEntity
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.runBlocking
@@ -199,6 +200,12 @@ class LaunchNoMainThreadRoomReadE2eTest {
                 content = key,
             )
             keyId = storedKey.id
+            // Issue #2446: the auto-open assertion below requires a REAL
+            // successful production connect (FolderList must land, not the
+            // "Trust and connect" screen), so this seeded host needs a
+            // pre-verified fingerprint, exactly like every other real-fixture
+            // seed helper.
+            val trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             hostId = db.hostDao().insert(
                 HostEntity(
                     name = hostName,
@@ -210,6 +217,7 @@ class LaunchNoMainThreadRoomReadE2eTest {
                     pocketshellInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
                     pocketshellLastDetectedAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
         }

--- a/app/src/androidTest/java/com/pocketshell/app/proof/LongRunningSessionStabilityTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/LongRunningSessionStabilityTest.kt
@@ -138,6 +138,7 @@ import java.util.Locale
  */
 @RunWith(AndroidJUnit4::class)
 class LongRunningSessionStabilityTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -161,7 +162,7 @@ class LongRunningSessionStabilityTest {
     fun tenMinuteForegroundHoldRetainsTmuxSessionWithoutReconnectsOrMemoryGrowth() { runBlocking {
         assumeLongRunningTestEnabled()
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         // Clear logcat before the test starts so the reconnect-counter
         // parse below operates on a slice that belongs to THIS run only.
@@ -339,7 +340,7 @@ class LongRunningSessionStabilityTest {
     @Test
     fun steadyForegroundHoldDoesNotFlapTransportEveryTenSeconds() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         execShellCommand("logcat -c")
 
@@ -442,6 +443,7 @@ class LongRunningSessionStabilityTest {
                     pocketshellCliVersion = appVersion,
                     pocketshellExpectedCliVersion = appVersion,
                     pocketshellVersionCompatible = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MobileSpuriousReconnectE2eTest.kt
@@ -83,6 +83,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class MobileSpuriousReconnectE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788/#848: createAndroidComposeRule<MainActivity>() + the shared
     // SeedBeforeLaunchRule own the harness — the durable launch-owned shape the
@@ -113,7 +114,7 @@ class MobileSpuriousReconnectE2eTest {
         clearLastSessionPrefs()
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
         seededHostRowTag = seedDockerHost(key)
     }
@@ -883,6 +884,7 @@ class MobileSpuriousReconnectE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MostlyEmptyModelHealsAtRevealJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MostlyEmptyModelHealsAtRevealJourneyE2eTest.kt
@@ -88,6 +88,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class MostlyEmptyModelHealsAtRevealJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -401,7 +402,7 @@ class MostlyEmptyModelHealsAtRevealJourneyE2eTest {
         val key = readFixtureKey()
         seededKey = key
         try {
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedTmuxSession(key)
             seededHostRowTag = seedDockerHost(key)
         } catch (t: Throwable) {
@@ -432,6 +433,7 @@ class MostlyEmptyModelHealsAtRevealJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MultiHostSessionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MultiHostSessionE2eTest.kt
@@ -169,8 +169,8 @@ class MultiHostSessionE2eTest {
         val key = readFixtureKey()
         fixtureKey = key
         val pem = SshKey.Pem(key)
-        waitForSshFixtureReady(pem, port = AGENTS_PORT)
-        waitForSshFixtureReady(pem, port = TMUX_PORT)
+        val trustedHostKeyShaA = waitForSshFixtureReady(pem, port = AGENTS_PORT)
+        val trustedHostKeyShaB = waitForSshFixtureReady(pem, port = TMUX_PORT)
 
         val suffix = System.currentTimeMillis().toString().takeLast(6)
         sessionA = "issue147-a-$suffix"
@@ -180,7 +180,7 @@ class MultiHostSessionE2eTest {
         baselineHostA = sshdProcessCount(key, AGENTS_PORT)
         baselineHostB = sshdProcessCount(key, TMUX_PORT)
         Log.i(LOG_TAG, "sshd baseline: hostA=$baselineHostA hostB=$baselineHostB")
-        seededHosts = seedDockerHosts(key)
+        seededHosts = seedDockerHosts(key, trustedHostKeyShaA, trustedHostKeyShaB)
     }
 
     private fun readFixtureKey(): String =
@@ -191,7 +191,11 @@ class MultiHostSessionE2eTest {
             .bufferedReader()
             .use { it.readText() }
 
-    private suspend fun seedDockerHosts(key: String): SeededHosts {
+    private suspend fun seedDockerHosts(
+        key: String,
+        trustedHostKeyShaA: String,
+        trustedHostKeyShaB: String,
+    ): SeededHosts {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -204,7 +208,7 @@ class MultiHostSessionE2eTest {
                 name = "issue147-key-${System.currentTimeMillis()}",
                 content = key,
             )
-            fun host(name: String, port: Int): HostEntity =
+            fun host(name: String, port: Int, trustedHostKeySha256: String): HostEntity =
                 HostEntity(
                     name = name,
                     hostname = DEFAULT_HOST,
@@ -219,12 +223,13 @@ class MultiHostSessionE2eTest {
                     // Keep the setup cache internally complete so HostList does
                     // not route the tmux-only host-B fixture into a setup sheet.
                     pocketshellVersionCompatible = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 )
 
             val hostAName = "Issue147 Host A"
             val hostBName = "Issue147 Host B"
-            val hostAId = db.hostDao().insert(host(hostAName, AGENTS_PORT))
-            val hostBId = db.hostDao().insert(host(hostBName, TMUX_PORT))
+            val hostAId = db.hostDao().insert(host(hostAName, AGENTS_PORT, trustedHostKeyShaA))
+            val hostBId = db.hostDao().insert(host(hostBName, TMUX_PORT, trustedHostKeyShaB))
             SeededHosts(
                 hostAName = hostAName,
                 hostBName = hostBName,

--- a/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/MultiSessionSwitchJourneyE2eTest.kt
@@ -141,6 +141,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class MultiSessionSwitchJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788: `createAndroidComposeRule<MainActivity>()` (NOT
     // `createEmptyComposeRule()` + a hand-rolled `ActivityScenario.launch`) so
@@ -216,7 +217,7 @@ class MultiSessionSwitchJourneyE2eTest {
     private suspend fun seedForCurrentTest(methodName: String) {
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         when (methodName) {
             "backToPickerThenOpenShowsSingleTargetIdentityNeverStaleProjectCrumb" -> {
                 seedTmuxSessionsInDistinctProjects(key)
@@ -1732,6 +1733,7 @@ class MultiSessionSwitchJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/NotificationTapLivePinnedForegroundReseedJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/NotificationTapLivePinnedForegroundReseedJourneyE2eTest.kt
@@ -119,6 +119,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class NotificationTapLivePinnedForegroundReseedJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -316,7 +317,7 @@ class NotificationTapLivePinnedForegroundReseedJourneyE2eTest {
         notificationManager.cancelAll()
         BackgroundGraceTestOverride.setForTest(WITHIN_GRACE_MS)
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedTmuxSession(fixtureKey, altScreen)
         hostRowTag = seedDockerHost(fixtureKey)
     }
@@ -651,6 +652,7 @@ class NotificationTapLivePinnedForegroundReseedJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             pinnedHostId = hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundAttachmentOffsetResumeJourneyE2eTest.kt
@@ -112,6 +112,7 @@ class OutboundAttachmentOffsetResumeJourneyE2eTest {
     private val resumedResultReady = CountDownLatch(1)
     private val timings = mutableListOf<String>()
     private val artifactRunId = "run-${System.currentTimeMillis()}"
+    private lateinit var trustedHostKeySha256: String
 
     private suspend fun seedBeforeLaunch() {
         val context = targetContext()
@@ -132,7 +133,10 @@ class OutboundAttachmentOffsetResumeJourneyE2eTest {
         waitForSshFixtureReady(SshKey.Pem(fixtureKey), port = DIRECT_AGENTS_SSH_PORT)
         proxy = ToxiproxyControl(baseUrl = "http://$DEFAULT_HOST:$TOXIPROXY_API_PORT")
         proxy.reset()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey), port = NETWORK_FAULT_SSH_PORT)
+        // The seeded HostEntity (seedDockerHost, below) targets
+        // NETWORK_FAULT_SSH_PORT (the Toxiproxy front), so its probe is the
+        // one whose fingerprint gets threaded onto the fixture (#2446).
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey), port = NETWORK_FAULT_SSH_PORT)
         val identity = seedFakeAgentSession(fixtureKey)
         val hostId = seedDockerHost(fixtureKey)
         hostRowTag = HOST_ROW_TAG_PREFIX + hostId
@@ -1258,6 +1262,7 @@ class OutboundAttachmentOffsetResumeJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
         } finally {

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceAcrossFlapE2eTest.kt
@@ -116,9 +116,9 @@ class OutboundExactlyOnceAcrossFlapE2eTest {
         )
         val key = OutboundExactlyOnceFixture.readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        val trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         OutboundExactlyOnceFixture.seedFakeAgentSession(key, testName.methodName)
-        hostRowTag = OutboundExactlyOnceFixture.seedDockerHost(key)
+        hostRowTag = OutboundExactlyOnceFixture.seedDockerHost(key, trustedHostKeySha256)
     }
 
     @Before

--- a/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceFixture.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/OutboundExactlyOnceFixture.kt
@@ -60,7 +60,7 @@ internal object OutboundExactlyOnceFixture {
             .bufferedReader()
             .use { it.readText() }
 
-    suspend fun seedDockerHost(key: String): String {
+    suspend fun seedDockerHost(key: String, trustedHostKeySha256: String): String {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val db = Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
             .fallbackToDestructiveMigration(dropAllTables = true)
@@ -82,6 +82,7 @@ internal object OutboundExactlyOnceFixture {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/PaneOutputOverflowRecoveryJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/PaneOutputOverflowRecoveryJourneyE2eTest.kt
@@ -107,6 +107,7 @@ import com.pocketshell.app.proof.signals.readAuthoritativeTmuxSessionIdentity
  */
 @RunWith(AndroidJUnit4::class)
 class PaneOutputOverflowRecoveryJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788/#848: launch-owned `createAndroidComposeRule<MainActivity>()` (NOT
     // `createEmptyComposeRule()` + a hand-rolled `ActivityScenario.launch`) so the Compose test
@@ -137,7 +138,7 @@ class PaneOutputOverflowRecoveryJourneyE2eTest {
         TmuxSessionLatencyTelemetry.resetForTest()
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedBannerSession(key)
         hostRowTag = seedDockerHost(key)
     }
@@ -733,6 +734,7 @@ class PaneOutputOverflowRecoveryJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/PreExistingMultiWindowSeedE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/PreExistingMultiWindowSeedE2eTest.kt
@@ -80,6 +80,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class PreExistingMultiWindowSeedE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -222,7 +223,7 @@ class PreExistingMultiWindowSeedE2eTest {
         val key = readFixtureKey()
         seededKey = key
         try {
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
             // Seed a fresh session with TWO windows, each with a distinct marker
             // printed once and then left idle. The idle shells emit no further
@@ -258,6 +259,7 @@ class PreExistingMultiWindowSeedE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ProjectSwitcherDropdownE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ProjectSwitcherDropdownE2eTest.kt
@@ -71,6 +71,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class ProjectSwitcherDropdownE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -94,7 +95,7 @@ class ProjectSwitcherDropdownE2eTest {
     @Test
     fun projectCrumbDropdownWarmSwitchesToSiblingSession() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         seedTmuxSessions(key)
         val hostRowTag = seedDockerHost(key, "Issue463 Project Switcher")
@@ -264,6 +265,7 @@ class ProjectSwitcherDropdownE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RealAgentReleaseGateTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RealAgentReleaseGateTest.kt
@@ -78,6 +78,7 @@ import java.util.Locale
  */
 @RunWith(AndroidJUnit4::class)
 class RealAgentReleaseGateTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -145,7 +146,7 @@ class RealAgentReleaseGateTest {
     fun realClaudeCliRunsInTmuxPaneAndProducesJsonlConversationLog() { runBlocking {
         assumeReleaseGateEnabled()
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key), port = REAL_AGENT_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key), port = REAL_AGENT_PORT)
 
         val marker = shortMarker()
         val workDir = "/tmp/ps-real-c-$marker"
@@ -200,7 +201,7 @@ class RealAgentReleaseGateTest {
     fun realCodexCliRunsInTmuxPaneAndProducesJsonlRolloutLog() { runBlocking {
         assumeReleaseGateEnabled()
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key), port = REAL_AGENT_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key), port = REAL_AGENT_PORT)
 
         val marker = shortMarker()
         val workDir = "/tmp/ps-real-x-$marker"
@@ -272,7 +273,7 @@ class RealAgentReleaseGateTest {
     fun collapsedPasteChipFormatMatchesShippedClaudeBinaryAndProductionRecogniser() { runBlocking {
         assumeReleaseGateEnabled()
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key), port = REAL_AGENT_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key), port = REAL_AGENT_PORT)
 
         val templates = extractRealClaudePasteChipTemplates(key)
         assertTrue(
@@ -404,6 +405,7 @@ class RealAgentReleaseGateTest {
                     pocketshellVersionCompatible = true,
                     pocketshellDaemonRunning = true,
                     pocketshellDaemonEnabled = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectKebabInPlaceJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectKebabInPlaceJourneyE2eTest.kt
@@ -132,6 +132,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class ReconnectKebabInPlaceJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -153,7 +154,7 @@ class ReconnectKebabInPlaceJourneyE2eTest {
                 runBlocking {
                     val key = readFixtureKey()
                     seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
+                    trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
                     seedTmuxSession(key)
                     seededHostRowTag = seedDockerHost(key)
                 }
@@ -710,6 +711,7 @@ class ReconnectKebabInPlaceJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectPartialBlankReseedJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectPartialBlankReseedJourneyE2eTest.kt
@@ -142,6 +142,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class ReconnectPartialBlankReseedJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -170,7 +171,7 @@ class ReconnectPartialBlankReseedJourneyE2eTest {
     fun withinGraceReattachRestoresFullViewportNotJustTheLiveLine() { runBlocking {
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
 
         val hostRowTag = seedDockerHost(key)
@@ -301,7 +302,7 @@ class ReconnectPartialBlankReseedJourneyE2eTest {
     private suspend fun runBeyondGraceFullyRepaintsJourney(altScreen: Boolean, namePrefix: String) {
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedBeyondGraceTmuxSession(key, altScreen)
 
         val hostRowTag = seedDockerHost(key)
@@ -713,6 +714,7 @@ class ReconnectPartialBlankReseedJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectRepaintE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectRepaintE2eTest.kt
@@ -85,6 +85,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class ReconnectRepaintE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788: createAndroidComposeRule<MainActivity>() (not
     // createEmptyComposeRule + hand-rolled ActivityScenario.launch) fixes the
@@ -130,7 +131,7 @@ class ReconnectRepaintE2eTest {
     private suspend fun seedBeforeLaunch() {
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         baselineSshdPids = listSshdPidsForTestuser(key)
         seedAltScreenSession(key)
         hostRowTag = seedDockerHost(key)
@@ -246,6 +247,7 @@ class ReconnectRepaintE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectStormLivelockE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ReconnectStormLivelockE2eTest.kt
@@ -144,6 +144,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class ReconnectStormLivelockE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -174,7 +175,7 @@ class ReconnectStormLivelockE2eTest {
     private suspend fun seedRemoteAndDb() {
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
         seededHostRowTag = seedDockerHost(key)
     }
@@ -881,6 +882,7 @@ class ReconnectStormLivelockE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RedrawFullViewportReseedJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RedrawFullViewportReseedJourneyE2eTest.kt
@@ -104,6 +104,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class RedrawFullViewportReseedJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -151,7 +152,7 @@ class RedrawFullViewportReseedJourneyE2eTest {
     private suspend fun runRedrawJourney(altScreen: Boolean, namePrefix: String) {
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key, altScreen)
 
         val hostRowTag = seedDockerHost(key)
@@ -629,6 +630,7 @@ class RedrawFullViewportReseedJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/RedrawNonDestructiveNearBlankCaptureE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/RedrawNonDestructiveNearBlankCaptureE2eTest.kt
@@ -78,6 +78,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class RedrawNonDestructiveNearBlankCaptureE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -105,7 +106,7 @@ class RedrawNonDestructiveNearBlankCaptureE2eTest {
     fun redrawKeepsRichContentWhenRemoteCaptureIsNearBlank(): Unit { runBlocking {
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedIdleNearBlankSession(key)
 
         val hostRowTag = seedDockerHost(key)
@@ -415,6 +416,7 @@ class RedrawNonDestructiveNearBlankCaptureE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SendWithAttachmentStaysVisibleE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SendWithAttachmentStaysVisibleE2eTest.kt
@@ -100,6 +100,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class SendWithAttachmentStaysVisibleE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Launch-owned MainActivity rule (#788/#848): the Compose test clock drives the SAME
     // foreground MainActivity the Termux TerminalView interop child is placed into.
@@ -137,7 +138,7 @@ class SendWithAttachmentStaysVisibleE2eTest {
         BackgroundGraceTestOverride.setForTest(null)
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedFullFrameSession(key)
         hostRowTag = seedDockerHost(key)
     }
@@ -792,6 +793,7 @@ class SendWithAttachmentStaysVisibleE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/ServerDeathReconnectNoResurrectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/ServerDeathReconnectNoResurrectE2eTest.kt
@@ -84,6 +84,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class ServerDeathReconnectNoResurrectE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -121,7 +122,7 @@ class ServerDeathReconnectNoResurrectE2eTest {
         BackgroundGraceTestOverride.setForTest(null)
         val key = readFixtureKey()
         fixtureKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         // Seed TWO sessions so the multi-session class (every session vanishes on
         // server-death) is exercised, then confirm the server is alive.
         seedTmuxSessions(key)
@@ -317,6 +318,7 @@ class ServerDeathReconnectNoResurrectE2eTest {
                 // #2000: this journey owns the exact persisted intent that can
                 // be re-adopted later and pin the reconnect grace forever.
                 enabled = true,
+                trustedHostKeySha256 = trustedHostKeySha256,
             ),
         )
         return HOST_ROW_TAG_PREFIX + forwardingHostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SessionSwipeSwitchE2eTest.kt
@@ -123,6 +123,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class SessionSwipeSwitchE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -178,7 +179,7 @@ class SessionSwipeSwitchE2eTest {
     @Test
     fun swipeDownPagerSwitchesSessionAndActivatesCachedRuntimeOnReturn() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         seedTmuxSessions(key)
         val hostRowTag = seedDockerHost(key, "Issue237 Swipe")
@@ -661,7 +662,7 @@ class SessionSwipeSwitchE2eTest {
      */
     private suspend fun attachToSessionAForCaptureProof(): String {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSessions(key)
         val hostRowTag = seedDockerHost(key, "Issue1994 Capture")
         launchedActivity = ActivityScenario.launch(MainActivity::class.java)
@@ -815,6 +816,7 @@ class SessionSwipeSwitchE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SilentDropSyntheticSeamJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SilentDropSyntheticSeamJourneyE2eTest.kt
@@ -78,6 +78,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class SilentDropSyntheticSeamJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -97,7 +98,7 @@ class SilentDropSyntheticSeamJourneyE2eTest {
                 runBlocking {
                     val key = readFixtureKey()
                     seededKey = key
-                    waitForSshFixtureReady(SshKey.Pem(key))
+                    trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
                     seedTmuxSession(key)
                     seededHostRowTag = seedDockerHost(key)
                 }
@@ -511,6 +512,7 @@ class SilentDropSyntheticSeamJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SlowClassifyKeepsSharedLeaseJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SlowClassifyKeepsSharedLeaseJourneyDockerTest.kt
@@ -105,6 +105,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class SlowClassifyKeepsSharedLeaseJourneyDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -128,7 +129,7 @@ class SlowClassifyKeepsSharedLeaseJourneyDockerTest {
     private suspend fun seedRemoteAndDb() {
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         // Make the host classify genuinely slow BEFORE the app can fire it, so
         // the very first in-app classify already overruns the 3.5s bound.
         writeClassifyDelay(key, CLASSIFY_DELAY_SECS)
@@ -509,6 +510,7 @@ class SlowClassifyKeepsSharedLeaseJourneyDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SshReconnectE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SshReconnectE2eTest.kt
@@ -118,6 +118,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class SshReconnectE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -140,7 +141,7 @@ class SshReconnectE2eTest {
         // The fixture kills each accepted SSH session after ~12s, but
         // `waitForSshFixtureReady` opens its own short-lived `exec`
         // session that completes in well under that window.
-        waitForSshFixtureReady(SshKey.Pem(key), port = FLAKY_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key), port = FLAKY_PORT)
 
         val marker = "r${System.currentTimeMillis().toString(36).takeLast(5)}"
         // The flaky-agent container's entrypoint seeds this exact name
@@ -400,6 +401,7 @@ class SshReconnectE2eTest {
                     // skips past.
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/SystemBackForegroundE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/SystemBackForegroundE2eTest.kt
@@ -61,6 +61,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class SystemBackForegroundE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -83,7 +84,7 @@ class SystemBackForegroundE2eTest {
     @Test
     fun systemBackOnHostDetailAndTerminalKeepsAppForegrounded() { kotlinx.coroutines.runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
         val hostRowTag = seedDockerHost(key, "Issue520 Back")
         forceFlatHostDetailViewMode()
@@ -350,6 +351,7 @@ class SystemBackForegroundE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxDetachOnBackgroundE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxDetachOnBackgroundE2eTest.kt
@@ -124,6 +124,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxDetachOnBackgroundE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createEmptyComposeRule()
 
@@ -167,7 +168,7 @@ class TmuxDetachOnBackgroundE2eTest {
     @Test
     fun backgroundingTheAppDetachesTmuxAndDesktopGetsFullSize() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
         clearLogcat()
 
@@ -434,6 +435,7 @@ class TmuxDetachOnBackgroundE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxKeyBarCtrlComboE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxKeyBarCtrlComboE2eTest.kt
@@ -94,6 +94,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxKeyBarCtrlComboE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -1369,7 +1370,7 @@ class TmuxKeyBarCtrlComboE2eTest {
 
     private suspend fun seedBeforeLaunch() {
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedTmuxSession(fixtureKey)
         hostRowTag = seedDockerHost(fixtureKey, "Issue1662 Hotkeys")
     }
@@ -1494,6 +1495,7 @@ class TmuxKeyBarCtrlComboE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxOrphanClientCleanupE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxOrphanClientCleanupE2eTest.kt
@@ -106,6 +106,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxOrphanClientCleanupE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createEmptyComposeRule()
 
@@ -153,7 +154,7 @@ class TmuxOrphanClientCleanupE2eTest {
     @Test
     fun closingTheAppDoesNotLeaveAnOrphanCcClient() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         // ---- Seed the session with a long-running tail so the session
         // outlives the test body (a `sleep` is enough — the actual pane
@@ -357,7 +358,7 @@ class TmuxOrphanClientCleanupE2eTest {
     @Test
     fun aForeignClientOnTheSameSessionIsNotReportedAsPocketShellsOrphan() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSession(key)
 
         val foreign = attachForeignPlainClient(key, SEEDED_SESSION)
@@ -508,7 +509,7 @@ class TmuxOrphanClientCleanupE2eTest {
     fun aLeakedAlwaysOnForwardingPinIsIsolatedNamedAndReleasedInsteadOfBlamedOnTheProduct() {
         runBlocking {
             val key = readFixtureKey()
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedTmuxSession(key)
             val foreignBaseline = listClientNames(key, SEEDED_SESSION)
 
@@ -896,6 +897,7 @@ class TmuxOrphanClientCleanupE2eTest {
                     pocketshellVersionCompatible = true,
                     pocketshellDaemonRunning = true,
                     pocketshellDaemonEnabled = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchE2eTest.kt
@@ -88,6 +88,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxSessionSwitchE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -115,7 +116,7 @@ class TmuxSessionSwitchE2eTest {
     @Test
     fun switchingBetweenTmuxSessionsViaDrawerDoesNotCrash() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         // Seed both sessions fresh on the fixture so the picker has them
         // ready and the test is hermetic against earlier runs.
@@ -241,7 +242,7 @@ class TmuxSessionSwitchE2eTest {
     @Test
     fun backThenTapSessionRowLandsInThatSessionNotAnotherOne() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedTmuxSessions(key)
 
         val hostRowTag = seedDockerHost(key, "Issue652 Wrong Project")
@@ -384,6 +385,7 @@ class TmuxSessionSwitchE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchSameHostReusesSshE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxSessionSwitchSameHostReusesSshE2eTest.kt
@@ -85,6 +85,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxSessionSwitchSameHostReusesSshE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -131,7 +132,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
     @Test
     fun sameHostSessionSwitchReusesSshTransport() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         seedTmuxSessions(key)
         val hostRowTag = seedDockerHost(key, "Issue178 Same Host")
@@ -289,7 +290,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
     @Test
     fun dashboardSameHostSessionTapReusesSshTransport() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         seedTmuxSessions(key)
         val hostRowTag = seedDockerHost(key, "Issue278 Dashboard Same Host")
@@ -369,7 +370,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
     @Test
     fun sameHostWarmSwitchBenchmarkReportsRepeatedStats() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         seedTmuxSessions(key)
         val hostRowTag = seedDockerHost(key, "Issue337 Warm Switch Budget")
@@ -507,6 +508,7 @@ class TmuxSessionSwitchSameHostReusesSshE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/TmuxTerminalSurfaceFailureE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/TmuxTerminalSurfaceFailureE2eTest.kt
@@ -206,6 +206,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxTerminalSurfaceFailureE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     // Issue #788/#848: launch-owned rule so the Compose clock and the real
     // TerminalView interop child share one MainActivity. Seed the Docker tmux
@@ -233,7 +234,7 @@ class TmuxTerminalSurfaceFailureE2eTest {
 
     private suspend fun seedBeforeLaunch() {
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedTmuxSession(fixtureKey)
         hostRowTag = seedDockerHost(fixtureKey, "Issue423 Surface")
         forceFlatHostDetailViewMode()
@@ -509,6 +510,7 @@ class TmuxTerminalSurfaceFailureE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/VoiceGestureCoachmarkMainActivityDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/VoiceGestureCoachmarkMainActivityDockerTest.kt
@@ -80,6 +80,7 @@ import org.junit.rules.RuleChain
  */
 @RunWith(AndroidJUnit4::class)
 class VoiceGestureCoachmarkMainActivityDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private val compose = createAndroidComposeRule<MainActivity>()
 
@@ -213,7 +214,7 @@ class VoiceGestureCoachmarkMainActivityDockerTest {
         clearLastSessionPrefs()
         clearEducationPreference()
         clearVoiceApiKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         seedTmuxSession(fixtureKey)
         hostRowTag = seedDockerHost(fixtureKey)
         forceFlatHostDetailViewMode()
@@ -249,6 +250,7 @@ class VoiceGestureCoachmarkMainActivityDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/VoiceSendActivePaneStaysVisibleE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/VoiceSendActivePaneStaysVisibleE2eTest.kt
@@ -102,6 +102,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class VoiceSendActivePaneStaysVisibleE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -383,7 +384,7 @@ class VoiceSendActivePaneStaysVisibleE2eTest {
         val key = readFixtureKey()
         seededKey = key
         try {
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedTmuxSession(key)
             seededHostRowTag = seedDockerHost(key)
         } catch (t: Throwable) {
@@ -414,6 +415,7 @@ class VoiceSendActivePaneStaysVisibleE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WalkthroughVisualScreenshotTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WalkthroughVisualScreenshotTest.kt
@@ -62,6 +62,7 @@ import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class WalkthroughVisualScreenshotTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -93,7 +94,7 @@ class WalkthroughVisualScreenshotTest {
             val sshKey = SshKey.Pem(key)
 
             val hostRowTag = seedWalkthroughHostAndSnippets(key)
-            waitForSshFixtureReady(sshKey)
+            trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
             // Issue #761: kill any leaked sessions from a prior failed run AND
             // seed a fresh one. The seeded session is torn down in `finally`
             // below so it does not accumulate on the shared `agents:2222`
@@ -397,6 +398,7 @@ class WalkthroughVisualScreenshotTest {
                     pocketshellDaemonRunning = true,
                     pocketshellDaemonEnabled = true,
                     pocketshellVersionCompatible = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             db.snippetDao().insert(

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseBatchCDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseBatchCDockerTest.kt
@@ -54,6 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 @RunWith(AndroidJUnit4::class)
 class WarmLeaseReuseBatchCDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private class CountingConnector(
         private val delegate: SshLeaseConnector,
@@ -70,7 +71,7 @@ class WarmLeaseReuseBatchCDockerTest {
         val keyContent = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         val key = SshKey.Pem(keyContent)
-        waitForSshFixtureReady(key)
+        trustedHostKeySha256 = waitForSshFixtureReady(key)
 
         val keyPath = writeKeyToFile(keyContent)
         val connector = CountingConnector(DefaultSshLeaseConnector())
@@ -92,6 +93,7 @@ class WarmLeaseReuseBatchCDockerTest {
                 port = DEFAULT_PORT,
                 username = DEFAULT_USER,
                 keyId = keyId,
+                trustedHostKeySha256 = trustedHostKeySha256,
             )
             db.hostDao().insert(host)
 

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WarmLeaseReuseDockerTest.kt
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 @RunWith(AndroidJUnit4::class)
 class WarmLeaseReuseDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private class CountingConnector(
         private val delegate: SshLeaseConnector,
@@ -59,7 +60,7 @@ class WarmLeaseReuseDockerTest {
         val keyContent = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         val key = SshKey.Pem(keyContent)
-        waitForSshFixtureReady(key)
+        trustedHostKeySha256 = waitForSshFixtureReady(key)
 
         val keyPath = writeKeyToFile(keyContent)
         val connector = CountingConnector(DefaultSshLeaseConnector())
@@ -72,6 +73,7 @@ class WarmLeaseReuseDockerTest {
             port = DEFAULT_PORT,
             username = DEFAULT_USER,
             keyId = 1L,
+            trustedHostKeySha256 = trustedHostKeySha256,
         )
 
         // --- Surface 1: start-directory autocomplete (worst offender) ---

--- a/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/proof/WithinGraceSocketDropForegroundJourneyE2eTest.kt
@@ -121,6 +121,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class WithinGraceSocketDropForegroundJourneyE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -154,7 +155,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
     fun withinGraceForegroundAfterSocketDropRetainsViewportAndRetryRecoversSameSession() { runBlocking {
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         // Baseline sshd workers BEFORE the app connects so we can identify the
         // app's `-CC` worker by set-difference once it attaches.
@@ -685,6 +686,7 @@ class WithinGraceSocketDropForegroundJourneyE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/session/ShowKeyboardChipE2eTest.kt
@@ -160,6 +160,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ShowKeyboardChipE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
 
@@ -193,7 +194,7 @@ class ShowKeyboardChipE2eTest {
         clearLastSessionPrefs()
         val key = readFixtureKey()
         seededKey = key
-        waitForSshFixtureReady(SshKey.Pem(key), port = DEFAULT_PORT)
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key), port = DEFAULT_PORT)
         seedTmuxSession(key)
         seededHostRowTag = seedDockerHost(key)
     }
@@ -779,6 +780,7 @@ class ShowKeyboardChipE2eTest {
                     // the folders/session surface.
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/share/SharePasteIntoSessionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/share/SharePasteIntoSessionE2eTest.kt
@@ -62,6 +62,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class SharePasteIntoSessionE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -125,7 +126,7 @@ class SharePasteIntoSessionE2eTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         val marker = System.currentTimeMillis().toString()
         val sessionName = "issue193-$marker"
@@ -314,6 +315,7 @@ class SharePasteIntoSessionE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
         } finally {

--- a/app/src/androidTest/java/com/pocketshell/app/share/ShareTargetE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/share/ShareTargetE2eTest.kt
@@ -58,6 +58,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ShareTargetE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -153,7 +154,7 @@ class ShareTargetE2eTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         val marker = "psshare${System.currentTimeMillis()}"
         val hostId = seedHost(targetContext, key, marker)
@@ -275,7 +276,7 @@ class ShareTargetE2eTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         val marker = "psmulti${System.currentTimeMillis()}"
         val hostId = seedHost(targetContext, key, marker)
@@ -407,7 +408,7 @@ class ShareTargetE2eTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         val marker = "psproj${System.currentTimeMillis()}"
         // A project path under $HOME. `.inbox/` is created on demand by
@@ -521,7 +522,7 @@ class ShareTargetE2eTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         val marker = "pssession${System.currentTimeMillis()}"
         val sessionName = "issue507-$marker"
@@ -699,7 +700,7 @@ class ShareTargetE2eTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         val marker = "psinto${System.currentTimeMillis()}"
         val sessionName = "issue560-$marker"
@@ -1009,6 +1010,7 @@ class ShareTargetE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             db.projectRootDao().insert(
@@ -1090,6 +1092,7 @@ class ShareTargetE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
         } finally {

--- a/app/src/androidTest/java/com/pocketshell/app/snippets/SnippetPickerTmuxZOrderDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/snippets/SnippetPickerTmuxZOrderDockerTest.kt
@@ -58,6 +58,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class SnippetPickerTmuxZOrderDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private companion object {
         const val DATABASE_NAME: String = "pocketshell.db"
@@ -97,7 +98,7 @@ class SnippetPickerTmuxZOrderDockerTest {
             .bufferedReader()
             .use { it.readText() }
         val sshKey = SshKey.Pem(key)
-        waitForSshFixtureReady(sshKey, port = sshPort)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = sshPort)
         killStaleTmuxSession(sshKey, sshPort)
         seedTmuxSession(sshKey, sshPort, SESSION_NAME)
 
@@ -289,6 +290,7 @@ class SnippetPickerTmuxZOrderDockerTest {
                     pocketshellDaemonRunning = true,
                     pocketshellDaemonEnabled = true,
                     pocketshellVersionCompatible = true,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             db.snippetDao().insert(

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/AgentApprovalQuickReplyJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/AgentApprovalQuickReplyJourneyDockerTest.kt
@@ -88,6 +88,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class AgentApprovalQuickReplyJourneyDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private companion object {
         const val DATABASE_NAME: String = "pocketshell.db"
@@ -143,7 +144,7 @@ class AgentApprovalQuickReplyJourneyDockerTest {
             .bufferedReader()
             .use { it.readText() }
         val sshKey = SshKey.Pem(key)
-        waitForSshFixtureReady(sshKey, port = sshPort)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = sshPort)
         killSession(sshKey, sshPort)
         seedAgentApprovalSession(sshKey, sshPort)
 
@@ -379,6 +380,7 @@ class AgentApprovalQuickReplyJourneyDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationStaysReachableAfterDetectionDropsDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationStaysReachableAfterDetectionDropsDockerTest.kt
@@ -105,6 +105,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ConversationStaysReachableAfterDetectionDropsDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -383,7 +384,7 @@ class ConversationStaysReachableAfterDetectionDropsDockerTest {
         val key = readFixtureKey()
         seededKey = key
         clearLastSessionPrefs()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         val sessionName = when (methodName) {
             "conversationStaysReachableAfterLiveDetectionDropsWithLoadedTranscript" ->
                 seedMaskedLiveClaudeSession(key)
@@ -491,6 +492,7 @@ class ConversationStaysReachableAfterDetectionDropsDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             seededHostId = hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest.kt
@@ -105,6 +105,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -480,7 +481,7 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
         val key = readFixtureKey()
         seededKey = key
         clearLastSessionPrefs()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         val sessionName = when (methodName) {
             "conversationToggleReturnsForMaskedLiveClaudeInRecordedShellSession" ->
                 seedMaskedLiveClaudeSession(key)
@@ -709,6 +710,7 @@ class ConversationToggleVisibleForLiveAgentInShellRecordedSessionDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationTuiCommandJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/ConversationTuiCommandJourneyDockerTest.kt
@@ -122,6 +122,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class ConversationTuiCommandJourneyDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     val compose = createAndroidComposeRule<MainActivity>()
     private val grantPermissions = PreGrantPermissionsRule()
@@ -477,7 +478,7 @@ class ConversationTuiCommandJourneyDockerTest {
         val key = readFixtureKey()
         seededKey = key
         clearLastSessionPrefs()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         val sessionName = when (methodName) {
             "modelCommandFromConversationShowsNoticeNoEchoBubbleThenTapOpensTerminal" ->
                 seedMaskedLiveClaudeSession(key)
@@ -670,6 +671,7 @@ class ConversationTuiCommandJourneyDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue1686QueueDrainWireOracleDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue1686QueueDrainWireOracleDockerTest.kt
@@ -115,6 +115,7 @@ import java.io.File
  */
 @RunWith(AndroidJUnit4::class)
 class Issue1686QueueDrainWireOracleDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -151,7 +152,7 @@ class Issue1686QueueDrainWireOracleDockerTest {
     fun queuedComposerSendDrainsOverWritableWireWhileConnectionStatusFalselyNotConnected() {
         runBlocking {
             val key = readFixtureKey()
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedInteractiveSession(key)
             val hostRowTag = seedDockerHost(key, "Issue1686 Drain")
 
@@ -228,7 +229,7 @@ class Issue1686QueueDrainWireOracleDockerTest {
     fun transportAliveEdgeUnparksAutoFailedRowThenDrainsOverWire() {
         runBlocking {
             val key = readFixtureKey()
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedInteractiveSession(key)
             val hostRowTag = seedDockerHost(key, "Issue1686 Unpark")
 
@@ -322,7 +323,7 @@ class Issue1686QueueDrainWireOracleDockerTest {
     fun silentWireRecoveryUnparksAutoFailedRowWithoutConnectionEnumEdge() {
         runBlocking {
             val key = readFixtureKey()
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedInteractiveSession(key)
             val hostRowTag = seedDockerHost(key, "Issue2042 Silent Wire Heal")
 
@@ -437,7 +438,7 @@ class Issue1686QueueDrainWireOracleDockerTest {
     fun deliveredAgentRouteRowLeavesTheQueueWithNoTranscriptAuthority() {
         runBlocking {
             val key = readFixtureKey()
-            waitForSshFixtureReady(SshKey.Pem(key))
+            trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
             seedInteractiveSession(key, prompt = "\u276f ")
             val hostRowTag = seedDockerHost(key, "Issue2056 Delivered Row")
 
@@ -802,6 +803,7 @@ class Issue1686QueueDrainWireOracleDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue2160RecordedSourceLocaleProofDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue2160RecordedSourceLocaleProofDockerTest.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.withTimeout
  */
 @RunWith(AndroidJUnit4::class)
 class Issue2160RecordedSourceLocaleProofDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private lateinit var sshKey: SshKey.Pem
     private val cleanupCommands = mutableListOf<String>()
@@ -77,7 +78,7 @@ class Issue2160RecordedSourceLocaleProofDockerTest {
         val keyText = InstrumentationRegistry.getInstrumentation().context.assets
             .open("test_key").bufferedReader().use { it.readText() }
         sshKey = SshKey.Pem(keyText)
-        waitForSshFixtureReady(sshKey)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey)
     } }
 
     @After
@@ -412,6 +413,7 @@ class Issue2160RecordedSourceLocaleProofDockerTest {
                         port = DEFAULT_PORT,
                         username = DEFAULT_USER,
                         keyId = 1L,
+                        trustedHostKeySha256 = trustedHostKeySha256,
                     ),
                     keyPath = "/unused-the-connector-holds-the-pem",
                     passphrase = null,

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ImeRecompositionProofTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue796ImeRecompositionProofTest.kt
@@ -133,6 +133,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class Issue796ImeRecompositionProofTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -159,7 +160,7 @@ class Issue796ImeRecompositionProofTest {
             .bufferedReader()
             .use { it.readText() }
         val sshKey = SshKey.Pem(key)
-        waitForSshFixtureReady(sshKey, port = sshPort)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = sshPort)
         killSession(sshKey, sshPort)
         seedTriggerGatedRedrawSession(sshKey, sshPort)
 
@@ -473,6 +474,7 @@ class Issue796ImeRecompositionProofTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/Issue887TerminalFixedUnderImeE2eTest.kt
@@ -81,6 +81,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class Issue887TerminalFixedUnderImeE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -116,7 +117,7 @@ class Issue887TerminalFixedUnderImeE2eTest {
     @Test
     fun terminalDoesNotPanOrResizeWhenSoftKeyboardShows() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedShellSession(key)
         val hostRowTag = seedDockerHost(key, "Issue887 Terminal Fixed")
         // Issue #788: flat host-detail mode + seed BEFORE launch so the session
@@ -623,6 +624,7 @@ class Issue887TerminalFixedUnderImeE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxAttachPrefillDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxAttachPrefillDockerTest.kt
@@ -86,6 +86,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxAttachPrefillDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -114,7 +115,7 @@ class TmuxAttachPrefillDockerTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         val sessionName = SEEDED_TMUX_SESSION
         val firstSeedLine = "issue103-seed-line-001"
@@ -364,7 +365,7 @@ class TmuxAttachPrefillDockerTest {
             .open("test_key")
             .bufferedReader()
             .use { it.readText() }
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         val sessionName = "issue259-spinner-${System.currentTimeMillis()}"
         val longFrame = "Beboppin... (30.6k tokens thinking)"
@@ -679,6 +680,7 @@ class TmuxAttachPrefillDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxCreateAfterAttachFailureDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxCreateAfterAttachFailureDockerTest.kt
@@ -48,6 +48,7 @@ import java.io.FileOutputStream
 /** Issue #1832 production-screen proof: failed attach -> real New-session sheet -> real Toast. */
 @RunWith(AndroidJUnit4::class)
 class TmuxCreateAfterAttachFailureDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -82,7 +83,7 @@ class TmuxCreateAfterAttachFailureDockerTest {
     @Test
     fun failedAttachKeepsNewSessionSurfaceReachableAndShowsToastWithoutCreating() { runBlocking {
         fixtureKey = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(fixtureKey))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(fixtureKey))
         val suffix = System.nanoTime().toString().takeLast(7)
         val healthySession = "issue1832-live-$suffix"
         val createFolder = "/tmp/issue1832-create-$suffix"
@@ -269,6 +270,7 @@ class TmuxCreateAfterAttachFailureDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + healthyHostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxDetectedPortForwardDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxDetectedPortForwardDockerTest.kt
@@ -67,6 +67,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxDetectedPortForwardDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private companion object {
         const val DATABASE_NAME: String = "pocketshell.db"
@@ -106,7 +107,7 @@ class TmuxDetectedPortForwardDockerTest {
             .bufferedReader()
             .use { it.readText() }
         val sshKey = SshKey.Pem(key)
-        waitForSshFixtureReady(sshKey, port = sshPort)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = sshPort)
         killTmuxSession(sshKey, sshPort)
         seedTmuxSession(sshKey, sshPort)
 
@@ -262,6 +263,7 @@ class TmuxDetectedPortForwardDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxInSessionNewSessionCollisionDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxInSessionNewSessionCollisionDockerTest.kt
@@ -122,6 +122,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxInSessionNewSessionCollisionDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -202,7 +203,7 @@ class TmuxInSessionNewSessionCollisionDockerTest {
     @Test
     fun createCollidingWithASessionOnItsOwnSocketDisambiguatesInsteadOfOrphaning() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         val suffix = "issue2378-${System.nanoTime().toString().takeLast(6)}"
         val folder = "/tmp/$suffix"
         val baseName = "tmp-$suffix"
@@ -320,7 +321,7 @@ class TmuxInSessionNewSessionCollisionDockerTest {
     @Test
     fun inSessionNewSessionInSameFolderGetsSuffixedSessionNotCollisionAllEntryPoints() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         // Fresh summary file for this run (both entry points append to it).
         artifactFile("summary.txt").writeText("")
         val hostRowTag = seedDockerHost(key, "Issue898 InSession NewSession")
@@ -368,7 +369,7 @@ class TmuxInSessionNewSessionCollisionDockerTest {
     @Test
     fun collidingBaseNameStillYieldsAGenuinelyNewSessionOnTheHost() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         val suffix = "host-${System.nanoTime().toString().takeLast(6)}"
         val folder = "/tmp/issue1820-$suffix"
         val baseName = "tmp-issue1820-$suffix"
@@ -524,7 +525,7 @@ class TmuxInSessionNewSessionCollisionDockerTest {
     @Test
     fun failedPostCreateLaunchIsReportedAsPartialSuccessOnARealHost() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         val suffix = "issue1928-${System.nanoTime().toString().takeLast(6)}"
         val folder = "/tmp/$suffix"
         createdFolders += folder
@@ -894,6 +895,7 @@ class TmuxInSessionNewSessionCollisionDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxResizeSessionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxResizeSessionE2eTest.kt
@@ -64,6 +64,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxResizeSessionE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -91,7 +92,7 @@ class TmuxResizeSessionE2eTest {
     @Test
     fun attachAutomaticallySizesTmuxToPhoneViewport() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedDesktopSizedSession(key)
         val seededWindowDims = readRemoteDims(key)
         assertEquals(
@@ -234,7 +235,7 @@ class TmuxResizeSessionE2eTest {
     @Test
     fun cachedSizeReplayRestoresFullWindowAndAgentPaneIsNotCut() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedDesktopSizedSession(key)
         val hostRowTag = seedDockerHost(key, "Issue1169 Agent Cut")
 
@@ -375,6 +376,7 @@ class TmuxResizeSessionE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionOpencodeInputDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxSessionOpencodeInputDockerTest.kt
@@ -167,6 +167,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxSessionOpencodeInputDockerTest {
+    private lateinit var trustedHostKeySha256: String
 
     private companion object {
         const val DATABASE_NAME: String = "pocketshell.db"
@@ -228,7 +229,7 @@ class TmuxSessionOpencodeInputDockerTest {
             .bufferedReader()
             .use { it.readText() }
         val sshKey = SshKey.Pem(key)
-        waitForSshFixtureReady(sshKey, port = sshPort)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = sshPort)
         // Kill any leftover session of the same name so the test starts
         // from a deterministic state (no stale pane from a prior failed
         // run).
@@ -409,7 +410,7 @@ class TmuxSessionOpencodeInputDockerTest {
             .bufferedReader()
             .use { it.readText() }
         val sshKey = SshKey.Pem(key)
-        waitForSshFixtureReady(sshKey, port = sshPort)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = sshPort)
         killTmuxSession(sshKey, sshPort, ISSUE_303_AGENT_SESSION_NAME)
         killTmuxSession(sshKey, sshPort, ISSUE_303_PLAIN_SESSION_NAME)
         seedIssue303AgentSession(sshKey, sshPort, recordOwnedKind = true)
@@ -710,7 +711,7 @@ class TmuxSessionOpencodeInputDockerTest {
             .bufferedReader()
             .use { it.readText() }
         val sshKey = SshKey.Pem(key)
-        waitForSshFixtureReady(sshKey, port = sshPort)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = sshPort)
         killTmuxSession(sshKey, sshPort, ISSUE_303_AGENT_SESSION_NAME)
         seedIssue303AgentSession(sshKey, sshPort)
 
@@ -834,7 +835,7 @@ class TmuxSessionOpencodeInputDockerTest {
             .bufferedReader()
             .use { it.readText() }
         val sshKey = SshKey.Pem(key)
-        waitForSshFixtureReady(sshKey, port = sshPort)
+        trustedHostKeySha256 = waitForSshFixtureReady(sshKey, port = sshPort)
         killTmuxSession(sshKey, sshPort, ISSUE_297_SESSION_NAME)
         installIssue297AgentShimAndSeedSession(sshKey, sshPort)
 
@@ -1135,6 +1136,7 @@ class TmuxSessionOpencodeInputDockerTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             hostRowTag = HOST_ROW_TAG_PREFIX + hostId

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/TmuxShellComposerOcclusionE2eTest.kt
@@ -98,6 +98,7 @@ import com.pocketshell.app.proof.signals.captureViewToBitmap
  */
 @RunWith(AndroidJUnit4::class)
 class TmuxShellComposerOcclusionE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -135,7 +136,7 @@ class TmuxShellComposerOcclusionE2eTest {
     @Test
     fun shellComposerControlsAreVisibleAndReachableInBothKeyboardStates() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         seedShellSession(key)
         val hostRowTag = seedDockerHost(key, "Issue641 Shell Composer")
 
@@ -868,6 +869,7 @@ class TmuxShellComposerOcclusionE2eTest {
                     keyId = storedKey.id,
                     tmuxInstalled = true,
                     lastBootstrapAt = System.currentTimeMillis(),
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
             commandSnippetId = db.snippetDao().insert(

--- a/app/src/androidTest/java/com/pocketshell/app/usage/UsageScreenE2eTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/usage/UsageScreenE2eTest.kt
@@ -63,6 +63,7 @@ import java.io.FileOutputStream
  */
 @RunWith(AndroidJUnit4::class)
 class UsageScreenE2eTest {
+    private lateinit var trustedHostKeySha256: String
 
     @get:Rule
     val compose = createEmptyComposeRule()
@@ -84,7 +85,7 @@ class UsageScreenE2eTest {
     @Test
     fun usagePanel_populatedCell_showsProviderCards() { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
         var fixtureStdout = ""
 
         // Sanity probe: the agents fixture actually returns provider
@@ -231,7 +232,7 @@ class UsageScreenE2eTest {
         // (blank). After the fix the fetcher still runs against agents:2222
         // and the panel renders the provider cards.
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        trustedHostKeySha256 = waitForSshFixtureReady(SshKey.Pem(key))
 
         seedHost(
             key = key,
@@ -295,7 +296,13 @@ class UsageScreenE2eTest {
         // Best-effort probe; an unreachable agents target still lets the
         // empty-cell test prove the panel renders for hosts that can't
         // be reached (Skipped → no provider cards, no missing-tool rows).
-        runCatching { waitForSshFixtureReady(SshKey.Pem(key)) }
+        // Issue #2446: this seeded host targets `port = 2299` below (a dead
+        // port, deliberately unbound), NOT the port this probe just verified
+        // (`DEFAULT_PORT`) — the TCP connect fails before host-key
+        // verification is ever reached, so an empty fallback fingerprint on
+        // probe failure is fine; it is never checked for this host.
+        trustedHostKeySha256 = runCatching { waitForSshFixtureReady(SshKey.Pem(key)) }
+            .getOrDefault("")
 
         seedHost(
             key = key,
@@ -397,6 +404,7 @@ class UsageScreenE2eTest {
                     pocketshellCliVersion = pocketshellCliVersion,
                     pocketshellExpectedCliVersion = pocketshellExpectedCliVersion,
                     pocketshellVersionCompatible = pocketshellVersionCompatible,
+                    trustedHostKeySha256 = trustedHostKeySha256,
                 ),
             )
         } finally {


### PR DESCRIPTION
Comprehensive follow-up to #2445/#2451 — the last known blocker for \`main\`'s Emulator journey CI lane. Full review: https://github.com/alexeygrigorev/pocketshell/issues/2446

Test-fixture-only (all 122 files under \`app/src/androidTest/\`), no production code touched. Independently re-verified by the reviewer: full JVM gate 604/604, an independent 30-class emulator sample (102 test-method executions, zero \`UnknownHostKeyException\`), G1 red→green on 3 representative files, 30+ diffs spot-checked across every subsystem.

A real production gap found in the same investigation (3 gateways never wired for trust resolution) is filed separately as #2453 — deliberately out of scope here.

Closes #2446