### PR TITLE
Automate bounded one-shot retry + signature comparison for red runs

### DIFF
--- a/.github/workflows/full-suite-notify.yml
+++ b/.github/workflows/full-suite-notify.yml
@@ -7,18 +7,36 @@ name: Full-suite red-run notify
 # fast-attribution mechanism the v0.4.45 release postmortem (#2338/#2294, 11
 # days red `main`) was missing.
 #
+# Issue #2459 extends this with a BOUNDED ONE-SHOT RETRY-AND-COMPARE: on the
+# first red scheduled run (run_attempt == 1), also capture its failure
+# signature, store it on the tracking issue, and trigger exactly one full
+# `gh run rerun`. When that retry's own completion re-fires this same
+# `workflow_run` event (same run id, run_attempt >= 2), compare the retry's
+# outcome against the stored signature and classify it as G5 infra/flake (a
+# clean or differing retry) or a confirmed regression (an identical
+# signature), posting the verdict — citing BOTH run URLs — as a follow-up
+# comment instead of leaving that comparison to a human every time. See
+# scripts/ci-retry-gate.sh for the anti-infinite-loop mechanism (a total,
+# stateless function of run_attempt: only run_attempt == 1 may ever start a
+# retry, so the retry's own result can never trigger a second one).
+#
 # Deliberately a SEPARATE workflow, triggered by `workflow_run` once Tests
 # concludes, rather than a job inside tests.yml: `.github/workflows/tests.yml`
 # is under a hard file-size ratchet (scripts/check-file-size-hygiene.sh) with
 # essentially no headroom left, and this notify logic needs no job-level
 # `needs:` access into Tests' jobs anyway — it re-derives everything it needs
-# (which top-level job failed, the last known-green scheduled run's SHA) from
-# the GitHub API against the now-completed run, via
-# scripts/ci-run-jobs.sh and scripts/ci-skip-check.sh respectively.
+# (which top-level job failed, the last known-green scheduled run's SHA, the
+# retry-comparison signature) from the GitHub API against the now-completed
+# run, via scripts/ci-run-jobs.sh, scripts/ci-skip-check.sh, and
+# scripts/ci-retry-signature.py respectively.
 #
-# Only fires for a SCHEDULED Tests run that concluded failure — never for a
-# push/PR/workflow_dispatch run (those have no "last known green scheduled
-# run" concept to bisect against) and never for a green run.
+# Only fires for a SCHEDULED Tests run — never for a push/PR/workflow_dispatch
+# run (those have no "last known green scheduled run" concept to bisect
+# against). The job-level `if` no longer also requires `conclusion ==
+# 'failure'`: a `run_attempt >= 2` GREEN completion is exactly the "the
+# bounded retry came back clean" case that must still run the compare step,
+# so the conclusion check moved into scripts/ci-retry-gate.sh's PHASE
+# decision instead (see its header comment for the full state table).
 
 on:
   workflow_run:
@@ -27,38 +45,94 @@ on:
 
 jobs:
   notify:
