### PR TITLE
Fix 4 of #2458's emulator-journey scatter: missed host-key-trust wiring

### DIFF
--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerDockerTest.kt
@@ -98,6 +98,15 @@ class FileViewerDockerTest {
      */
     private lateinit var leasing: CountingLeaseManager
 
+    /**
+     * Issue #2458 (host-key-trust fixture gap): an in-memory host row carrying
+     * the real fixture fingerprint, backing [leasing]'s resolver. Without it,
+     * [CountingLeaseManager]'s connector cannot resolve host-key trust and
+     * every real connect throws `UnknownHostKeyException` against a fixture
+     * host key this process has never seen — see [FileViewerLeaseTestSupport.kt].
+     */
+    private lateinit var trustDb: com.pocketshell.core.storage.AppDatabase
+
     /** Issue #2021: the focus reading this journey inherited at its entry boundary. */
     private var journeyEntryFocus: InheritedJourneyFocus? = null
     private val focusOwner by lazy {
@@ -117,7 +126,6 @@ class FileViewerDockerTest {
         val keyText = InstrumentationRegistry.getInstrumentation()
             .context.assets.open("test_key").bufferedReader().use { it.readText() }
         sshKey = SshKey.Pem(keyText)
-        leasing = CountingLeaseManager()
         val cacheDir = InstrumentationRegistry.getInstrumentation().targetContext.cacheDir
         keyFile = File(cacheDir, "issue497-file-viewer-key").apply {
             parentFile?.mkdirs()
@@ -125,7 +133,29 @@ class FileViewerDockerTest {
             FileOutputStream(this).use { it.write(keyText.toByteArray()) }
             setReadable(true, true)
         }
-        waitForSshFixtureReady(sshKey)
+        val fingerprint = waitForSshFixtureReady(sshKey)
+        trustDb = androidx.room.Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            com.pocketshell.core.storage.AppDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        val trustKeyId = trustDb.sshKeyDao().insert(
+            com.pocketshell.core.storage.entity.SshKeyEntity(
+                name = "file-viewer-docker-test",
+                privateKeyPath = keyFile.absolutePath,
+            ),
+        )
+        trustDb.hostDao().insert(
+            com.pocketshell.core.storage.entity.HostEntity(
+                id = TEST_HOST_ID,
+                name = "file-viewer-docker-test-host",
+                hostname = DEFAULT_HOST,
+                port = DEFAULT_PORT,
+                username = DEFAULT_USER,
+                keyId = trustKeyId,
+                trustedHostKeySha256 = fingerprint,
+            ),
+        )
+        leasing = CountingLeaseManager(hostDao = trustDb.hostDao())
     } }
 
     @After
@@ -149,6 +179,7 @@ class FileViewerDockerTest {
         }
         runCatching { keyFile.delete() }
         runCatching { leasing.manager.close() }
+        runCatching { trustDb.close() }
     } }
 
     @Test

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerLeaseTestSupport.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerLeaseTestSupport.kt
@@ -1,8 +1,10 @@
 package com.pocketshell.app.fileviewer
 
