### PR TITLE
fix: J04 create-session oracle was asserting against dead placeholder route

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/tree/J04CreateSessionJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/tree/J04CreateSessionJourney.kt
@@ -1,11 +1,13 @@
 package com.pocketshell.next.tree
 
 import android.os.SystemClock
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -21,12 +23,13 @@ import com.pocketshell.next.connect.JourneyScreenshots
 import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.appGraph
 import com.pocketshell.next.hosts.hostRowTag
+import com.pocketshell.next.terminal.SESSION_SCREEN_TAG
+import com.pocketshell.next.terminal.SESSION_TITLE_TAG
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -140,7 +143,6 @@ class J04CreateSessionJourney {
      * which the HOST agrees exists, in the folder that was typed.
      */
     @Test
-    @Ignore("quarantined: #2478, expires 2026-10-04 — create-session lands on the wrong destination; pre-existing product bug, needs real investigation not a test fix (D36)")
     fun creatingASessionFromTheTreeLandsOnItAndItAppearsOnTheTree() {
         openTree()
         assertTrue(
@@ -168,10 +170,9 @@ class J04CreateSessionJourney {
 
         compose.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).performClick()
 
-        // Landed IN the new session (U-4 has not replaced this route yet, so
-        // what renders is the scaffold placeholder carrying the session name).
-        awaitText(sessionRouteLabel(SESSION_NEW))
-        compose.onNodeWithText(sessionRouteLabel(SESSION_NEW)).assertIsDisplayed()
+        // Landed IN the new session — on the REAL terminal screen (U-4), whose
+        // header title is the session identity the route carried.
+        awaitSessionScreen(SESSION_NEW)
         JourneyScreenshots.capture("03-session-opened", JOURNEY)
 
         // The HOST's own answer: the session is really there, and it was really
@@ -199,12 +200,11 @@ class J04CreateSessionJourney {
      * an error, it opens the session that is already there.
      */
     @Test
-    @Ignore("quarantined: #2478, expires 2026-10-04 — same-name create surfaces an error instead of reopening the existing session; pre-existing product bug, needs real investigation not a test fix (D36)")
     fun creatingTheSameNameTwiceOpensTheExistingSessionWithoutAnError() {
         openTree()
 
         createFromSheet(FOLDER_TWICE)
-        awaitText(sessionRouteLabel(SESSION_TWICE))
+        awaitSessionScreen(SESSION_TWICE)
         pressBack()
         awaitTag(SESSION_TREE_TAG)
         assertEquals(
@@ -218,7 +218,7 @@ class J04CreateSessionJourney {
 
         // The second create still OPENS the session — a client that treated
         // `created:false` as a failure would never get here.
-        awaitText(sessionRouteLabel(SESSION_TWICE))
+        awaitSessionScreen(SESSION_TWICE)
         JourneyScreenshots.capture("05-existing-session-opened", JOURNEY)
         assertEquals(
             "an idempotent create must not duplicate the session",
@@ -296,8 +296,28 @@ class J04CreateSessionJourney {
         compose.runOnUiThread { compose.activity.onBackPressedDispatcher.onBackPressed() }
     }
 
-    /** What the (still placeholder) Session route renders for [name]. */
-    private fun sessionRouteLabel(name: String): String = "Session(hostId=$hostId, name=$name)"
+    /**
+     * The create landed on the SESSION route, and on the session it just made.
+     *
+     * The identity check is the header title, not merely "a session screen is
+     * up": that is the assertion that fails if the create navigates to the
+     * wrong session (a stale `openRequest`, the typed name instead of the
+     * host's answer, a dedup that opens a neighbour). Waiting on
+     * [SESSION_SCREEN_TAG] alone would pass for any of those.
+     */
+    private fun awaitSessionScreen(name: String) {
+        awaitTag(SESSION_SCREEN_TAG)
+        compose.waitUntil(timeoutMillis = TIMEOUT_MS) {
+            compose.onAllNodesWithTag(SESSION_TITLE_TAG)
+                .fetchSemanticsNodes()
+                .any { node ->
+                    node.config.getOrNull(SemanticsProperties.Text)
+                        ?.any { it.text == name } == true
+                }
+        }
+        compose.onNodeWithTag(SESSION_SCREEN_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(SESSION_TITLE_TAG).assertTextEquals(name)
+    }
 
     /**
      * The host's own answer to the command the app just ran, over an
@@ -334,12 +354,6 @@ class J04CreateSessionJourney {
     private fun awaitTag(tag: String) {
         compose.waitUntil(timeoutMillis = TIMEOUT_MS) {
             compose.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()
-        }
-    }
-
-    private fun awaitText(text: String) {
-        compose.waitUntil(timeoutMillis = TIMEOUT_MS) {
-            compose.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()
         }
     }
 

--- a/app2/src/main/java/com/pocketshell/next/MainActivity.kt
+++ b/app2/src/main/java/com/pocketshell/next/MainActivity.kt
@@ -3,23 +3,17 @@ package com.pocketshell.next
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -55,10 +49,13 @@ import javax.inject.Inject
  * The single Activity of app2 (plan §A.1). Everything is Compose; there are no
  * fragments and no second Activity.
  *
- * Today it hosts the empty scaffold — each route renders a placeholder. The
- * U-tasks replace those placeholders with real screens one at a time, which is
- * why the graph is wired now: every later slice is a one-line swap inside
- * [AppNavHost] rather than a navigation change.
+ * The graph was wired before the screens existed, so each U-task was a one-line
+ * swap inside [AppNavHost] rather than a navigation change. Every route now
+ * resolves to a REAL screen; the `RoutePlaceholder` scaffold those swaps
+ * replaced is gone (D22 — superseded code is deleted, not left dark). It had to
+ * go: journey J04 was still asserting on the placeholder's
+ * `Session(hostId=…, name=…)` label long after U-4 stopped rendering it, and a
+ * dead composable is exactly what lets an oracle like that look alive (#2478).
  */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -112,9 +109,6 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-
-/** Test tag on the placeholder body, so a journey can assert which route rendered. */
-const val ROUTE_PLACEHOLDER_TAG: String = "route_placeholder"
 
 /**
  * Every non-dial action the host list can start. Grouped into one type because
@@ -412,27 +406,5 @@ fun AppNavHost(
             // are the installation's, not a host's.
             crashReportsScreen { navController.popBackStack() }
         }
-    }
-}
-
-/**
- * Scaffold stand-in for a not-yet-ported screen. Intentionally text-only —
- * building any real chrome here would be a design decision made twice, since
- * every U-task replaces this with the ui-kit primitives (docs/design-system.md).
- */
-@Composable
-private fun RoutePlaceholder(label: String) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.testTag(ROUTE_PLACEHOLDER_TAG),
-        )
     }
 }

--- a/scripts/journey-quarantine.txt
+++ b/scripts/journey-quarantine.txt
@@ -25,5 +25,3 @@
 # fixed or removed) or by RE-TRIAGING it (a fresh `added`/`expires` in both
 # places, and a reason that says why it is still broken) — never let a row sit
 # expired.
-com.pocketshell.next.tree.J04CreateSessionJourney#creatingASessionFromTheTreeLandsOnItAndItAppearsOnTheTree	#2478	2026-09-04	2026-10-04	create-session lands on the wrong destination; pre-existing product bug found during the app2 journey bring-up, needs real investigation not a test fix, hence the 30-day window rather than the 2-week default
-com.pocketshell.next.tree.J04CreateSessionJourney#creatingTheSameNameTwiceOpensTheExistingSessionWithoutAnError	#2478	2026-09-04	2026-10-04	same-name create surfaces an error instead of reopening the existing session; same pre-existing bug as the sibling row, same 30-day investigation window

--- a/scripts/test-journey-quarantine-non-blocking.sh
+++ b/scripts/test-journey-quarantine-non-blocking.sh
@@ -63,6 +63,49 @@ run_guard() {  # against the sandbox root + the real list
   POCKETSHELL_JOURNEY_QUARANTINE_ROOT="$SANDBOX/root" bash "$GUARD" 2>&1
 }
 
+# The class the untracked-@Ignore cases plant their fixture annotation into. It
+# must be a real journey class (so the guard's registry accepts it) that the
+# shipped list does NOT quarantine, so a planted annotation is genuinely
+# untracked.
+FIXTURE_CLASS="com.pocketshell.next.usage.J12UsagePanelJourney"
+
+# Plants `@Ignore("silently parked")` on the first @Test method of
+# $FIXTURE_CLASS in the SANDBOX copy and echoes the method name it annotated.
+#
+# Every case that needs "a live @Ignore the list does not account for" builds it
+# HERE rather than relying on one happening to exist in the shipped tree. That
+# incidental dependency is a real trap: it made case (d) pass only for as long
+# as some unrelated journey happened to be quarantined, and turned the very
+# first empty-list tree (issue #2478 removing the last two annotations) into a
+# spurious red. Callers must reset_root first.
+plant_untracked_ignore() {
+  local src="$SANDBOX/root/java/${FIXTURE_CLASS//./\/}.kt"
+  if [[ ! -f "$src" ]]; then
+    echo "fixture source not found: $src" >&2
+    return 1
+  fi
+  if grep -qF "$FIXTURE_CLASS" "$QUARANTINE_LIST"; then
+    echo "fixture assumption broken: $FIXTURE_CLASS is itself quarantined" >&2
+    return 1
+  fi
+  python3 - "$src" <<'PY'
+import re, sys
+path = sys.argv[1]
+src = open(path).read()
+needle = "    @Test\n"
+i = src.index(needle)
+rest = src[i + len(needle):]
+m = re.search(r'\bfun[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*\(', rest)
+if not m:
+    sys.exit("no @Test method found to annotate")
+src = src[:i] + "    @Test\n    @Ignore(\"silently parked\")\n" + rest
+if "import org.junit.Ignore" not in src:
+    src = src.replace("import org.junit.Test", "import org.junit.Ignore\nimport org.junit.Test", 1)
+open(path, 'w').write(src)
+print(m.group(1))
+PY
+}
+
 # ---------------------------------------------------------------------------
 # (a) GREEN CONTROL — the shipped tree reconciles. Without this, every red
 #     below could be a red the tree already had.
@@ -84,7 +127,6 @@ fi
 first_row="$(grep -vE '^[[:space:]]*(#|$)' "$QUARANTINE_LIST" | head -1 | cut -f1)"
 if [[ -z "$first_row" ]]; then
   pass "(b) skipped: the quarantine list is empty, so there is no row to strip"
-  pass "(c) skipped: the quarantine list is empty"
 else
   q_class="${first_row%%#*}"
   q_method="${first_row#*#}"
@@ -109,54 +151,47 @@ $out"
     fail "(b) the guard reddened for the wrong reason:
 $out"
   pass "(b) a registered row whose method lost its @Ignore reddens, naming the method"
-
-  # -------------------------------------------------------------------------
-  # (c) SIBLINGS STILL BLOCK. Quarantine is per METHOD; a sibling @Test in the
-  #     same class must not inherit the exemption. Assert the guard treats an
-  #     @Ignore on an unregistered sibling as untracked.
-  # -------------------------------------------------------------------------
-  reset_root
-  sibling_class="com.pocketshell.next.usage.J12UsagePanelJourney"
-  sibling_src="$SANDBOX/root/java/${sibling_class//./\/}.kt"
-  [[ -f "$sibling_src" ]] || fail "(c) sibling fixture source not found: $sibling_src"
-  grep -qF "$sibling_class" "$QUARANTINE_LIST" &&
-    fail "(c) fixture assumption broken: $sibling_class is itself quarantined"
-  python3 - "$sibling_src" <<'PY'
-import sys
-path = sys.argv[1]
-src = open(path).read()
-needle = "    @Test\n"
-i = src.index(needle)
-src = src[:i] + "    @Test\n    @Ignore(\"silently parked\")\n" + src[i + len(needle):]
-if "import org.junit.Ignore" not in src:
-    src = src.replace("import org.junit.Test", "import org.junit.Ignore\nimport org.junit.Test", 1)
-open(path, 'w').write(src)
-PY
-  [[ $? -eq 0 ]] || fail "(c) MUTATION DID NOT APPLY"
-  out="$(run_guard)" && fail "(c) an @Ignore on an unregistered journey method did NOT redden the guard — a test can be parked forever with no issue and no expiry:
-$out"
-  grep -q 'NO row in' <<<"$out" ||
-    fail "(c) the guard reddened for the wrong reason:
-$out"
-  pass "(c) an @Ignore with no registry row reddens (quarantine is a queue, not a graveyard)"
 fi
+
+# ---------------------------------------------------------------------------
+# (c) AN @Ignore WITH NO ROW STILL BLOCKS THE BUILD. Quarantine is per METHOD
+#     and per registry row; annotating a method nobody triaged must not be a
+#     silent exemption. The fixture annotation is PLANTED here, so this case
+#     proves the property whether or not the shipped list currently has rows.
+# ---------------------------------------------------------------------------
+reset_root
+c_method="$(plant_untracked_ignore 2>&1)" || fail "(c) MUTATION DID NOT APPLY: $c_method"
+out="$(run_guard)" && fail "(c) an @Ignore on an unregistered journey method did NOT redden the guard — a test can be parked forever with no issue and no expiry:
+$out"
+grep -qF "$FIXTURE_CLASS#$c_method: @Ignore on a journey @Test with NO row in" <<<"$out" ||
+  fail "(c) the guard reddened for the wrong reason (expected the planted $FIXTURE_CLASS#$c_method to be reported untracked):
+$out"
+pass "(c) an @Ignore with no registry row reddens (quarantine is a queue, not a graveyard)"
 
 # ---------------------------------------------------------------------------
 # (d) FAIL-SAFE: a malformed list must not legitimise the annotations it fails
 #     to parse. A broken list means NOTHING is tracked, so every live @Ignore
 #     becomes untracked and the guard reddens — never the other way round.
+#
+#     The @Ignore this case needs is PLANTED, not borrowed from whatever the
+#     shipped tree happens to contain. Borrowing made the case unprovable in
+#     the steady state the policy is aiming for — an empty list and no live
+#     annotations — where it reported a spurious red (issue #2478's PR) even
+#     though the guard behaved correctly.
 # ---------------------------------------------------------------------------
 reset_root
+d_method="$(plant_untracked_ignore 2>&1)" || fail "(d) MUTATION DID NOT APPLY: $d_method"
 broken="$SANDBOX/broken-list.txt"
 printf 'this-row-has-no-tabs-at-all\n' > "$broken"
 out="$(POCKETSHELL_JOURNEY_QUARANTINE_ROOT="$SANDBOX/root" \
        POCKETSHELL_JOURNEY_QUARANTINE_FILE="$broken" bash "$GUARD" 2>&1)" && \
   fail "(d) a malformed quarantine list was treated as clean:
 $out"
-if grep -q 'parse error' <<<"$out" && grep -q 'NO row in' <<<"$out"; then
+if grep -q 'parse error' <<<"$out" &&
+   grep -qF "$FIXTURE_CLASS#$d_method: @Ignore on a journey @Test with NO row in" <<<"$out"; then
   pass "(d) a malformed list fails closed: it is a parse error AND its annotations become untracked"
 else
-  fail "(d) a malformed list did not fail closed in both ways:
+  fail "(d) a malformed list did not fail closed in both ways (expected a parse error AND the planted $FIXTURE_CLASS#$d_method reported untracked):
 $out"
 fi
 


### PR DESCRIPTION
## Summary
- Both quarantined `J04CreateSessionJourney` failures were a stale test oracle waiting on `RoutePlaceholder`'s label, which `AppNavHost` stopped rendering once the real `SessionRoute` landed — not a create-session destination/dedup bug.
- Deletes the now-dead `RoutePlaceholder`/`ROUTE_PLACEHOLDER_TAG` (D22 hard cut) and tightens the oracle to assert exact session-name identity.
- Removes both `@Ignore` quarantines and their `scripts/journey-quarantine.txt` rows.

## Verification
- Red on base (both `@Ignore` stripped): 2/2 `ComposeTimeoutException`, independently reproduced by both implementer and reviewer.
- Green with fix: 2/2, and J01-J04 sweep 13/13.
- Mutation test: reinjected a wrong-destination mutant — red at the new title-identity assertion, not the old tag-only proxy (G6).
- `:app2:testDebugUnitTest` 763/0/0/0, quarantine-expiry/test-validity/file-size-hygiene checks green.
- Reviewer took independent on-device screenshots confirming correct destination and non-error dedup notice.

Reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2478#issuecomment-5544408867

Closes #2478