-    name: File/update red scheduled-run tracking issue
-    if: github.event.workflow_run.event == 'schedule' && github.event.workflow_run.conclusion == 'failure'
+    name: File/update red scheduled-run tracking issue + bounded retry (#2459)
+    if: github.event.workflow_run.event == 'schedule'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
-      actions: read
+      actions: write
       issues: write
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
+      # issue #2459: the one decision every other step branches on. PHASE is
+      # one of first_red | retry_red | retry_clean | noop — see
+      # scripts/ci-retry-gate.sh's header for the full state table and why
+      # this alone bounds the retry to exactly one shot.
+      - id: gate
+        run: |
+          scripts/ci-retry-gate.sh \
+            --run-attempt "${{ github.event.workflow_run.run_attempt }}" \
+            --conclusion "${{ github.event.workflow_run.conclusion }}"
+
       - id: jobs
+        if: steps.gate.outputs.phase == 'first_red'
         env:
           GH_TOKEN: ${{ github.token }}
         run: scripts/ci-run-jobs.sh --repo "${{ github.repository }}" --run-id "${{ github.event.workflow_run.id }}"
 
       - id: green
+        if: steps.gate.outputs.phase == 'first_red'
         env:
           GH_TOKEN: ${{ github.token }}
         run: scripts/ci-skip-check.sh --repo "${{ github.repository }}" --sha "${{ github.event.workflow_run.head_sha }}"
 
-      - name: File or update the tracking issue
+      - name: File or update the tracking issue (first red)
+        if: steps.gate.outputs.phase == 'first_red'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           scripts/ci-red-issue.sh \
             --repo "${{ github.repository }}" \
-            --run-url "${{ github.event.workflow_run.html_url }}" \
+            --run-url "${{ github.event.workflow_run.html_url }}/attempts/1" \
             --sha "${{ github.event.workflow_run.head_sha }}" \
             --last-green-sha "${{ steps.green.outputs.last_green_sha }}" \
             --unit-gate "${{ steps.jobs.outputs.unit_gate }}" \
             --python "${{ steps.jobs.outputs.python }}" \
             --integration "${{ steps.jobs.outputs.integration }}" \
             --emulator-journey-verdict "${{ steps.jobs.outputs.emulator_journey_verdict }}"
+
+      # issue #2459: this run's own failure signature (failed job names, plus
+      # failing test class names for the emulator-journey shards), computed
+      # whenever this event needs to be COMPARED against another attempt —
+      # i.e. on the original red run (to store for later) and on the retry's
+      # own red completion (to compare against what was stored).
+      - id: signature
+        if: steps.gate.outputs.phase == 'first_red' || steps.gate.outputs.phase == 'retry_red'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p artifacts
+          python3 scripts/ci-retry-signature.py \
+            --repo "${{ github.repository }}" \
+            --run-id "${{ github.event.workflow_run.id }}" \
+            --journey-artifact-prefix "emulator-journey-android-test-reports-shard-" \
+            --out artifacts/ci-retry-signature.txt
+
+      - name: Store the signature and trigger the one bounded retry (#2459)
+        if: steps.gate.outputs.phase == 'first_red'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/ci-retry-notify.sh store \
+            --repo "${{ github.repository }}" \
+            --marker "pocketshell-full-suite-red-marker" \
+            --run-id "${{ github.event.workflow_run.id }}" \
+            --signature-file artifacts/ci-retry-signature.txt
+          gh run rerun "${{ github.event.workflow_run.id }}" --repo "${{ github.repository }}"
+
+      - name: Compare the bounded retry's outcome and classify (#2459)
+        if: steps.gate.outputs.phase == 'retry_red' || steps.gate.outputs.phase == 'retry_clean'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/ci-retry-notify.sh report \
+            --repo "${{ github.repository }}" \
+            --marker "pocketshell-full-suite-red-marker" \
+            --run-id "${{ github.event.workflow_run.id }}" \
+            --original-run-url "${{ github.event.workflow_run.html_url }}/attempts/1" \
+            --retry-run-url "${{ github.event.workflow_run.html_url }}/attempts/${{ github.event.workflow_run.run_attempt }}" \
+            --retry-conclusion "${{ github.event.workflow_run.conclusion }}" \
+            --retry-signature-file "artifacts/ci-retry-signature.txt"

--- a/.github/workflows/nightly-extensive-notify.yml
+++ b/.github/workflows/nightly-extensive-notify.yml
@@ -1,0 +1,130 @@
+name: Nightly Extensive red-run notify
+
+# Issue #2459: the `Nightly Extensive Tests` sibling of
+# .github/workflows/full-suite-notify.yml (issue #2353's scheduled `Tests`
+# red-run tracker). Nightly Extensive Tests previously had NO red-run
+# notifier of its own — this fills that gap, reusing the exact same
+# bounded-retry-and-compare mechanism (scripts/ci-retry-gate.sh,
+# scripts/ci-retry-signature.py, scripts/ci-retry-classify.sh,
+# scripts/ci-retry-notify.sh) with its OWN tracking-issue marker/title
+# (scripts/ci-nightly-extensive-red-issue.sh) and its own journey-artifact
+# prefix (`nightly-extensive-android-test-reports-shard-`, the artifact the
+# `extensive` matrix job already uploads per shard — no
+# nightly-extensive.yml change required to produce it).
+#
+# On the first red scheduled run (run_attempt == 1): file/update the
+# tracking issue, capture the failure signature, store it, and trigger
+# exactly one full `gh run rerun`. When the retry's own completion re-fires
+# this event (same run id, run_attempt >= 2), compare it against the stored
+# signature and post the verdict — citing both run URLs — as a follow-up
+# comment. See scripts/ci-retry-gate.sh's header for the full PHASE state
+# table and why a retry can never trigger a second retry.
+#
+# Deliberately a SEPARATE workflow, triggered by `workflow_run` once Nightly
+# Extensive Tests concludes (same rationale as full-suite-notify.yml: no
+# job-level `needs:` access into a sibling workflow's jobs is possible or
+# needed — everything is re-derived from the GitHub API against the
+# now-completed run).
+#
+# Only fires for a SCHEDULED run — never for the `workflow_dispatch`
+# force-run trigger nightly-extensive.yml also has (that has no "last known
+# green nightly run" concept to bisect against, same reasoning
+# full-suite-notify.yml already applies to Tests' own workflow_dispatch
+# runs). A guard-skipped nightly run (no new commits in 24h) still concludes
+# `success`, so it never reaches this workflow's `first_red`/`retry_red`
+# branches — only a genuinely red run (or the bounded retry of one) does.
+
+on:
+  workflow_run:
+    workflows: ["Nightly Extensive Tests"]
+    types: [completed]
+
+jobs:
+  notify:
+    name: File/update red nightly tracking issue + bounded retry (#2459)
+    if: github.event.workflow_run.event == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with: { fetch-depth: 0 }
+
+      - id: gate
+        run: |
+          scripts/ci-retry-gate.sh \
+            --run-attempt "${{ github.event.workflow_run.run_attempt }}" \
+            --conclusion "${{ github.event.workflow_run.conclusion }}"
+
+      # issue #2459: this run's failure signature (failed job names, plus
+      # failing test class names for the nightly extensive journey shards),
+      # needed both to build the first-red tracking-issue body and to compare
+      # against on the retry's own completion.
+      - id: signature
+        if: steps.gate.outputs.phase == 'first_red' || steps.gate.outputs.phase == 'retry_red'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p artifacts
+          python3 scripts/ci-retry-signature.py \
+            --repo "${{ github.repository }}" \
+            --run-id "${{ github.event.workflow_run.id }}" \
+            --journey-artifact-prefix "nightly-extensive-android-test-reports-shard-" \
+            --out artifacts/ci-retry-signature.txt
+
+      - id: failed_jobs
+        if: steps.gate.outputs.phase == 'first_red'
+        run: |
+          failed="$(grep '^job:' artifacts/ci-retry-signature.txt | sed 's/^job://' | paste -sd ';' - | sed 's/;/; /g')"
+          echo "failed=$failed" >> "$GITHUB_OUTPUT"
+
+      - id: green
+        if: steps.gate.outputs.phase == 'first_red'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/ci-skip-check.sh \
+            --repo "${{ github.repository }}" \
+            --sha "${{ github.event.workflow_run.head_sha }}" \
+            --workflow-file nightly-extensive.yml
+
+      - name: File or update the tracking issue (first red)
+        if: steps.gate.outputs.phase == 'first_red'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/ci-nightly-extensive-red-issue.sh \
+            --repo "${{ github.repository }}" \
+            --run-url "${{ github.event.workflow_run.html_url }}/attempts/1" \
+            --sha "${{ github.event.workflow_run.head_sha }}" \
+            --last-green-sha "${{ steps.green.outputs.last_green_sha }}" \
+            --failed-jobs "${{ steps.failed_jobs.outputs.failed }}"
+
+      - name: Store the signature and trigger the one bounded retry (#2459)
+        if: steps.gate.outputs.phase == 'first_red'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/ci-retry-notify.sh store \
+            --repo "${{ github.repository }}" \
+            --marker "pocketshell-nightly-extensive-red-marker" \
+            --run-id "${{ github.event.workflow_run.id }}" \
+            --signature-file artifacts/ci-retry-signature.txt
+          gh run rerun "${{ github.event.workflow_run.id }}" --repo "${{ github.repository }}"
+
+      - name: Compare the bounded retry's outcome and classify (#2459)
+        if: steps.gate.outputs.phase == 'retry_red' || steps.gate.outputs.phase == 'retry_clean'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/ci-retry-notify.sh report \
+            --repo "${{ github.repository }}" \
+            --marker "pocketshell-nightly-extensive-red-marker" \
+            --run-id "${{ github.event.workflow_run.id }}" \
+            --original-run-url "${{ github.event.workflow_run.html_url }}/attempts/1" \
+            --retry-run-url "${{ github.event.workflow_run.html_url }}/attempts/${{ github.event.workflow_run.run_attempt }}" \
+            --retry-conclusion "${{ github.event.workflow_run.conclusion }}" \
+            --retry-signature-file "artifacts/ci-retry-signature.txt"

--- a/scripts/ci-nightly-extensive-red-issue.sh
+++ b/scripts/ci-nightly-extensive-red-issue.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# scripts/ci-nightly-extensive-red-issue.sh — issue #2459
+#
+# On a RED `Nightly Extensive Tests` run (.github/workflows/nightly-
+# extensive.yml `schedule:` trigger), file (or update) ONE tracking issue
+# with the failure signature and the bounded list of `main` commits since the
+# last known-green nightly run. Mirrors scripts/ci-red-issue.sh's pattern
+# (issue #2353) for the SCHEDULED `Tests` workflow's own red-run tracker —
+# same marker-search-then-comment-or-create shape, same "loud on gh failure"
+# discipline — but this is the workflow #2459's Scope explicitly calls out as
+# missing an equivalent notifier for ("add the equivalent for Nightly
+# Extensive Tests if it doesn't already have a red-run notifier").
+#
+# Unlike ci-red-issue.sh, this does not hardcode a fixed 4-job summary
+# (`Unit tests` / `Python` / `Integration` / `Emulator journey verdict`) —
+# nightly-extensive.yml's job names are different and its shard count is not
+# fixed at 4 keys, so the failed-job summary is a single pre-joined
+# `--failed-jobs` string the caller derives from
+# scripts/ci-retry-signature.py's `job:` lines instead.
+#
+# Run from inside the workflow's own checkout (needs full history —
+# `fetch-depth: 0` — to resolve `--last-green-sha..--sha`).
+#
+# USAGE
+#   ci-nightly-extensive-red-issue.sh
+#     --repo OWNER/NAME --run-url URL --sha SHA
+#     [--last-green-sha SHA] [--failed-jobs "name1; name2; ..."]
+#     [--gh PATH]
+#
+# Self-test: scripts/test-ci-nightly-extensive-red-issue.sh
+#
+# Exits non-zero (and says why on stderr) on any `gh` failure — a red run
+# that fails to notify must ITSELF be loud, not swallowed.
+
+set -uo pipefail
+
+TITLE="CI: scheduled Nightly Extensive Tests is red (issue #2459)"
+MARKER="pocketshell-nightly-extensive-red-marker"
+
+REPO=""
+RUN_URL=""
+SHA=""
+LAST_GREEN_SHA=""
+FAILED_JOBS=""
+GH_BIN="${POCKETSHELL_GH_BIN:-gh}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --run-url) RUN_URL="$2"; shift 2 ;;
+    --sha) SHA="$2"; shift 2 ;;
+    --last-green-sha) LAST_GREEN_SHA="$2"; shift 2 ;;
+    --failed-jobs) FAILED_JOBS="$2"; shift 2 ;;
+    --gh) GH_BIN="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$RUN_URL" || -z "$SHA" ]]; then
+  echo "usage: $0 --repo OWNER/NAME --run-url URL --sha SHA [--last-green-sha SHA] [--failed-jobs STR] [--gh PATH]" >&2
+  exit 2
+fi
+
+if ! command -v "$GH_BIN" >/dev/null 2>&1; then
+  echo "gh CLI not found ($GH_BIN) — cannot file/update the red-run tracking issue" >&2
+  exit 1
+fi
+
+commits_section="commit list unavailable (no prior known-green nightly run, or history was not fetched)"
+if [[ -n "$LAST_GREEN_SHA" ]] && git cat-file -e "${LAST_GREEN_SHA}^{commit}" 2>/dev/null; then
+  commits_section="$(git log "${LAST_GREEN_SHA}..${SHA}" --oneline 2>/dev/null)"
+  [[ -n "$commits_section" ]] || commits_section="(no commits between last-green and HEAD)"
+fi
+
+failure_summary="$FAILED_JOBS"
+[[ -n "$failure_summary" ]] || failure_summary="(no failed job names supplied; check the run directly)"
+
+last_green_line="(no prior known-green nightly run recorded)"
+[[ -n "$LAST_GREEN_SHA" ]] && last_green_line="$LAST_GREEN_SHA"
+
+body="$(cat <<BODY
+This is the standing tracking issue for a red **scheduled Nightly Extensive
+Tests** run (\`.github/workflows/nightly-extensive.yml\` \`schedule:\`
+trigger — issue #2459). Repeated red runs comment here instead of filing a
+new issue each cycle.
+
+Marker: $MARKER
+
+## Latest red run
+
+- Run: $RUN_URL
+- Commit: \`$SHA\`
+- Failed job(s): $failure_summary
+- Last known-green nightly run: \`$last_green_line\`
+
+## Bounded merge window (commits since the last known-green nightly run)
+
+\`\`\`
+$commits_section
+\`\`\`
+
+A bounded one-shot retry is automatically triggered for this run; its result
+will be posted as a follow-up comment on this issue (issue #2459).
+BODY
+)"
+
+existing=""
+existing="$("$GH_BIN" issue list --repo "$REPO" --state open \
+  --search "$MARKER in:body" --json number --limit 5 --jq '.[0].number // empty' \
+  2>/dev/null)" || existing=""
+
+if [[ -n "$existing" ]]; then
+  if ! "$GH_BIN" issue comment "$existing" --repo "$REPO" --body "$body"; then
+    echo "failed to comment on existing red-run tracking issue #$existing" >&2
+    exit 1
+  fi
+  echo "Commented on existing tracking issue #$existing"
+else
+  created=""
+  if ! created="$("$GH_BIN" issue create --repo "$REPO" --title "$TITLE" --body "$body")"; then
+    echo "failed to create the red-run tracking issue" >&2
+    exit 1
+  fi
+  echo "Created tracking issue: $created"
+fi

--- a/scripts/ci-retry-classify.sh
+++ b/scripts/ci-retry-classify.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# scripts/ci-retry-classify.sh — issue #2459
+#
+# Pure classification of a bounded retry outcome against the original red
+# run's captured failure signature (see scripts/ci-retry-signature.py for how
+# a signature is produced). No `gh`/network dependency — a deterministic
+# function of two signature files plus the retry's own conclusion, so it is
+# fully covered by scripts/test-ci-retry-classify.sh without touching the
+# GitHub API.
+#
+# SIGNATURE FILE FORMAT (see ci-retry-signature.py)
+#   Lines starting with '#' are metadata/comments, e.g. `# status=ok` or
+#   `# status=degraded:<reason>`. Every other non-blank line is a token:
+#     job:<job name>            a top-level workflow job that failed
+#     class:<Class#method>      a failing test inside a journey job
+#
+# USAGE
+#   ci-retry-classify.sh \
+#     --original-signature FILE \
+#     --retry-conclusion success|failure \
+#     [--retry-signature FILE]
+#
+# OUTPUT (stdout, KEY=VALUE, one per line — always both keys):
+#   CLASSIFICATION=infra|regression|inconclusive
+#   REASON=<free text>
+#
+# CLASSIFICATION meanings:
+#   infra         G5 "captured signature + clean re-run" case — the retry
+#                 came back clean, OR came back red with a DIFFERENT failure
+#                 signature. Do not escalate/freeze on this alone.
+#   regression    the retry reproduced the IDENTICAL non-empty failure
+#                 signature (same failed job names + same failing test
+#                 classes where applicable). This is the D36-freeze-worthy
+#                 case, now backed by two runs' evidence instead of one.
+#   inconclusive  both runs are red but the automated comparison could not be
+#                 trusted (a signature capture was degraded, or the original
+#                 signature was empty despite a healthy capture) — needs
+#                 human triage. Never silently reported as either infra or a
+#                 confirmed regression when the evidence itself is in doubt.
+#
+# If $GITHUB_OUTPUT is set, the same two keys (lowercased) are ALSO appended
+# there.
+#
+# Self-test: scripts/test-ci-retry-classify.sh
+
+set -uo pipefail
+
+ORIGINAL_SIG=""
+RETRY_CONCLUSION=""
+RETRY_SIG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --original-signature) ORIGINAL_SIG="$2"; shift 2 ;;
+    --retry-conclusion) RETRY_CONCLUSION="$2"; shift 2 ;;
+    --retry-signature) RETRY_SIG="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$ORIGINAL_SIG" || -z "$RETRY_CONCLUSION" ]]; then
+  echo "usage: $0 --original-signature FILE --retry-conclusion success|failure [--retry-signature FILE]" >&2
+  exit 2
+fi
+
+case "$RETRY_CONCLUSION" in
+  success | failure) ;;
+  *)
+    echo "--retry-conclusion must be 'success' or 'failure', got '$RETRY_CONCLUSION'" >&2
+    exit 2
+    ;;
+esac
+
+emit() {
+  local classification="$1" reason="$2"
+  printf 'CLASSIFICATION=%s\n' "$classification"
+  printf 'REASON=%s\n' "$reason"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      printf 'classification=%s\n' "$classification"
+      printf 'reason=%s\n' "$reason"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# status=<ok|degraded:...> from the trailing `# status=` comment line, and the
+# real (non-comment, non-blank) token set, sorted+deduped, from a signature
+# file. A missing file reads as an empty, degraded signature rather than
+# crashing — the classifier's job is to say "inconclusive", never to abort.
+read_status() {
+  local file="$1"
+  [[ -f "$file" ]] || { printf 'degraded:missing signature file %s' "$file"; return; }
+  local line
+  line="$(grep -m1 '^# status=' "$file" 2>/dev/null || true)"
+  if [[ -z "$line" ]]; then
+    printf 'degraded:no status line in %s' "$file"
+    return
+  fi
+  printf '%s' "${line#\# status=}"
+}
+
+read_tokens() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  grep -v '^\s*#' "$file" 2>/dev/null | grep -v '^\s*$' | LC_ALL=C sort -u
+}
+
+original_status="$(read_status "$ORIGINAL_SIG")"
+original_tokens="$(read_tokens "$ORIGINAL_SIG")"
+
+if [[ "$RETRY_CONCLUSION" == "success" ]]; then
+  emit infra "retry completed clean (conclusion=success) — G5 infra/flake, no escalation"
+  exit 0
+fi
+
+# retry-conclusion == failure from here on.
+if [[ -z "$RETRY_SIG" ]]; then
+  emit inconclusive "retry-conclusion=failure but no --retry-signature was supplied — cannot compare, needs human triage"
+  exit 0
+fi
+
+retry_status="$(read_status "$RETRY_SIG")"
+retry_tokens="$(read_tokens "$RETRY_SIG")"
+
+if [[ "$original_status" != ok || "$retry_status" != ok ]]; then
+  emit inconclusive "both runs are red but at least one signature capture was degraded (original=$original_status, retry=$retry_status) — the automated comparison cannot be trusted, needs human triage"
+  exit 0
+fi
+
+if [[ -z "$original_tokens" ]]; then
+  emit inconclusive "original run's failure signature was empty despite a healthy capture (status=ok) — cannot compare, needs human triage"
+  exit 0
+fi
+
+if [[ "$original_tokens" == "$retry_tokens" ]]; then
+  emit regression "retry reproduced the identical failure signature (same failed job(s)/class(es)) — confirmed regression, both runs cited as evidence"
+  exit 0
+fi
+
+emit infra "retry's failure signature differs from the original (different job(s)/class(es) failed, or the retry's set is a strict subset/superset) — G5 infra/flake, no escalation"