+import com.pocketshell.app.testaccess.AuthoritativeSshLeaseConnector
 import com.pocketshell.core.ssh.DefaultSshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseConnector
 import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.storage.dao.HostDao
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -10,23 +12,41 @@ import java.util.concurrent.atomic.AtomicInteger
  * (issue #697). The viewer borrows a session from an app-wide
  * [SshLeaseManager] instead of cold-connecting per open, so these tests build
  * a manager (optionally one that counts real handshakes) to feed the view-model.
+ *
+ * Issue #2458 (host-key-trust fixture gap): [FileViewerViewModel] has no
+ * `hostDao` of its own — every consumer of these helpers relies ENTIRELY on
+ * the lease manager's connector to resolve host-key trust at `acquire()`
+ * time. Both helpers wrap the real connector in [AuthoritativeSshLeaseConnector]
+ * (the same class production wires via Hilt in `app/di/SshLeaseModule.kt`) so
+ * a caller that supplies [hostDao] gets the production trust-resolution path;
+ * the default `hostDao = null` reproduces the exact prior (no-op passthrough)
+ * behaviour, so existing callers that never verified a host key are
+ * byte-for-byte unaffected.
  */
 
 /** A plain lease manager that dials real SSH handshakes via the default connector. */
-internal fun realLeaseManager(): SshLeaseManager =
-    SshLeaseManager(connector = DefaultSshLeaseConnector())
+internal fun realLeaseManager(hostDao: HostDao? = null): SshLeaseManager =
+    SshLeaseManager(
+        connector = AuthoritativeSshLeaseConnector(
+            delegate = DefaultSshLeaseConnector(),
+            hostDao = hostDao,
+        ),
+    )
 
 /**
  * A lease manager whose [handshakeCount] increments on every real cold SSH
  * handshake. A warm lease already held for the same key means the viewer reuses
  * it and the counter does not advance — proving zero per-open handshakes.
  */
-internal class CountingLeaseManager {
+internal class CountingLeaseManager(hostDao: HostDao? = null) {
     val handshakeCount = AtomicInteger(0)
     val manager: SshLeaseManager = SshLeaseManager(
-        connector = SshLeaseConnector { target ->
-            handshakeCount.incrementAndGet()
-            DefaultSshLeaseConnector().connect(target)
-        },
+        connector = AuthoritativeSshLeaseConnector(
+            delegate = SshLeaseConnector { target ->
+                handshakeCount.incrementAndGet()
+                DefaultSshLeaseConnector().connect(target)
+            },
+            hostDao = hostDao,
+        ),
     )
 }

--- a/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerTabsJourneyDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/fileviewer/FileViewerTabsJourneyDockerTest.kt
@@ -57,13 +57,20 @@ class FileViewerTabsJourneyDockerTest {
     private lateinit var leasing: CountingLeaseManager
     private val seededPaths = mutableListOf<String>()
 
+    /**
+     * Issue #2458 (host-key-trust fixture gap): backs [leasing]'s resolver
+     * with a real fixture host row — see [FileViewerLeaseTestSupport.kt] and
+     * the sibling fix in `FileViewerDockerTest`. Without it every real
+     * connect this journey drives throws `UnknownHostKeyException`.
+     */
+    private lateinit var trustDb: com.pocketshell.core.storage.AppDatabase
+
     @Before
     fun setUp() {
         runBlocking {
             val keyText = InstrumentationRegistry.getInstrumentation()
                 .context.assets.open("test_key").bufferedReader().use { it.readText() }
             sshKey = SshKey.Pem(keyText)
-            leasing = CountingLeaseManager()
             val cacheDir = InstrumentationRegistry.getInstrumentation().targetContext.cacheDir
             keyFile = File(cacheDir, "issue1715-file-tabs-key").apply {
                 parentFile?.mkdirs()
@@ -71,7 +78,29 @@ class FileViewerTabsJourneyDockerTest {
                 FileOutputStream(this).use { it.write(keyText.toByteArray()) }
                 setReadable(true, true)
             }
-            waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
+            val fingerprint = waitForSshFixtureReady(sshKey, port = DAEMON_PORT)
+            trustDb = androidx.room.Room.inMemoryDatabaseBuilder(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                com.pocketshell.core.storage.AppDatabase::class.java,
+            ).allowMainThreadQueries().build()
+            val trustKeyId = trustDb.sshKeyDao().insert(
+                com.pocketshell.core.storage.entity.SshKeyEntity(
+                    name = "file-viewer-tabs-journey-test",
+                    privateKeyPath = keyFile.absolutePath,
+                ),
+            )
+            trustDb.hostDao().insert(
+                com.pocketshell.core.storage.entity.HostEntity(
+                    id = TEST_HOST_ID,
+                    name = "file-viewer-tabs-journey-test-host",
+                    hostname = DEFAULT_HOST,
+                    port = DAEMON_PORT,
+                    username = DEFAULT_USER,
+                    keyId = trustKeyId,
+                    trustedHostKeySha256 = fingerprint,
+                ),
+            )
+            leasing = CountingLeaseManager(hostDao = trustDb.hostDao())
             resetDaemonWorkspace()
         }
     }
@@ -91,6 +120,7 @@ class FileViewerTabsJourneyDockerTest {
             }
             runCatching { keyFile.delete() }
             runCatching { leasing.manager.close() }
+            runCatching { trustDb.close() }
         }
     }
 

--- a/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillWindowDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/projects/FolderListKillWindowDockerTest.kt
@@ -10,11 +10,13 @@ import com.pocketshell.app.proof.DEFAULT_PORT
 import com.pocketshell.app.proof.DEFAULT_USER
 import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.testaccess.AuthoritativeSshLeaseConnector
 import com.pocketshell.app.tmux.SessionLifecycleSignals
 import com.pocketshell.app.tmux.TmuxSessionViewModel
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseManager
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.SshKeyEntity
@@ -212,6 +214,17 @@ class FolderListKillWindowDockerTest {
             hostDao = db.hostDao(),
             folderListGateway = SshFolderListGateway(),
             sessionLifecycleSignals = signals,
+            // Issue #2458: TmuxSessionViewModel's own connect() resolves host-key
+            // trust through `sshLeaseManager.resolveTarget`, which no-ops unless
+            // the connector implements SshLeaseTargetResolver. Production wires
+            // that resolver (AuthoritativeSshLeaseConnector) via Hilt
+            // (app/di/SshLeaseModule.kt); this direct construction bypasses Hilt,
+            // so passing `hostDao` alone left every connect() building a
+            // VerifiedFingerprint(null) policy that rejects the fixture's real
+            // (never-before-seen-by-this-process) host key on every attempt.
+            sshLeaseManager = SshLeaseManager(
+                connector = AuthoritativeSshLeaseConnector(hostDao = db.hostDao()),
+            ),
         )
         try {
             tmuxVm.connect(

--- a/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
+++ b/app/src/androidTest/java/com/pocketshell/app/tmux/AgentConversationReconnectDockerTest.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.app.tmux
 
 import android.os.SystemClock
+import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.app.connectivity.TerminalNetworkChange
@@ -13,11 +14,16 @@ import com.pocketshell.app.proof.waitForSshFixtureReady
 import com.pocketshell.app.session.ConversationLoadState
 import com.pocketshell.app.session.SessionTab
 import com.pocketshell.app.sessions.ActiveTmuxClients
+import com.pocketshell.app.testaccess.AuthoritativeSshLeaseConnector
 import com.pocketshell.core.agents.AgentKind
 import com.pocketshell.core.agents.ConversationEvent
 import com.pocketshell.core.ssh.KnownHostsPolicy
 import com.pocketshell.core.ssh.SshConnection
 import com.pocketshell.core.ssh.SshKey
+import com.pocketshell.core.ssh.SshLeaseManager
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
 import com.pocketshell.core.tmux.TmuxClientFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -134,6 +140,7 @@ class AgentConversationReconnectDockerTest {
     private val factoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val timings = mutableListOf<String>()
     private val cleanupCommands = mutableListOf<String>()
+    private val trustedFixtures = mutableListOf<TrustedFixture>()
 
     @After
     fun tearDown() {
@@ -142,8 +149,65 @@ class AgentConversationReconnectDockerTest {
                 runCatching { execRemote(readFixtureKey(), cleanupCommands.joinToString("\n")) }
             }
         }
+        trustedFixtures.forEach { runCatching { it.close() } }
         factoryScope.cancel()
         writeTimings()
+    }
+
+    /**
+     * Issue #2458 (host-key-trust fixture gap): [TmuxSessionViewModel.connect]
+     * only resolves host-key trust when this ViewModel's `hostDao` is set AND
+     * its `sshLeaseManager`'s connector implements `SshLeaseTargetResolver`.
+     * Production wires that resolver (`AuthoritativeSshLeaseConnector`) via
+     * Hilt (`app/di/SshLeaseModule.kt`); this file constructs
+     * `TmuxSessionViewModel` directly and bypasses Hilt entirely, so — with
+     * neither `hostDao` nor a resolver-backed `sshLeaseManager` supplied —
+     * every real connect() built a `VerifiedFingerprint(null)` policy and the
+     * fixture's real (never-before-seen-by-this-process) host key tripped
+     * `UnknownHostKeyException` on EVERY attempt (100% failure, all 4
+     * methods, confirmed on `main` @ 21fc4b95). This mirrors the production
+     * wiring: an in-memory host row per test-local `hostId`, carrying the
+     * fingerprint [waitForSshFixtureReady] already discovers (and this file
+     * used to discard), plus a resolver-backed lease manager so
+     * `TmuxSessionViewModel.requestResolvedConnect` finds it.
+     */
+    private fun trustedFixture(hostIds: List<Long>, fingerprint: String, keyPath: String): TrustedFixture {
+        val db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            AppDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        runBlocking {
+            val keyId = db.sshKeyDao().insert(
+                SshKeyEntity(name = "agent-conversation-reconnect-key", privateKeyPath = keyPath),
+            )
+            hostIds.forEach { id ->
+                db.hostDao().insert(
+                    HostEntity(
+                        id = id,
+                        name = "agent-conversation-reconnect-$id",
+                        hostname = DEFAULT_HOST,
+                        port = DEFAULT_PORT,
+                        username = DEFAULT_USER,
+                        keyId = keyId,
+                        trustedHostKeySha256 = fingerprint,
+                    ),
+                )
+            }
+        }
+        val manager = SshLeaseManager(connector = AuthoritativeSshLeaseConnector(hostDao = db.hostDao()))
+        return TrustedFixture(db, manager).also { trustedFixtures += it }
+    }
+
+    private class TrustedFixture(
+        private val db: AppDatabase,
+        val sshLeaseManager: SshLeaseManager,
+    ) : AutoCloseable {
+        val hostDao get() = db.hostDao()
+
+        override fun close() {
+            sshLeaseManager.close()
+            db.close()
+        }
     }
 
     @Test
@@ -153,9 +217,10 @@ class AgentConversationReconnectDockerTest {
         val key = readFixtureKey()
         // agents:2222 readiness — so a not-yet-up fixture is the loud failure,
         // not the cause of a later hang.
-        waitForSshFixtureReady(SshKey.Pem(key))
+        val fingerprint = waitForSshFixtureReady(SshKey.Pem(key))
 
         val keyPath = writeKeyFile(key)
+        val trust = trustedFixture(listOf(495L), fingerprint, keyPath)
         val sessionName = "issue495-reconnect-${System.currentTimeMillis().toString().takeLast(8)}"
         val processDir = "/tmp/issue495-claude-${System.nanoTime()}"
         val wrapperPath = "$processDir/claude"
@@ -234,6 +299,8 @@ class AgentConversationReconnectDockerTest {
             tmuxClientFactory = TmuxClientFactory(factoryScope),
             activeTmuxClients = registry,
             runtimeCache = TmuxSessionRuntimeCache(maxEntries = 0),
+            hostDao = trust.hostDao,
+            sshLeaseManager = trust.sshLeaseManager,
         )
         // Issue #2111: pin the open-time default to Terminal (the real #818
         // opt-out). This is what makes the reattach memory restore the ONLY
@@ -528,9 +595,10 @@ class AgentConversationReconnectDockerTest {
     @Test
     fun conversationTapIsHonouredBeforeDetectionLands(): Unit { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        val fingerprint = waitForSshFixtureReady(SshKey.Pem(key))
 
         val keyPath = writeKeyFile(key)
+        val trust = trustedFixture(listOf(778L), fingerprint, keyPath)
         val sessionName = "issue778-tap-${System.currentTimeMillis().toString().takeLast(8)}"
         // A plain shell pane in the writable home dir — no agent, no /workspace.
         val cwd = "/home/$DEFAULT_USER"
@@ -554,6 +622,8 @@ class AgentConversationReconnectDockerTest {
             tmuxClientFactory = TmuxClientFactory(factoryScope),
             activeTmuxClients = ActiveTmuxClients(),
             runtimeCache = TmuxSessionRuntimeCache(maxEntries = 0),
+            hostDao = trust.hostDao,
+            sshLeaseManager = trust.sshLeaseManager,
         )
 
         try {
@@ -671,9 +741,10 @@ class AgentConversationReconnectDockerTest {
     @Test
     fun agentOpensOnDefaultViewAndIsNotYankedMidSessionShellGetsNoConversationRow(): Unit { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        val fingerprint = waitForSshFixtureReady(SshKey.Pem(key))
 
         val keyPath = writeKeyFile(key)
+        val trust = trustedFixture(listOf(807L, 809L, 808L), fingerprint, keyPath)
         val suffix = System.currentTimeMillis().toString().takeLast(8)
         val agentSessionName = "issue807-agent-$suffix"
         val shellSessionName = "issue807-shell-$suffix"
@@ -756,6 +827,8 @@ class AgentConversationReconnectDockerTest {
             tmuxClientFactory = TmuxClientFactory(factoryScope),
             activeTmuxClients = ActiveTmuxClients(),
             runtimeCache = TmuxSessionRuntimeCache(maxEntries = 0),
+            hostDao = trust.hostDao,
+            sshLeaseManager = trust.sshLeaseManager,
         )
         try {
             agentVm.connect(
@@ -976,6 +1049,8 @@ class AgentConversationReconnectDockerTest {
             tmuxClientFactory = TmuxClientFactory(factoryScope),
             activeTmuxClients = ActiveTmuxClients(),
             runtimeCache = TmuxSessionRuntimeCache(maxEntries = 0),
+            hostDao = trust.hostDao,
+            sshLeaseManager = trust.sshLeaseManager,
         )
         agentTerminalVm.setDefaultAgentSessionViewForTest(
             com.pocketshell.app.settings.DefaultAgentSessionView.Terminal,
@@ -1024,6 +1099,8 @@ class AgentConversationReconnectDockerTest {
             tmuxClientFactory = TmuxClientFactory(factoryScope),
             activeTmuxClients = ActiveTmuxClients(),
             runtimeCache = TmuxSessionRuntimeCache(maxEntries = 0),
+            hostDao = trust.hostDao,
+            sshLeaseManager = trust.sshLeaseManager,
         )
         try {
             shellVm.connect(
@@ -1110,9 +1187,10 @@ class AgentConversationReconnectDockerTest {
     @Test
     fun reconciledPresumedAgentWithDroppedRowReseedsConversationPlaceholderOnDevice(): Unit { runBlocking {
         val key = readFixtureKey()
-        waitForSshFixtureReady(SshKey.Pem(key))
+        val fingerprint = waitForSshFixtureReady(SshKey.Pem(key))
 
         val keyPath = writeKeyFile(key)
+        val trust = trustedFixture(listOf(874L), fingerprint, keyPath)
         val sessionName = "issue874-void-${System.currentTimeMillis().toString().takeLast(8)}"
         val cwd = "/home/$DEFAULT_USER"
         cleanupCommands += "tmux kill-session -t ${shellQuote(sessionName)} 2>/dev/null || true"
@@ -1137,6 +1215,8 @@ class AgentConversationReconnectDockerTest {
             tmuxClientFactory = TmuxClientFactory(factoryScope),
             activeTmuxClients = ActiveTmuxClients(),
             runtimeCache = TmuxSessionRuntimeCache(maxEntries = 0),
+            hostDao = trust.hostDao,
+            sshLeaseManager = trust.sshLeaseManager,
         )
         // The open-time default is Conversation (the black-screen cure) — the
         // exact state where the residual void appears.


### PR DESCRIPTION
Release-blocking for v0.4.47. Full review: https://github.com/alexeygrigorev/pocketshell/issues/2458

Fixes 4 of the 8 originally-scattered classes (missed direct-construction host-key-trust wiring, same class as #2445/#2446/#2449/#2451/#2455). The other 4 were investigated separately (#2461, closed) and confirmed pre-existing/unrelated, already tracked in #2335 and #788 — not part of this fix.

Reviewer independently verified: G1 red→green on 2 representative classes, all 4 fixed classes green on the real emulator, and confirmed 2 unrelated sibling-class failures found along the way are pre-existing on clean \`main\` and out of the release-journey scope.

Refs #2458