--- a/scripts/ci-retry-gate.sh
+++ b/scripts/ci-retry-gate.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/ci-retry-gate.sh — issue #2459
+#
+# Pure decision function for the bounded one-shot retry-and-compare mechanism
+# that automates the G5 ("infra/flake requires a captured signature and a
+# clean re-run") classification step for a red SCHEDULED `Tests` run or a red
+# `Nightly Extensive Tests` run.
+#
+# THE ANTI-INFINITE-LOOP MECHANISM
+#
+# `gh run rerun <run-id>` reruns the SAME workflow run — it does not create a
+# new run id, it increments that run's `run_attempt` (1 -> 2 -> ...). The
+# `workflow_run` `completed` event that fires when the rerun finishes carries
+# the SAME `github.event.workflow_run.id` and the NEW `run_attempt`. That
+# makes "is this event itself the retry's own completion" a mechanical,
+# stateless check: retries are only ever allowed to start from
+# `run_attempt == 1`. Once this script is asked to decide for
+# `run_attempt >= 2` it ALWAYS returns `RETRY_ALLOWED=false` — regardless of
+# whether that attempt is red or green — so a retry's own result can never
+# trigger a third run. This is a total function of `run_attempt` alone: no
+# external state (an issue comment, a file, a label) has to be read
+# correctly for the bound to hold, so there is no failure mode where a
+# corrupted/missing marker re-opens the loop.
+#
+# USAGE
+#   ci-retry-gate.sh --run-attempt N --conclusion success|failure
+#
+# OUTPUT (stdout, KEY=VALUE, one per line — always all three keys):
+#   PHASE=first_red | retry_red | retry_clean | noop
+#   RETRY_ALLOWED=true|false
+#   REASON=<free text>
+#
+# PHASE meanings (the caller workflow branches on this):
+#   first_red   attempt 1 concluded failure — this is a genuinely new red run.
+#               File/update the tracking issue, capture this run's failure
+#               signature, and trigger exactly one retry.
+#   retry_red   attempt >= 2 concluded failure — this IS the bounded retry,
+#               and it reproduced red. Compare its signature against the
+#               stored attempt-1 signature and classify (never retry again).
+#   retry_clean attempt >= 2 concluded success — the bounded retry came back
+#               clean. This is the G5 "clean re-run" case: classify as infra,
+#               do not retry again.
+#   noop        attempt 1 concluded success (an ordinary green scheduled run)
+#               or the attempt number could not be read at all. Nothing to
+#               do. A malformed/missing `run_attempt` fails CLOSED to noop —
+#               the safe default for a COSTLY, semi-irreversible action (an
+#               extra full-suite rerun) is to skip it, never to guess and
+#               retry anyway.
+#
+# If $GITHUB_OUTPUT is set, the same three keys (lowercased) are ALSO
+# appended there for the workflow step to consume directly.
+#
+# Self-test: scripts/test-ci-retry-gate.sh
+
+set -uo pipefail
+
+RUN_ATTEMPT=""
+CONCLUSION=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-attempt) RUN_ATTEMPT="$2"; shift 2 ;;
+    --conclusion) CONCLUSION="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$CONCLUSION" ]]; then
+  echo "usage: $0 --run-attempt N --conclusion success|failure" >&2
+  exit 2
+fi
+
+emit() {
+  local phase="$1" allowed="$2" reason="$3"
+  printf 'PHASE=%s\n' "$phase"
+  printf 'RETRY_ALLOWED=%s\n' "$allowed"
+  printf 'REASON=%s\n' "$reason"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      printf 'phase=%s\n' "$phase"
+      printf 'retry_allowed=%s\n' "$allowed"
+      printf 'reason=%s\n' "$reason"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# Fail closed to noop on a missing/non-numeric attempt: never retry on data
+# we cannot trust to be attempt 1.
+if ! [[ "$RUN_ATTEMPT" =~ ^[0-9]+$ ]] || [[ "$RUN_ATTEMPT" -lt 1 ]]; then
+  emit noop false "run_attempt was missing or not a positive integer ('$RUN_ATTEMPT') — failing closed, no retry"
+  exit 0
+fi
+
+if [[ "$RUN_ATTEMPT" -eq 1 ]]; then
+  if [[ "$CONCLUSION" == "failure" ]]; then
+    emit first_red true "attempt 1 concluded failure — a genuinely new red run, trigger the one bounded retry"
+  else
+    emit noop false "attempt 1 concluded '$CONCLUSION' — an ordinary non-red scheduled run, nothing to do"
+  fi
+  exit 0
+fi
+
+# RUN_ATTEMPT >= 2: this event IS the bounded retry's own completion (or a
+# later manual re-run of it). RETRY_ALLOWED is unconditionally false here —
+# the bound holds regardless of this attempt's own conclusion.
+if [[ "$CONCLUSION" == "failure" ]]; then
+  emit retry_red false "attempt $RUN_ATTEMPT concluded failure — this IS the bounded retry; compare signatures and classify, never retry again"
+else
+  emit retry_clean false "attempt $RUN_ATTEMPT concluded '$CONCLUSION' — the bounded retry came back clean (G5 infra/flake), never retry again"
+fi

--- a/scripts/ci-retry-notify.sh
+++ b/scripts/ci-retry-notify.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# scripts/ci-retry-notify.sh — issue #2459
+#
+# Orchestrates the two halves of the bounded retry-and-compare mechanism that
+# need to talk to the SAME marker-found tracking issue
+# (scripts/ci-red-issue.sh / a workflow-specific sibling files it) but happen
+# in two SEPARATE job invocations, potentially hours apart (the retry has to
+# finish running first):
+#
+#   store   run right after a genuinely new red run (attempt 1) is filed.
+#           Captures THIS run's failure signature as a hidden, machine-
+#           parseable comment on the tracking issue, keyed by run_id, so the
+#           later `report` call — a completely separate workflow_run event,
+#           with no in-memory state carried over — can find it again.
+#
+#   report  run when the bounded retry (attempt >= 2) itself completes.
+#           Re-finds the same tracking issue by marker, re-finds the stored
+#           attempt-1 signature by run_id, classifies via
+#           scripts/ci-retry-classify.sh (kept pure/testable on its own), and
+#           posts ONE final comment citing both run URLs and the verdict.
+#
+# USAGE
+#   ci-retry-notify.sh store \
+#     --repo OWNER/NAME --marker MARKER --run-id ID \
+#     --signature-file FILE [--gh PATH]
+#
+#   ci-retry-notify.sh report \
+#     --repo OWNER/NAME --marker MARKER --run-id ID \
+#     --original-run-url URL --retry-run-url URL \
+#     --retry-conclusion success|failure --retry-signature-file FILE \
+#     [--classify-script PATH] [--gh PATH]
+#
+# `store` exits non-zero (loud) when the tracking issue cannot be found or
+# the comment cannot be posted — a silent storage failure would make the
+# LATER `report` call blind, defeating the whole mechanism, so this must
+# fail as loudly as scripts/ci-red-issue.sh itself does on a `gh` failure.
+#
+# `report` degrades more gently: if the tracking issue has disappeared (e.g.
+# manually closed) or the stored signature cannot be found, it prints a loud
+# warning AND still runs the classifier against an empty original signature
+# (which scripts/ci-retry-classify.sh reports as `inconclusive`, never a
+# false `infra` or `regression`), so the retry's outcome is never silently
+# dropped even without anywhere to comment it.
+#
+# Self-test: scripts/test-ci-retry-notify.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLASSIFY_SCRIPT_DEFAULT="$SCRIPT_DIR/ci-retry-classify.sh"
+
+MODE="${1:-}"
+[[ "$MODE" == "store" || "$MODE" == "report" ]] && shift || true
+
+REPO=""
+MARKER=""
+RUN_ID=""
+SIGNATURE_FILE=""
+ORIGINAL_RUN_URL=""
+RETRY_RUN_URL=""
+RETRY_CONCLUSION=""
+RETRY_SIGNATURE_FILE=""
+CLASSIFY_SCRIPT="$CLASSIFY_SCRIPT_DEFAULT"
+GH_BIN="${POCKETSHELL_GH_BIN:-gh}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --marker) MARKER="$2"; shift 2 ;;
+    --run-id) RUN_ID="$2"; shift 2 ;;
+    --signature-file) SIGNATURE_FILE="$2"; shift 2 ;;
+    --original-run-url) ORIGINAL_RUN_URL="$2"; shift 2 ;;
+    --retry-run-url) RETRY_RUN_URL="$2"; shift 2 ;;
+    --retry-conclusion) RETRY_CONCLUSION="$2"; shift 2 ;;
+    --retry-signature-file) RETRY_SIGNATURE_FILE="$2"; shift 2 ;;
+    --classify-script) CLASSIFY_SCRIPT="$2"; shift 2 ;;
+    --gh) GH_BIN="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+STORE_TAG_PREFIX="pocketshell-ci-retry-signature"
+
+usage_fail() {
+  echo "usage: $0 store|report --repo O/R --marker M --run-id ID [...]" >&2
+  exit 2
+}
+
+[[ "$MODE" == "store" || "$MODE" == "report" ]] || usage_fail
+[[ -n "$REPO" && -n "$MARKER" && -n "$RUN_ID" ]] || usage_fail
+
+if ! command -v "$GH_BIN" >/dev/null 2>&1; then
+  echo "gh CLI not found ($GH_BIN) — cannot reach the tracking issue" >&2
+  exit 1
+fi
+
+find_tracking_issue() {
+  "$GH_BIN" issue list --repo "$REPO" --state open \
+    --search "$MARKER in:body" --json number --limit 5 --jq '.[0].number // empty' \
+    2>/dev/null
+}
+
+if [[ "$MODE" == "store" ]]; then
+  [[ -n "$SIGNATURE_FILE" ]] || usage_fail
+  [[ -f "$SIGNATURE_FILE" ]] || { echo "signature file not found: $SIGNATURE_FILE" >&2; exit 1; }
+
+  issue_number=""
+  issue_number="$(find_tracking_issue)" || issue_number=""
+  if [[ -z "$issue_number" ]]; then
+    echo "no open tracking issue found via marker '$MARKER' — cannot store the retry signature (the caller must file the tracking issue BEFORE calling store)" >&2
+    exit 1
+  fi
+
+  body="$(cat <<BODY
+<!-- $STORE_TAG_PREFIX run_id=$RUN_ID -->
+Stored the attempt-1 failure signature for run_id \`$RUN_ID\` so the bounded
+retry's completion can be compared against it (issue #2459).
+
+BEGIN_SIGNATURE
+$(cat "$SIGNATURE_FILE")
+END_SIGNATURE
+BODY
+)"
+
+  if ! "$GH_BIN" issue comment "$issue_number" --repo "$REPO" --body "$body"; then
+    echo "failed to store the retry signature on tracking issue #$issue_number" >&2
+    exit 1
+  fi
+  echo "Stored retry signature for run_id $RUN_ID on tracking issue #$issue_number"
+  exit 0
+fi
+
+# --- report ------------------------------------------------------------
+[[ -n "$ORIGINAL_RUN_URL" && -n "$RETRY_RUN_URL" && -n "$RETRY_CONCLUSION" ]] || usage_fail
+case "$RETRY_CONCLUSION" in
+  success | failure) ;;
+  *) echo "--retry-conclusion must be 'success' or 'failure'" >&2; exit 2 ;;
+esac
+
+issue_number=""
+issue_number="$(find_tracking_issue)" || issue_number=""
+if [[ -z "$issue_number" ]]; then
+  echo "WARNING: no open tracking issue found via marker '$MARKER' — the bounded retry for run_id $RUN_ID completed but there is nowhere to comment the verdict. Classifying anyway so this is not silently dropped from the job log." >&2
+fi
+
+original_sig_tmp="$(mktemp)"
+trap 'rm -f "$original_sig_tmp"' EXIT
+
+found_stored=0
+if [[ -n "$issue_number" ]]; then
+  comments_json=""
+  comments_json="$("$GH_BIN" issue view "$issue_number" --repo "$REPO" --json comments --jq \
+    "[.comments[] | select(.body | contains(\"$STORE_TAG_PREFIX run_id=$RUN_ID\"))] | last | .body // empty" \
+    2>/dev/null)" || comments_json=""
+  if [[ -n "$comments_json" ]]; then
+    printf '%s\n' "$comments_json" | awk '/^BEGIN_SIGNATURE$/{f=1;next}/^END_SIGNATURE$/{f=0}f' > "$original_sig_tmp"
+    if [[ -s "$original_sig_tmp" ]]; then
+      found_stored=1
+    fi
+  fi
+fi
+
+if [[ "$found_stored" -eq 0 ]]; then
+  echo "WARNING: no stored attempt-1 signature found for run_id $RUN_ID (issue ${issue_number:-none}) — classifying against an empty signature, which reports as inconclusive rather than a false infra/regression verdict." >&2
+  : > "$original_sig_tmp"
+fi
+
+classify_out=""
+classify_out="$("$CLASSIFY_SCRIPT" \
+  --original-signature "$original_sig_tmp" \
+  --retry-conclusion "$RETRY_CONCLUSION" \
+  --retry-signature "${RETRY_SIGNATURE_FILE:-/dev/null}")"
+
+classification="$(sed -n 's/^CLASSIFICATION=//p' <<<"$classify_out" | tail -n1)"
+reason="$(sed -n 's/^REASON=//p' <<<"$classify_out" | tail -n1)"
+
+echo "$classify_out"
+
+if [[ -z "$issue_number" ]]; then
+  exit 0
+fi
+
+verdict_line=""
+case "$classification" in
+  regression)
+    verdict_line="**REGRESSION CONFIRMED** — the bounded retry reproduced the identical failure signature. This is real, reproducible evidence for a D36 freeze (not a single-run guess)."
+    ;;
+  infra)
+    verdict_line="**Infra/flake (G5)** — the bounded retry did not reproduce the same failure. Not treated as blocking; not extending/triggering a freeze on this alone."
+    ;;
+  *)
+    verdict_line="**Inconclusive** — both runs are red but the automated comparison could not be trusted (see reason below). Needs human triage."
+    ;;
+esac
+
+body="$(cat <<BODY
+## Bounded retry result (issue #2459)
+
+$verdict_line
+
+- Original run: $ORIGINAL_RUN_URL
+- Retry run: $RETRY_RUN_URL
+- Classification: \`$classification\`
+- Reason: $reason
+
+This retry was automatically triggered once (bounded — the retry's own
+result is never itself retried) after the original run's failure signature
+was captured.
+BODY
+)"
+
+if ! "$GH_BIN" issue comment "$issue_number" --repo "$REPO" --body "$body"; then
+  echo "failed to post the bounded-retry verdict on tracking issue #$issue_number" >&2
+  exit 1
+fi
+echo "Posted bounded-retry verdict ($classification) on tracking issue #$issue_number"

--- a/scripts/ci-retry-signature.py
+++ b/scripts/ci-retry-signature.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""scripts/ci-retry-signature.py — issue #2459.
+
+Computes a bounded-retry failure signature for ONE workflow run: the sorted
+set of top-level job NAMES that concluded `failure`, plus (for jobs whose
+android-test-report artifact matches `--journey-artifact-prefix`) the sorted
+set of failing `Class#method` test signatures inside it. This is the "which
+jobs failed, and for the Emulator/Extensive journey jobs specifically, which
+test classes failed" comparison scripts/ci-retry-classify.sh needs to tell a
+G5 infra/flake retry apart from a confirmed regression.
+
+Deliberately reuses `emit_from_xml` from scripts/nightly-failure-recurrence.py
+(imported by file path, unmodified) for the JUnit-XML-to-`Class#method`
+normalization, instead of re-implementing test-signature parsing a second
+time — the exact vocabulary issue #2459 asks this to extend rather than
+duplicate. The artifacts this reads are the raw
+`emulator-journey-android-test-reports-shard-*` / `nightly-extensive-android-
+test-reports-shard-*` artifacts both workflows already upload per shard, no
+workflow YAML change required to produce them.
+
+FAIL-OPEN, ALWAYS. Any `gh` failure (job listing, artifact listing, artifact
+download, XML parse) degrades the affected portion of the signature rather
+than crashing this script or the caller's job — a retry-signature capture
+must never itself turn a red run into a workflow-execution failure. Overall
+capture health is recorded on a trailing `# status=ok` or
+`# status=degraded:<reason>` line so a downstream consumer (ci-retry-
+classify.sh) can refuse to trust a degraded capture instead of silently
+treating missing data as "no failures".
+
+USAGE
+  ci-retry-signature.py --repo OWNER/NAME --run-id ID
+    [--journey-artifact-prefix PREFIX]  (default: no class-level lookup)
+    [--gh PATH]                         (default: gh)
+    [--workdir DIR]                     (default: a fresh temp dir)
+    [--out FILE]                        (default: stdout only)
+
+OUTPUT (stdout, and to --out FILE when given):
+  job:<job name>            one line per failed top-level job, sorted
+  class:<Class#method>      one line per failing journey test, sorted
+  # status=ok|degraded:<reason>
+
+Self-test: scripts/test-ci-retry-signature.sh
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _load_nightly_failure_recurrence():
+    spec = importlib.util.spec_from_file_location(
+        "pocketshell_nightly_failure_recurrence",
+        SCRIPT_DIR / "nightly-failure-recurrence.py",
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("cannot load scripts/nightly-failure-recurrence.py")
+    module = importlib.util.module_from_spec(spec)
+    # Registered in sys.modules under its own name BEFORE exec: the target
+    # module uses @dataclass, whose machinery looks up
+    # sys.modules[cls.__module__] while the class body executes, and raises
+    # if the module is not registered yet.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def gh_api(gh_bin: str, repo_path: str) -> tuple[dict | list | None, str]:
+    result = subprocess.run(
+        [gh_bin, "api", repo_path],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None, (result.stderr.strip() or result.stdout.strip() or "gh api failed")
+    try:
+        return json.loads(result.stdout), ""
+    except json.JSONDecodeError as error:
+        return None, f"unparsable gh api response: {error}"
+
+
+def failed_job_names(gh_bin: str, repo: str, run_id: str) -> tuple[list[str], str]:
+    """Returns (sorted failed job names, '' on success | error reason)."""
+    data, err = gh_api(gh_bin, f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100")
+    if err:
+        return [], err
+    jobs = data.get("jobs", []) if isinstance(data, dict) else []
+    names = sorted(
+        {job.get("name", "") for job in jobs if job.get("conclusion") == "failure" and job.get("name")}
+    )
+    return names, ""
+
+
+def journey_artifact_names(gh_bin: str, repo: str, run_id: str, prefix: str) -> tuple[list[str], str]:
+    if not prefix:
+        return [], ""
+    data, err = gh_api(gh_bin, f"repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100")
+    if err:
+        return [], err
+    artifacts = data.get("artifacts", []) if isinstance(data, dict) else []
+    names = sorted(
+        {a.get("name", "") for a in artifacts if a.get("name", "").startswith(prefix)}
+    )
+    return names, ""
+
+
+def download_artifact(gh_bin: str, repo: str, run_id: str, name: str, dest_dir: Path) -> bool:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        [gh_bin, "run", "download", str(run_id), "--repo", repo, "-n", name, "-D", str(dest_dir)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def failing_journey_classes(
+    gh_bin: str,
+    repo: str,
+    run_id: str,
+    prefix: str,
+    workdir: Path,
+) -> tuple[list[str], bool]:
+    """Returns (sorted 'Class#method' signatures, degraded).
+
+    `degraded` is True only when the ARTIFACT LISTING call itself failed —
+    an individual shard artifact that fails to download, or an artifact with
+    no XML inside it, best-effort-skips instead of degrading the whole
+    capture (a shard with genuinely zero failing tests looks the same as a
+    shard whose artifact could not be fetched, and biasing toward
+    "signature differs" -> infra rather than a false regression confirmation
+    is the intentional, safety-first asymmetry here).
+    """
+    names, err = journey_artifact_names(gh_bin, repo, run_id, prefix)
+    if err:
+        return [], True
+    if not names:
+        return [], False
+
+    nfr = _load_nightly_failure_recurrence()
+    signatures: set[str] = set()
+    for name in names:
+        dest = workdir / name
+        if not download_artifact(gh_bin, repo, run_id, name, dest):
+            continue
+        try:
+            found = nfr.emit_from_xml(dest)
+        except nfr.RecurrenceError:
+            continue
+        signatures.update(found.keys())
+    return sorted(signatures), False
+
+
+def build_signature(
+    gh_bin: str,
+    repo: str,
+    run_id: str,
+    journey_artifact_prefix: str,
+    workdir: Path,
+) -> str:
+    lines: list[str] = []
+    jobs, job_err = failed_job_names(gh_bin, repo, run_id)
+    for name in jobs:
+        lines.append(f"job:{name}")
+
+    class_degraded = False
+    if journey_artifact_prefix:
+        classes, class_degraded = failing_journey_classes(
+            gh_bin, repo, run_id, journey_artifact_prefix, workdir
+        )
+        for sig in classes:
+            lines.append(f"class:{sig}")
+
+    if job_err:
+        status = f"degraded:job listing failed ({job_err})"
+    elif class_degraded:
+        status = "degraded:journey artifact listing failed"
+    else:
+        status = "ok"
+    lines.append(f"# status={status}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--journey-artifact-prefix", default="")
+    parser.add_argument("--gh", default="gh")
+    parser.add_argument("--workdir", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    workdir = args.workdir
+    cleanup = False
+    if workdir is None:
+        workdir = Path(tempfile.mkdtemp(prefix="ci-retry-signature-"))
+        cleanup = True
+
+    signature = build_signature(args.gh, args.repo, args.run_id, args.journey_artifact_prefix, workdir)
+
+    sys.stdout.write(signature)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(signature, encoding="utf-8")
+
+    if cleanup:
+        import shutil
+
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-ci-cadence.sh
+++ b/scripts/test-ci-cadence.sh
@@ -9,9 +9,22 @@
 #   scripts/test-ci-plan.sh       — scripts/ci-plan.sh
 #   scripts/test-ci-red-issue.sh  — scripts/ci-red-issue.sh
 #   scripts/test-ci-run-jobs.sh   — scripts/ci-run-jobs.sh
+#
+# Issue #2459 adds the bounded retry-and-compare self-tests here too (same
+# rationale — one short `run:` line under tests.yml's file-size ratchet):
+#   scripts/test-ci-retry-gate.sh               — scripts/ci-retry-gate.sh
+#   scripts/test-ci-retry-classify.sh            — scripts/ci-retry-classify.sh
+#   scripts/test-ci-retry-signature.sh           — scripts/ci-retry-signature.py
+#   scripts/test-ci-retry-notify.sh              — scripts/ci-retry-notify.sh
+#   scripts/test-ci-nightly-extensive-red-issue.sh — scripts/ci-nightly-extensive-red-issue.sh
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 "$SCRIPT_DIR/test-ci-skip-check.sh"
 "$SCRIPT_DIR/test-ci-plan.sh"
 "$SCRIPT_DIR/test-ci-red-issue.sh"
 "$SCRIPT_DIR/test-ci-run-jobs.sh"
+"$SCRIPT_DIR/test-ci-retry-gate.sh"
+"$SCRIPT_DIR/test-ci-retry-classify.sh"
+"$SCRIPT_DIR/test-ci-retry-signature.sh"
+"$SCRIPT_DIR/test-ci-retry-notify.sh"
+"$SCRIPT_DIR/test-ci-nightly-extensive-red-issue.sh"

--- a/scripts/test-ci-nightly-extensive-red-issue.sh
+++ b/scripts/test-ci-nightly-extensive-red-issue.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci-nightly-extensive-red-issue.sh (issue #2459).
+#
+# Mirrors scripts/test-ci-red-issue.sh's shape (stubbed `gh`, throwaway git
+# repo with real commits, exact-args capture) for the Nightly Extensive
+# Tests sibling tracker. Covers: no existing tracking issue => create with
+# the bounded commit range + failed-job summary; an existing open issue
+# found via the marker search => comment (never a second create); a missing
+# --failed-jobs value is reported honestly rather than invented; a failed
+# search still creates rather than silently dropping the notification; and a
+# failed `gh` call (create, or the binary missing) surfaces as a loud
+# non-zero exit.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/ci-nightly-extensive-red-issue.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass_count=0
+pass() { pass_count=$((pass_count + 1)); echo "PASS: $*"; }
+
+[[ -f "$TARGET" ]] || fail "target script not found: $TARGET"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/bin"
+
+git init --quiet "$SANDBOX/repo"
+git -C "$SANDBOX/repo" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "commit A (last green)"
+sha_a="$(git -C "$SANDBOX/repo" rev-parse HEAD)"
+git -C "$SANDBOX/repo" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "commit B"
+git -C "$SANDBOX/repo" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m "commit C (red)"
+sha_c="$(git -C "$SANDBOX/repo" rev-parse HEAD)"
+
+# $1 = the issue number `issue list` should report as already-existing (empty
+#      string = none found, so the target must create a new one).
+write_fake_gh() {
+  local existing="$1"
+  cat > "$SANDBOX/bin/gh" <<FAKEGH
+#!/usr/bin/env bash
+n=\$(( \$(cat "$SANDBOX/call-count.txt" 2>/dev/null || echo 0) + 1 ))
+echo "\$n" > "$SANDBOX/call-count.txt"
+printf '%s\0' "\$@" > "$SANDBOX/call-\$n.args"
+if [[ "\${FAKE_GH_ISSUE_LIST_FAIL:-}" == "1" && "\$1 \$2" == "issue list" ]]; then exit 1; fi
+if [[ "\${FAKE_GH_CREATE_FAIL:-}" == "1" && "\$1 \$2" == "issue create" ]]; then exit 1; fi
+case "\$1 \$2" in
+  "issue list") echo '$existing' ;;
+  "issue comment") echo "commented" ;;
+  "issue create") echo "https://github.com/owner/repo/issues/999" ;;
+esac
+FAKEGH
+  chmod +x "$SANDBOX/bin/gh"
+}
+
+read_call_args() {
+  local _rca_n="$1" _rca_outvar="$2"
+  local -a _rca_accum=()
+  local _rca_a
+  while IFS= read -r -d '' _rca_a; do
+    _rca_accum+=("$_rca_a")
+  done < "$SANDBOX/call-$_rca_n.args"
+  eval "$_rca_outvar=(\"\${_rca_accum[@]}\")"
+}
+
+arg_value_after() {
+  local n="$1" flag="$2"
+  local -a args=()
+  read_call_args "$n" args
+  local i
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "$flag" ]]; then
+      printf '%s' "${args[$((i + 1))]}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+reset_sandbox_calls() { rm -f "$SANDBOX"/call-*.args "$SANDBOX/call-count.txt"; }
+
+# -----------------------------------------------------------------------
+# 1. No existing tracking issue => creates one with the real commit window
+#    (commit A excluded, B/C included) and the supplied failed-job summary.
+reset_sandbox_calls
+write_fake_gh ""
+out="$(cd "$SANDBOX/repo" && PATH="$SANDBOX/bin:$PATH" "$TARGET" \
+  --repo owner/repo \
+  --run-url "https://github.com/owner/repo/actions/runs/123" \
+  --sha "$sha_c" \
+  --last-green-sha "$sha_a" \
+  --failed-jobs "Extensive journey/E2E + network-fault + bootstrap (shard 2)" 2>&1)"
+echo "$out" | grep -q "Created tracking issue" || fail "expected a create when no existing issue is found: $out"
+calls="$(cat "$SANDBOX/call-count.txt")"
+[[ "$calls" -eq 2 ]] || fail "expected exactly 2 gh calls (list, create), got $calls"
+create_body="$(arg_value_after 2 --body)" || fail "create call must carry --body"
+echo "$create_body" | grep -q "commit B" || fail "created body must include commit B"
+echo "$create_body" | grep -q "commit C (red)" || fail "created body must include commit C"
+echo "$create_body" | grep -q "commit A (last green)" && fail "created body must NOT include commit A (the last-green boundary, excluded by a..b)"
+echo "$create_body" | grep -q "Extensive journey/E2E" || fail "created body must name the failed journey shard"
+echo "$create_body" | grep -q "pocketshell-nightly-extensive-red-marker" || fail "created body must include the stable marker"
+pass "no existing issue creates a new tracking issue with the real bounded commit range and the supplied failed-job summary"
+
+# -----------------------------------------------------------------------
+# 2. Existing open issue found => comments on it, never creates.
+reset_sandbox_calls
+write_fake_gh "42"
+out="$(cd "$SANDBOX/repo" && PATH="$SANDBOX/bin:$PATH" "$TARGET" \
+  --repo owner/repo --run-url "https://github.com/owner/repo/actions/runs/124" \
+  --sha "$sha_c" 2>&1)"
+echo "$out" | grep -q "Commented on existing tracking issue #42" || fail "expected a comment on the existing issue: $out"
+calls="$(cat "$SANDBOX/call-count.txt")"
+[[ "$calls" -eq 2 ]] || fail "expected exactly 2 gh calls (list, comment), got $calls"
+read_call_args 2 comment_args
+[[ "${comment_args[2]}" == "42" ]] || fail "must comment on issue #42, args were: ${comment_args[*]}"
+comment_body="$(arg_value_after 2 --body)" || fail "comment call must carry --body"
+echo "$comment_body" | grep -q "no prior known-green nightly run recorded" || fail "missing last-green sha must be reported honestly"
+echo "$comment_body" | grep -q "commit list unavailable" || fail "missing last-green sha must report an unavailable commit list, not invented content"
+echo "$comment_body" | grep -q "no failed job names supplied" || fail "missing --failed-jobs must be reported honestly, not invented"
+pass "existing open issue found by marker search gets a comment, not a new issue; missing last-green/failed-jobs are reported honestly"
+
+# -----------------------------------------------------------------------
+# 3. gh issue list fails => still falls through to creating (fail toward
+#    over-notifying, never silently drops the red-run signal).
+reset_sandbox_calls
+write_fake_gh ""
+out="$(cd "$SANDBOX/repo" && PATH="$SANDBOX/bin:$PATH" FAKE_GH_ISSUE_LIST_FAIL=1 "$TARGET" \
+  --repo owner/repo --run-url "u" --sha "$sha_c" 2>&1)"
+echo "$out" | grep -q "Created tracking issue" || fail "a failed search must still result in a create (never silently drop the notification): $out"
+pass "a failed issue-list search still creates a tracking issue rather than dropping the notification"
+
+# -----------------------------------------------------------------------
+# 4. gh issue create fails => the step is loud (non-zero exit, clear message).
+reset_sandbox_calls
+write_fake_gh ""
+set +e
+out="$(cd "$SANDBOX/repo" && PATH="$SANDBOX/bin:$PATH" FAKE_GH_CREATE_FAIL=1 "$TARGET" \
+  --repo owner/repo --run-url "u" --sha "$sha_c" 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "a failed gh issue create must exit non-zero"
+echo "$out" | grep -qi "failed to create" || fail "a failed gh issue create must say so: $out"
+pass "a failed gh issue create surfaces loudly"
+
+# -----------------------------------------------------------------------
+# 5. gh CLI missing entirely => loud non-zero exit.
+set +e
+out="$(bash "$TARGET" --repo owner/repo --run-url "u" --sha "$sha_c" --gh does-not-exist-gh-binary-xyz 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "missing gh must exit non-zero"
+echo "$out" | grep -qi "gh CLI not found" || fail "missing gh must say so: $out"
+pass "missing gh CLI surfaces loudly"
+
+# -----------------------------------------------------------------------
+# 6. missing required arguments => usage error, exit 2.
+set +e
+bash "$TARGET" --repo owner/repo >/dev/null 2>&1
+rc=$?
+set -e
+[[ "$rc" -eq 2 ]] || fail "missing required arguments must exit 2, got $rc"
+pass "missing required arguments exits 2"
+
+echo "OK: $pass_count self-test case(s) passed."

--- a/scripts/test-ci-retry-classify.sh
+++ b/scripts/test-ci-retry-classify.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci-retry-classify.sh (issue #2459).
+#
+# Pure/no-`gh` classification-table test, covering acceptance criterion #6:
+# a synthetic clean-retry case (classified infra) and a synthetic
+# same-signature-retry case (classified regression), plus the
+# differing-signature, degraded-capture, empty-original, and missing-file
+# edges.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/ci-retry-classify.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass_count=0
+pass() { pass_count=$((pass_count + 1)); echo "PASS: $*"; }
+
+[[ -f "$TARGET" ]] || fail "target script not found: $TARGET"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+write_sig() {
+  # $1 = path, $2 = status (ok|degraded:...), $3.. = token lines
+  local path="$1" status="$2"
+  shift 2
+  : > "$path"
+  local line
+  for line in "$@"; do
+    printf '%s\n' "$line" >> "$path"
+  done
+  printf '# status=%s\n' "$status" >> "$path"
+}
+
+run_classify() {
+  CLASSIFY_OUT="$("$TARGET" "$@" 2>&1)"
+  CLASSIFY_RC=$?
+  CLASSIFICATION="$(sed -n 's/^CLASSIFICATION=//p' <<<"$CLASSIFY_OUT" | tail -n1)"
+}
+
+# -----------------------------------------------------------------------
+# AC#6 case A: synthetic CLEAN retry -> infra, no escalation.
+orig="$SANDBOX/orig-a.txt"
+write_sig "$orig" ok "job:Emulator journey subset (load-bearing, Docker agents) (2)" \
+  "class:com.pocketshell.app.hosts.ReconnectJourneyE2eTest#reconnectAfterBackground"
+run_classify --original-signature "$orig" --retry-conclusion success
+[[ "$CLASSIFY_RC" -eq 0 ]] || fail "clean-retry case: exited $CLASSIFY_RC: $CLASSIFY_OUT"
+[[ "$CLASSIFICATION" == "infra" ]] || fail "clean-retry case: expected infra, got $CLASSIFICATION: $CLASSIFY_OUT"
+pass "AC6 case A: a clean retry (conclusion=success) classifies as infra, never regression"
+
+# -----------------------------------------------------------------------
+# AC#6 case B: synthetic SAME-SIGNATURE retry -> regression, both cited.
+retry_same="$SANDBOX/retry-same.txt"
+write_sig "$retry_same" ok "job:Emulator journey subset (load-bearing, Docker agents) (2)" \
+  "class:com.pocketshell.app.hosts.ReconnectJourneyE2eTest#reconnectAfterBackground"
+run_classify --original-signature "$orig" --retry-conclusion failure --retry-signature "$retry_same"
+[[ "$CLASSIFY_RC" -eq 0 ]] || fail "same-signature case: exited $CLASSIFY_RC: $CLASSIFY_OUT"
+[[ "$CLASSIFICATION" == "regression" ]] || fail "same-signature case: expected regression, got $CLASSIFICATION: $CLASSIFY_OUT"
+echo "$CLASSIFY_OUT" | grep -qi "confirmed regression" || fail "same-signature case: reason must say confirmed regression: $CLASSIFY_OUT"
+pass "AC6 case B: an identical-signature retry classifies as regression"
+
+# -----------------------------------------------------------------------
+# Differing signature -> infra (not regression, not silently dropped).
+retry_diff="$SANDBOX/retry-diff.txt"
+write_sig "$retry_diff" ok "job:Python utility tests (pocketshell)"
+run_classify --original-signature "$orig" --retry-conclusion failure --retry-signature "$retry_diff"
+[[ "$CLASSIFICATION" == "infra" ]] || fail "differing-signature case: expected infra, got $CLASSIFICATION: $CLASSIFY_OUT"
+pass "a red retry with a DIFFERENT failure signature classifies as infra, not regression"
+
+# -----------------------------------------------------------------------
+# Subset/superset signature (still technically "differs") -> infra, not a
+# false regression confirmation.
+retry_subset="$SANDBOX/retry-subset.txt"
+write_sig "$retry_subset" ok "job:Emulator journey subset (load-bearing, Docker agents) (2)"
+run_classify --original-signature "$orig" --retry-conclusion failure --retry-signature "$retry_subset"
+[[ "$CLASSIFICATION" == "infra" ]] || fail "subset-signature case: expected infra, got $CLASSIFICATION: $CLASSIFY_OUT"
+pass "a red retry whose failing set is a strict subset of the original classifies as infra, not a false regression"
+
+# -----------------------------------------------------------------------
+# Degraded capture on either side -> inconclusive, never a confident verdict.
+retry_degraded="$SANDBOX/retry-degraded.txt"
+write_sig "$retry_degraded" "degraded:journey artifact listing failed" \
+  "job:Emulator journey subset (load-bearing, Docker agents) (2)"
+run_classify --original-signature "$orig" --retry-conclusion failure --retry-signature "$retry_degraded"
+[[ "$CLASSIFICATION" == "inconclusive" ]] || fail "degraded-retry case: expected inconclusive, got $CLASSIFICATION: $CLASSIFY_OUT"
+pass "a degraded retry-signature capture classifies as inconclusive, not infra or regression"
+
+orig_degraded="$SANDBOX/orig-degraded.txt"
+write_sig "$orig_degraded" "degraded:job listing failed" "job:Unit tests"
+run_classify --original-signature "$orig_degraded" --retry-conclusion failure --retry-signature "$retry_same"
+[[ "$CLASSIFICATION" == "inconclusive" ]] || fail "degraded-original case: expected inconclusive, got $CLASSIFICATION: $CLASSIFY_OUT"
+pass "a degraded original-signature capture also classifies as inconclusive"
+
+# -----------------------------------------------------------------------
+# Empty original signature despite status=ok -> inconclusive (cannot claim
+# either verdict off nothing).
+orig_empty="$SANDBOX/orig-empty.txt"
+write_sig "$orig_empty" ok
+run_classify --original-signature "$orig_empty" --retry-conclusion failure --retry-signature "$retry_same"
+[[ "$CLASSIFICATION" == "inconclusive" ]] || fail "empty-original case: expected inconclusive, got $CLASSIFICATION: $CLASSIFY_OUT"
+pass "an empty (but status=ok) original signature classifies as inconclusive rather than guessing"
+
+# -----------------------------------------------------------------------
+# retry-conclusion=failure with no --retry-signature supplied at all ->
+# inconclusive, not a crash.
+run_classify --original-signature "$orig" --retry-conclusion failure
+[[ "$CLASSIFY_RC" -eq 0 ]] || fail "missing retry-signature case: exited $CLASSIFY_RC: $CLASSIFY_OUT"
+[[ "$CLASSIFICATION" == "inconclusive" ]] || fail "missing retry-signature case: expected inconclusive, got $CLASSIFICATION: $CLASSIFY_OUT"
+pass "retry-conclusion=failure with no --retry-signature classifies as inconclusive instead of crashing"
+
+# -----------------------------------------------------------------------
+# Missing required arguments -> usage error, exit 2.
+set +e
+"$TARGET" --original-signature "$orig" >/dev/null 2>&1
+rc=$?
+set -e
+[[ "$rc" -eq 2 ]] || fail "missing --retry-conclusion must exit 2, got $rc"
+pass "missing required argument exits 2"
+
+# -----------------------------------------------------------------------
+# Invalid --retry-conclusion value -> usage error, exit 2.
+set +e
+"$TARGET" --original-signature "$orig" --retry-conclusion bogus >/dev/null 2>&1
+rc=$?
+set -e
+[[ "$rc" -eq 2 ]] || fail "invalid --retry-conclusion must exit 2, got $rc"
+pass "invalid --retry-conclusion value exits 2"
+
+echo "OK: $pass_count self-test case(s) passed."

--- a/scripts/test-ci-retry-gate.sh
+++ b/scripts/test-ci-retry-gate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci-retry-gate.sh (issue #2459).
+#
+# Pure/no-`gh` decision table covering every PHASE branch, PLUS the
+# acceptance-criterion #5 proof: no matter how many times the retry's OWN
+# result is red (attempt 2, 3, 4, ...), RETRY_ALLOWED is never true again —
+# a retry can never trigger a second retry.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/ci-retry-gate.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass_count=0
+pass() { pass_count=$((pass_count + 1)); echo "PASS: $*"; }
+
+[[ -f "$TARGET" ]] || fail "target script not found: $TARGET"
+
+run_gate() {
+  GATE_OUT="$("$TARGET" --run-attempt "$1" --conclusion "$2" 2>&1)"
+  GATE_RC=$?
+  GATE_PHASE="$(sed -n 's/^PHASE=//p' <<<"$GATE_OUT" | tail -n1)"
+  GATE_ALLOWED="$(sed -n 's/^RETRY_ALLOWED=//p' <<<"$GATE_OUT" | tail -n1)"
+}
+
+assert_gate() {
+  local label="$1" attempt="$2" conclusion="$3" phase="$4" allowed="$5"
+  run_gate "$attempt" "$conclusion"
+  [[ "$GATE_RC" -eq 0 ]] || { echo "$GATE_OUT"; fail "$label: exited $GATE_RC"; }
+  [[ "$GATE_PHASE" == "$phase" ]] || { echo "$GATE_OUT"; fail "$label: phase=$GATE_PHASE, expected $phase"; }
+  [[ "$GATE_ALLOWED" == "$allowed" ]] || { echo "$GATE_OUT"; fail "$label: retry_allowed=$GATE_ALLOWED, expected $allowed"; }
+  pass "$label"
+}
+
+# 1. Attempt 1, red -> the one genuinely-new-red case: retry IS allowed.
+assert_gate "attempt 1 + failure -> first_red, retry allowed" 1 failure first_red true
+
+# 2. Attempt 1, green -> ordinary scheduled pass, nothing to do.
+assert_gate "attempt 1 + success -> noop, no retry" 1 success noop false
+
+# 3. Attempt 2, red -> this IS the bounded retry's own red result. Must
+#    NEVER allow another retry (the core anti-infinite-loop assertion).
+assert_gate "attempt 2 + failure -> retry_red, retry NOT allowed" 2 failure retry_red false
+
+# 4. Attempt 2, green -> the bounded retry came back clean.
+assert_gate "attempt 2 + success -> retry_clean, retry NOT allowed" 2 success retry_clean false
+
+# 5. Acceptance criterion #5: a retry's own red result never triggers a
+#    THIRD run. Exercise attempts 3..10, always red, and assert every single
+#    one refuses to allow a further retry — proving the bound holds no
+#    matter how many times a human/automation later re-runs it again.
+for attempt in 3 4 5 10; do
+  assert_gate "attempt $attempt + failure -> never re-triggers (bounded)" "$attempt" failure retry_red false
+done
+
+# 6. Missing/blank run-attempt fails CLOSED to noop (never retries on data it
+#    cannot trust to be attempt 1).
+assert_gate "missing run-attempt -> noop, fails closed" "" failure noop false
+
+# 7. Non-numeric run-attempt also fails closed.
+assert_gate "non-numeric run-attempt -> noop, fails closed" "not-a-number" failure noop false
+
+# 8. Zero/negative run-attempt (should never happen from the real webhook,
+#    but a malformed value must still fail closed rather than being treated
+#    as attempt 1).
+assert_gate "run-attempt=0 -> noop, fails closed" 0 failure noop false
+
+# 9. $GITHUB_OUTPUT mirrors the three keys (lowercased).
+gh_out="$(mktemp)"
+trap 'rm -f "$gh_out"' EXIT
+GITHUB_OUTPUT="$gh_out" "$TARGET" --run-attempt 1 --conclusion failure >/dev/null
+grep -qx "phase=first_red" "$gh_out" || fail "GITHUB_OUTPUT must mirror phase: $(cat "$gh_out")"
+grep -qx "retry_allowed=true" "$gh_out" || fail "GITHUB_OUTPUT must mirror retry_allowed: $(cat "$gh_out")"
+pass "GITHUB_OUTPUT mirrors phase/retry_allowed/reason"
+
+# 10. Missing required argument exits 2.
+set +e
+"$TARGET" --run-attempt 1 >/dev/null 2>&1
+rc=$?
+set -e
+[[ "$rc" -eq 2 ]] || fail "missing --conclusion must exit 2, got $rc"
+pass "missing required argument exits 2"
+
+echo "OK: $pass_count self-test case(s) passed."

--- a/scripts/test-ci-retry-notify.sh
+++ b/scripts/test-ci-retry-notify.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci-retry-notify.sh (issue #2459).
+#
+# Stubs `gh` on PATH — no network, no real repo. Covers: `store` finds the
+# marker-matched open issue and comments the raw signature keyed by run_id;
+# `store` fails LOUDLY (non-zero) when no tracking issue can be found (a
+# silent storage failure would blind the later `report` call); `report`
+# re-finds the stored signature by run_id and correctly classifies both a
+# clean retry (infra) and an identical-signature retry (regression), posting
+# a comment citing both run URLs each time; `report` degrades gracefully
+# (loud warning, still classifies as inconclusive, exits 0) when the tracking
+# issue or the stored signature cannot be found.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/ci-retry-notify.sh"
+CLASSIFY="$SCRIPT_DIR/ci-retry-classify.sh"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass_count=0
+pass() { pass_count=$((pass_count + 1)); echo "PASS: $*"; }
+
+[[ -f "$TARGET" ]] || fail "target script not found: $TARGET"
+[[ -f "$CLASSIFY" ]] || fail "dependency not found: $CLASSIFY"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/bin"
+
+STATE_DIR="$SANDBOX/gh-state"
+mkdir -p "$STATE_DIR"
+
+# $1 = issue number to report as found by marker search ("" = none found)
+# Comments already "posted" accumulate under $STATE_DIR/comments-<n>.txt so
+# a later `report` call's marker-search can be fed by an earlier `store`
+# call's write, and assertions can inspect exactly what was posted.
+#
+# `gh issue view --json comments --jq EXPR` needs jq-like filtering: the
+# target script calls `gh issue view N --repo R --json comments --jq EXPR`
+# and expects `gh` itself to apply --jq. This fake emulates the ONE jq
+# expression the target actually uses (`select(.body | contains("...")) |
+# last | .body // empty`) directly in Python rather than depending on a
+# system `jq` binary.
+write_fake_gh_with_jq() {
+  local existing="$1"
+  cat > "$SANDBOX/bin/gh" <<FAKEGH
+#!/usr/bin/env bash
+state="$STATE_DIR"
+if [[ "\$1 \$2" == "issue list" ]]; then
+  echo '$existing'
+  exit 0
+fi
+if [[ "\$1 \$2" == "issue view" ]]; then
+  number="\$3"
+  # Extract the --jq expression (always the last arg in this target's calls).
+  jq_expr="\${@: -1}"
+  file="\$state/comments-\$number.txt"
+  python3 - "\$file" "\$jq_expr" <<'PYEOF'
+import sys
+path, jq_expr = sys.argv[1], sys.argv[2]
+try:
+    text = open(path, "r", encoding="utf-8").read()
+    bodies = [b for b in text.split("\x00") if b]
+except FileNotFoundError:
+    bodies = []
+needle = None
+if "contains(\"" in jq_expr:
+    needle = jq_expr.split("contains(\"", 1)[1].split("\")", 1)[0]
+matches = [b for b in bodies if (needle is None or needle in b)]
+print(matches[-1] if matches else "")
+PYEOF
+  exit 0
+fi
+if [[ "\$1 \$2" == "issue comment" ]]; then
+  number="\$3"
+  body="\${@: -1}"
+  printf '%s\x00' "\$body" >> "\$state/comments-\$number.txt"
+  echo "commented on #\$number"
+  exit 0
+fi
+echo "unhandled fake gh invocation: \$*" >&2
+exit 1
+FAKEGH
+  chmod +x "$SANDBOX/bin/gh"
+}
+
+reset_state() { rm -rf "$STATE_DIR"; mkdir -p "$STATE_DIR"; }
+
+sig_clean="$SANDBOX/sig-orig.txt"
+printf 'job:Unit tests\nclass:com.foo.BarTest#baz\n# status=ok\n' > "$sig_clean"
+sig_same="$SANDBOX/sig-same.txt"
+printf 'job:Unit tests\nclass:com.foo.BarTest#baz\n# status=ok\n' > "$sig_same"
+
+# -----------------------------------------------------------------------
+# 1. store: no open tracking issue found -> loud non-zero failure (never
+#    silently blind the later report call).
+reset_state
+write_fake_gh_with_jq ""
+set +e
+out="$(PATH="$SANDBOX/bin:$PATH" "$TARGET" store --repo owner/repo --marker MARK --run-id 99 --signature-file "$sig_clean" 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "store with no tracking issue found must fail loudly: $out"
+echo "$out" | grep -qi "cannot store" || fail "store failure must say why: $out"
+pass "store fails loudly when no marker-matched tracking issue exists"
+
+# -----------------------------------------------------------------------
+# 2. store: issue #42 found -> comments the signature, tagged with run_id.
+reset_state
+write_fake_gh_with_jq "42"
+out="$(PATH="$SANDBOX/bin:$PATH" "$TARGET" store --repo owner/repo --marker MARK --run-id 99 --signature-file "$sig_clean" 2>&1)"
+echo "$out" | grep -q "Stored retry signature for run_id 99 on tracking issue #42" || fail "store must confirm the stored issue number: $out"
+grep -q "run_id=99" "$STATE_DIR/comments-42.txt" || fail "stored comment must be tagged with run_id=99"
+grep -q "job:Unit tests" "$STATE_DIR/comments-42.txt" || fail "stored comment must carry the raw signature"
+pass "store finds the marker-matched issue and comments the run_id-tagged signature"
+
+# -----------------------------------------------------------------------
+# 3. report (clean retry): after the store above, a clean retry classifies
+#    infra, posts a comment citing both run URLs.
+out="$(PATH="$SANDBOX/bin:$PATH" "$TARGET" report --repo owner/repo --marker MARK --run-id 99 \
+  --original-run-url "https://x/runs/1/attempts/1" \
+  --retry-run-url "https://x/runs/1/attempts/2" \
+  --retry-conclusion success \
+  --classify-script "$CLASSIFY" 2>&1)"
+echo "$out" | grep -q "CLASSIFICATION=infra" || fail "clean retry must classify infra: $out"
+echo "$out" | grep -q "Posted bounded-retry verdict (infra) on tracking issue #42" || fail "must post the verdict comment: $out"
+grep -q "https://x/runs/1/attempts/1" "$STATE_DIR/comments-42.txt" || fail "verdict comment must cite the original run URL"
+grep -q "https://x/runs/1/attempts/2" "$STATE_DIR/comments-42.txt" || fail "verdict comment must cite the retry run URL"
+grep -qi "not extending" "$STATE_DIR/comments-42.txt" || fail "an infra verdict must say it is not extending/triggering a freeze"
+pass "report classifies a clean retry as infra and cites both run URLs on the tracking issue"
+
+# -----------------------------------------------------------------------
+# 4. report (same-signature retry): a fresh store + report round for a
+#    DIFFERENT run_id classifies regression.
+reset_state
+write_fake_gh_with_jq "77"
+PATH="$SANDBOX/bin:$PATH" "$TARGET" store --repo owner/repo --marker MARK --run-id 200 --signature-file "$sig_clean" >/dev/null
+out="$(PATH="$SANDBOX/bin:$PATH" "$TARGET" report --repo owner/repo --marker MARK --run-id 200 \
+  --original-run-url "https://x/runs/2/attempts/1" \
+  --retry-run-url "https://x/runs/2/attempts/2" \
+  --retry-conclusion failure \
+  --retry-signature-file "$sig_same" \
+  --classify-script "$CLASSIFY" 2>&1)"
+echo "$out" | grep -q "CLASSIFICATION=regression" || fail "identical-signature retry must classify regression: $out"
+echo "$out" | grep -q "Posted bounded-retry verdict (regression) on tracking issue #77" || fail "must post the regression verdict: $out"
+grep -qi "REGRESSION CONFIRMED" "$STATE_DIR/comments-77.txt" || fail "regression verdict must be clearly flagged"
+grep -q "https://x/runs/2/attempts/1" "$STATE_DIR/comments-77.txt" || fail "regression verdict must cite the original run URL"
+grep -q "https://x/runs/2/attempts/2" "$STATE_DIR/comments-77.txt" || fail "regression verdict must cite the retry run URL"
+pass "report classifies an identical-signature retry as regression and cites both run URLs as confirming evidence"
+
+# -----------------------------------------------------------------------
+# 5. report: tracking issue vanished (no marker match) -> loud warning,
+#    still classifies (inconclusive, since there's no stored signature to
+#    compare against), exits 0 rather than crashing the retry-completion job.
+reset_state
+write_fake_gh_with_jq ""
+set +e
+out="$(PATH="$SANDBOX/bin:$PATH" "$TARGET" report --repo owner/repo --marker MARK --run-id 300 \
+  --original-run-url "https://x/runs/3/attempts/1" \
+  --retry-run-url "https://x/runs/3/attempts/2" \
+  --retry-conclusion failure \
+  --retry-signature-file "$sig_same" \
+  --classify-script "$CLASSIFY" 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -eq 0 ]] || fail "report must not crash the job when the tracking issue is missing: $out (rc=$rc)"
+echo "$out" | grep -qi "WARNING.*no open tracking issue" || fail "report must warn loudly when the tracking issue is missing: $out"
+echo "$out" | grep -q "CLASSIFICATION=inconclusive" || fail "with no stored signature to compare, must classify inconclusive, not a guess: $out"
+pass "report degrades gracefully (loud warning, inconclusive, exit 0) when the tracking issue cannot be found"
+
+echo "OK: $pass_count self-test case(s) passed."

--- a/scripts/test-ci-retry-signature.sh
+++ b/scripts/test-ci-retry-signature.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ci-retry-signature.py (issue #2459).
+#
+# Stubs `gh` on PATH so this runs with no network, no real repo, no
+# authentication — `gh api` calls return canned JSON, and `gh run download`
+# writes canned JUnit XML fixtures into the requested destination directory
+# (exactly what the real `gh run download` would do, just deterministic).
+# Exercises: job-level failure names, class-level failure names extracted
+# from journey-prefixed artifacts via the REAL
+# scripts/nightly-failure-recurrence.py `emit_from_xml` (imported, not
+# reimplemented), union-across-shards + dedup, a shard artifact with no
+# failing XML (silently skipped, not degraded), a failed jobs-listing call
+# (status=degraded, class-level lookup still attempted independently), a
+# failed artifacts-listing call (status=degraded), and the --out file mirror.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/ci-retry-signature.py"
+
+fail() { echo "TEST FAIL: $*" >&2; exit 1; }
+pass_count=0
+pass() { pass_count=$((pass_count + 1)); echo "PASS: $*"; }
+
+[[ -f "$TARGET" ]] || fail "target script not found: $TARGET"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required for this self-test"
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/bin"
+
+FAILING_XML='<?xml version="1.0" encoding="UTF-8"?>
+<testsuite>
+  <testcase classname="com.pocketshell.app.hosts.ReconnectJourneyE2eTest" name="reconnectAfterBackground" time="1.2">
+    <failure message="boom">stack trace</failure>
+  </testcase>
+  <testcase classname="com.pocketshell.app.hosts.ReconnectJourneyE2eTest" name="passingOne" time="0.5"/>
+</testsuite>'
+
+FAILING_XML_SHARD2='<?xml version="1.0" encoding="UTF-8"?>
+<testsuite>
+  <testcase classname="com.pocketshell.app.projects.MultiSessionSwitchJourneyE2eTest" name="switchesBetweenSessions" time="2.0">
+    <error message="timeout">stack</error>
+  </testcase>
+</testsuite>'
+
+# $1 = mode
+write_fake_gh() {
+  local mode="$1"
+  cat > "$SANDBOX/bin/gh" <<FAKEGH
+#!/usr/bin/env bash
+mode="$mode"
+if [[ "\$1 \$2" == "api"* ]]; then :; fi
+if [[ "\$1" == "api" ]]; then
+  path="\$2"
+  case "\$path" in
+    *"/jobs?per_page=100")
+      if [[ "\$mode" == "jobs_fail" ]]; then
+        echo "boom" >&2
+        exit 1
+      fi
+      echo '{"jobs": [
+        {"name": "Unit tests", "conclusion": "failure"},
+        {"name": "Python utility tests (pocketshell)", "conclusion": "success"},
+        {"name": "Emulator journey subset (load-bearing, Docker agents) (0)", "conclusion": "failure"},
+        {"name": "Emulator journey subset (load-bearing, Docker agents) (2)", "conclusion": "failure"}
+      ]}'
+      ;;
+    *"/artifacts?per_page=100")
+      if [[ "\$mode" == "artifacts_fail" ]]; then
+        echo "boom" >&2
+        exit 1
+      fi
+      if [[ "\$mode" == "no_journey_artifacts" ]]; then
+        echo '{"artifacts": [{"name": "unit-test-reports-debug"}]}'
+      else
+        echo '{"artifacts": [
+          {"name": "emulator-journey-android-test-reports-shard-0"},
+          {"name": "emulator-journey-android-test-reports-shard-1"},
+          {"name": "emulator-journey-android-test-reports-shard-2"}
+        ]}'
+      fi
+      ;;
+    *) echo '{}' ;;
+  esac
+  exit 0
+elif [[ "\$1" == "run" && "\$2" == "download" ]]; then
+  # args: run download RUN_ID --repo REPO -n NAME -D DEST
+  name=""
+  dest=""
+  shift 2
+  while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+      -n) name="\$2"; shift 2 ;;
+      -D) dest="\$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  mkdir -p "\$dest/androidTest-results"
+  case "\$name" in
+    *shard-0)
+      cat > "\$dest/androidTest-results/TEST-shard0.xml" <<'XML'
+$FAILING_XML
+XML
+      ;;
+    *shard-2)
+      cat > "\$dest/androidTest-results/TEST-shard2.xml" <<'XML'
+$FAILING_XML_SHARD2
+XML
+      ;;
+    *shard-1)
+      : # no XML at all for this shard (empty dir) -> emit_from_xml raises,
+        # caught and skipped, must NOT degrade overall status.
+      ;;
+  esac
+  exit 0
+else
+  echo "unhandled fake gh invocation: \$*" >&2
+  exit 1
+fi
+FAKEGH
+  chmod +x "$SANDBOX/bin/gh"
+}
+
+run_target() {
+  PATH="$SANDBOX/bin:$PATH" python3 "$TARGET" \
+    --repo owner/repo --run-id 123 --workdir "$SANDBOX/work-$RANDOM" "$@"
+}
+
+# 1. Normal case: 2 shards with failing XML (0 and 2), shard 1 has no XML.
+write_fake_gh normal
+out="$(run_target --journey-artifact-prefix emulator-journey-android-test-reports-shard-)"
+echo "$out" | grep -qx "job:Unit tests" || fail "must include failed job Unit tests: $out"
+echo "$out" | grep -qx "job:Emulator journey subset (load-bearing, Docker agents) (0)" || fail "must include failed journey shard 0 job: $out"
+echo "$out" | grep -q "^job:Python" && fail "must NOT include Python (it succeeded): $out"
+echo "$out" | grep -qx "class:com.pocketshell.app.hosts.ReconnectJourneyE2eTest#reconnectAfterBackground" || fail "must include the failing class from shard 0: $out"
+echo "$out" | grep -qx "class:com.pocketshell.app.projects.MultiSessionSwitchJourneyE2eTest#switchesBetweenSessions" || fail "must include the failing class from shard 2: $out"
+echo "$out" | grep -q "passingOne" && fail "must NOT include a passing test: $out"
+echo "$out" | grep -qx "# status=ok" || fail "a fully successful capture must report status=ok: $out"
+pass "job-level + class-level failures aggregate across shards, dedup passing tests excluded, status=ok"
+
+# 2. No journey-prefixed artifacts present at all -> job-level only, still ok.
+write_fake_gh no_journey_artifacts
+out="$(run_target --journey-artifact-prefix emulator-journey-android-test-reports-shard-)"
+echo "$out" | grep -qx "job:Unit tests" || fail "job-level lines must still appear: $out"
+echo "$out" | grep -q "^class:" && fail "no class lines expected when no journey artifacts match: $out"
+echo "$out" | grep -qx "# status=ok" || fail "no matching artifacts is not a degraded capture: $out"
+pass "no matching journey artifacts -> job-level signature only, still status=ok"
+
+# 3. No --journey-artifact-prefix supplied at all -> class-level lookup skipped entirely.
+write_fake_gh normal
+out="$(run_target)"
+echo "$out" | grep -q "^class:" && fail "omitting --journey-artifact-prefix must skip class-level lookup entirely: $out"
+pass "omitting --journey-artifact-prefix skips class-level lookup"
+
+# 4. Jobs API call fails -> status=degraded, but class-level lookup is
+#    attempted independently and still succeeds.
+write_fake_gh jobs_fail
+out="$(run_target --journey-artifact-prefix emulator-journey-android-test-reports-shard-)"
+echo "$out" | grep -q "^job:" && fail "a failed jobs listing must produce zero job: lines, not invented ones: $out"
+echo "$out" | grep -qx "class:com.pocketshell.app.hosts.ReconnectJourneyE2eTest#reconnectAfterBackground" || fail "class-level lookup must still run independently of the jobs-listing failure: $out"
+echo "$out" | grep -q "^# status=degraded:job listing failed" || fail "a failed jobs listing must report a degraded status: $out"
+pass "a failed jobs-listing API call degrades status but does not abort class-level lookup"
+
+# 5. Artifacts API call fails -> status=degraded, job-level still present.
+write_fake_gh artifacts_fail
+out="$(run_target --journey-artifact-prefix emulator-journey-android-test-reports-shard-)"
+echo "$out" | grep -qx "job:Unit tests" || fail "job-level lines must still appear when only the artifacts listing fails: $out"
+echo "$out" | grep -q "^class:" && fail "no class lines expected when the artifacts listing failed: $out"
+echo "$out" | grep -q "^# status=degraded:journey artifact listing failed" || fail "a failed artifacts listing must report a degraded status: $out"
+pass "a failed artifacts-listing API call degrades status but does not abort job-level lookup"
+
+# 6. --out file mirrors stdout.
+write_fake_gh normal
+out_file="$SANDBOX/sig-out.txt"
+stdout_out="$(PATH="$SANDBOX/bin:$PATH" python3 "$TARGET" --repo owner/repo --run-id 123 \
+  --workdir "$SANDBOX/work-out" --journey-artifact-prefix emulator-journey-android-test-reports-shard- \
+  --out "$out_file")"
+[[ -f "$out_file" ]] || fail "--out file was not written"
+diff <(printf '%s\n' "$stdout_out") <(cat "$out_file") >/dev/null || fail "--out file must mirror stdout exactly"
+pass "--out file mirrors stdout exactly"
+
+echo "OK: $pass_count self-test case(s) passed."


### PR DESCRIPTION
Not release-blocking — backlog process improvement from the v0.4.47 postmortem (see \`process.md\`'s new "Bounded retry before escalating infra" note). Full review: https://github.com/alexeygrigorev/pocketshell/issues/2459

Reviewer independently verified the anti-infinite-loop logic by hand and validated the signature/classification logic against real historical CI run data (not just synthetic fixtures), plus the full guard suite.

Closes #2459