### PR TITLE
fix: bound waitForIdle in app2 journey harness so a device wedge fails fast

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/composer/J07ComposerSendJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/composer/J07ComposerSendJourney.kt
@@ -23,6 +23,7 @@ import com.pocketshell.next.connect.AgentsFixture
 import com.pocketshell.next.connect.JourneyScreenshots
 import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.appGraph
+import com.pocketshell.next.connect.awaitIdle
 import com.pocketshell.next.hosts.hostRowTag
 import com.pocketshell.next.terminal.SESSION_ERROR_BANNER_TAG
 import com.pocketshell.next.terminal.SESSION_SCREEN_TAG
@@ -156,7 +157,7 @@ class J07ComposerSendJourney {
 
         compose.onNodeWithTag(COMPOSER_TAG).assertIsDisplayed()
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).performTextInput("echo $MARKER")
-        compose.waitForIdle()
+        compose.awaitIdle("after composing the draft")
         JourneyScreenshots.capture("01-composed", JOURNEY)
 
         compose.onNodeWithTag(COMPOSER_SEND_TAG).performClick()
@@ -180,7 +181,7 @@ class J07ComposerSendJourney {
         )
 
         // A delivered send clears the composer — and leaves no chip.
-        compose.waitForIdle()
+        compose.awaitIdle("after the send")
         compose.onNodeWithTag(COMPOSER_UNDELIVERED_TAG).assertDoesNotExist()
         compose.onNode(hasText(COMPOSER_PLACEHOLDER)).assertIsDisplayed()
     }
@@ -210,7 +211,7 @@ class J07ComposerSendJourney {
         awaitTag(SESSION_ERROR_BANNER_TAG, "the session-ended banner")
 
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).performTextInput(UNDELIVERED_TEXT)
-        compose.waitForIdle()
+        compose.awaitIdle("after composing the undelivered draft")
         // Prove the editor took the text and Send is live BEFORE asserting on
         // what Send does with it: a timeout on the chip alone cannot tell
         // "the send did the wrong thing" from "the tap never reached a send".
@@ -243,7 +244,7 @@ class J07ComposerSendJourney {
         awaitTranscript("the fixture's banner line") { it.contains(BANNER) }
 
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).performTextInput(HISTORY_TEXT)
-        compose.waitForIdle()
+        compose.awaitIdle("after composing the history draft")
         compose.onNodeWithTag(COMPOSER_SEND_TAG).performClick()
         awaitTranscript("the sent history line") { it.contains(squashed(HISTORY_TEXT)) }
 
@@ -252,7 +253,7 @@ class J07ComposerSendJourney {
         JourneyScreenshots.capture("04-history", JOURNEY)
 
         compose.onNode(hasText(HISTORY_TEXT)).performClick()
-        compose.waitForIdle()
+        compose.awaitIdle("after refilling the draft from history")
         JourneyScreenshots.capture("05-refilled", JOURNEY)
 
         // The composer holds the message again, ready to send a second time.
@@ -333,7 +334,7 @@ class J07ComposerSendJourney {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         var last = ""
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("transcript poll: $what")
             last = renderedTranscript()
             if (predicate(squashed(last))) return last
             SystemClock.sleep(POLL_MS)
@@ -393,7 +394,7 @@ class J07ComposerSendJourney {
     private fun awaitTag(tag: String, what: String = tag) {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("tag poll: $what")
             if (compose.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()) return
             SystemClock.sleep(POLL_MS)
         }

--- a/app2/src/androidTest/java/com/pocketshell/next/composer/J08VoiceDictationJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/composer/J08VoiceDictationJourney.kt
@@ -20,6 +20,7 @@ import com.pocketshell.next.connect.AgentsFixture
 import com.pocketshell.next.connect.JourneyScreenshots
 import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.appGraph
+import com.pocketshell.next.connect.awaitIdle
 import com.pocketshell.next.di.VoiceModule
 import com.pocketshell.next.hosts.hostRowTag
 import com.pocketshell.next.terminal.SESSION_SCREEN_TAG
@@ -151,13 +152,13 @@ class J08VoiceDictationJourney {
         awaitTag(COMPOSER_DISCARD_RECORDING_TAG, "the recording indicator")
 
         ScriptedSpeechRecognitionProvider.partial("run the")
-        compose.waitForIdle()
+        compose.awaitIdle("after a partial transcript")
         ScriptedSpeechRecognitionProvider.partial("run the tests")
-        compose.waitForIdle()
+        compose.awaitIdle("after a partial transcript")
         JourneyScreenshots.capture("01-recording", JOURNEY)
 
         ScriptedSpeechRecognitionProvider.final("run the tests now")
-        compose.waitForIdle()
+        compose.awaitIdle("after the final transcript")
         JourneyScreenshots.capture("02-transcribed", JOURNEY)
 
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).assertTextContains("run the tests now", substring = true)
@@ -211,7 +212,7 @@ class J08VoiceDictationJourney {
     private fun awaitTag(tag: String, what: String = tag) {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("tag poll: $what")
             if (compose.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()) return
             SystemClock.sleep(POLL_MS)
         }

--- a/app2/src/androidTest/java/com/pocketshell/next/connect/BoundedWait.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/connect/BoundedWait.kt
@@ -1,0 +1,199 @@
+package com.pocketshell.next.connect
+
+import android.os.SystemClock
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import java.util.WeakHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * A wall-clock bound around a harness wait that has no bound of its own.
+ *
+ * ## Why this exists (issue #2479)
+ *
+ * Every journey in this suite polls for its oracle inside a bounded loop:
+ *
+ * ```
+ * val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+ * while (SystemClock.elapsedRealtime() < deadline) {
+ *     compose.waitForIdle()          // <- UNBOUNDED
+ *     if (oracleSatisfied()) return
+ *     SystemClock.sleep(POLL_MS)
+ * }
+ * throw AssertionError(...)           // with a screenshot and a diagnosis
+ * ```
+ *
+ * The deadline is only as real as the calls inside the loop body, and
+ * `ComposeTestRule.waitForIdle()` is not one of them: it blocks until Compose
+ * agrees the app has settled, with no timeout of its own. When Compose's idling
+ * machinery never agrees — as it did not, twice on CI and repeatedly locally,
+ * after the second rotation in `J03AttachAndTypeJourney` — the "60 second"
+ * deadline becomes unreachable and the FIRST iteration of the loop consumes the
+ * whole job.
+ *
+ * The cost of that is much larger than one red test. The instrumentation
+ * process never exits, Gradle is killed by the job's step timeout 45 minutes
+ * later, and no `TEST-*.xml` is written AT ALL — so the fifteen journeys that
+ * genuinely passed before the wedge produce zero evidence and
+ * `scripts/check-app2-lane-execution.py` correctly reports the whole lane as
+ * unproven. One intermittent wait turns a suite into a coin flip with no
+ * salvage.
+ *
+ * ## What this does about it
+ *
+ * The blocking call runs on a worker thread and the caller waits on a
+ * [Future] with an explicit budget. When the budget expires the caller gets
+ * `false` and CONTINUES — the poll loop then re-checks its own deadline, keeps
+ * polling its real oracle without the idle sync, and fails with its usual
+ * screenshot and diagnosis at the time it promised to. A wedged idle-check
+ * becomes a red test with evidence instead of a dead job.
+ *
+ * Two details are load bearing:
+ *
+ *  - **One worker thread, and never a queue behind a stuck wait.** If the
+ *    previous submission has not returned, the next [run] returns `false`
+ *    immediately rather than submitting more work. A wedge therefore costs at
+ *    most ONE parked thread per instance for the rest of the test, not one per
+ *    poll iteration — and the poll loop spins at its normal [Future]-free cost
+ *    once it has been told the wait is hopeless.
+ *  - **The worker is a daemon.** A thread parked forever inside Compose's
+ *    idling machinery must not keep the instrumentation process alive after
+ *    JUnit has recorded the failure and moved on.
+ *
+ * This is a harness bound, deliberately NOT a fix for whatever makes Compose
+ * refuse to go idle (#2479 stays open for that). It makes the symptom cheap and
+ * observable — a 60-second failure carrying [stuckDiagnosis] — rather than
+ * silent and total.
+ */
+class BoundedWait(private val name: String) {
+
+    private val worker = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "bounded-wait-$name").apply { isDaemon = true }
+    }
+
+    private var pending: Future<*>? = null
+    private var stuckLabel: String? = null
+    private var stuckSince: Long = 0L
+    private var timeouts: Int = 0
+
+    /**
+     * Runs [block] on the worker and waits at most [budgetMs] for it.
+     *
+     * @return `true` when [block] completed inside the budget, `false` when it
+     *   did not (or when an earlier call is still parked). Anything [block]
+     *   throws is rethrown to the caller unchanged, so a real assertion failure
+     *   inside a wrapped wait is not swallowed by the bound.
+     */
+    @Synchronized
+    fun run(label: String, budgetMs: Long, block: () -> Unit): Boolean {
+        val outstanding = pending
+        if (outstanding != null) {
+            if (!outstanding.isDone) {
+                // Still parked from an earlier call. Submitting now would queue
+                // behind it and hand the caller a bound it cannot enforce.
+                return false
+            }
+            pending = null
+        }
+
+        val future = worker.submit(Runnable { block() })
+        pending = future
+        return try {
+            future.get(budgetMs, TimeUnit.MILLISECONDS)
+            pending = null
+            true
+        } catch (timeout: TimeoutException) {
+            timeouts += 1
+            if (stuckLabel == null) {
+                stuckLabel = label
+                stuckSince = SystemClock.elapsedRealtime()
+            }
+            println(
+                "BOUNDED_WAIT_TIMEOUT $name: `$label` did not return within ${budgetMs}ms " +
+                    "(see issue #2479). Continuing without it so the caller's own " +
+                    "deadline can still fire.",
+            )
+            false
+        } catch (failure: ExecutionException) {
+            pending = null
+            throw failure.cause ?: failure
+        }
+    }
+
+    /** True once any wait has blown its budget in this test. */
+    @Synchronized
+    fun isStuck(): Boolean = stuckLabel != null
+
+    /**
+     * A sentence for a failure message, or `""` when nothing ever timed out.
+     *
+     * Worth carrying into every assertion message in a journey: "the terminal
+     * never laid out portrait" reads like a layout bug, and "…and by the way
+     * Compose has not gone idle for 58 seconds" is a completely different
+     * investigation.
+     */
+    @Synchronized
+    fun stuckDiagnosis(): String {
+        val label = stuckLabel ?: return ""
+        val parked = pending?.isDone == false
+        val elapsed = SystemClock.elapsedRealtime() - stuckSince
+        return "NOTE (#2479): `$label` blew its wait budget ${timeouts}x, first " +
+            "${elapsed}ms ago, and is ${if (parked) "STILL parked" else "no longer parked"}. " +
+            "The wait was abandoned rather than allowed to consume this test's deadline."
+    }
+}
+
+/**
+ * The bounded form of [ComposeTestRule.waitForIdle], one budget per rule.
+ *
+ * Keyed on the rule instance (identity, via a [WeakHashMap]) so the "a wait is
+ * already parked" state resets automatically between tests: JUnit builds a new
+ * test-class instance — and therefore a new rule — per method, and a wedge in
+ * one method must not silently disable idle syncing for the next one.
+ */
+object ComposeIdle {
+
+    /**
+     * How long ONE idle sync may take before the caller gives up on it.
+     *
+     * Two orders of magnitude above a healthy `waitForIdle()` (milliseconds,
+     * even on a contended emulator with an IME animation in flight) and well
+     * under the 60-second deadline every journey poll loop carries, so a
+     * budget expiry leaves the loop most of its own budget to fail properly in.
+     */
+    const val BUDGET_MS: Long = 15_000L
+
+    private val waits = WeakHashMap<ComposeTestRule, BoundedWait>()
+
+    @Synchronized
+    private fun waitFor(rule: ComposeTestRule): BoundedWait =
+        waits.getOrPut(rule) { BoundedWait("compose-idle") }
+
+    fun await(rule: ComposeTestRule, label: String, budgetMs: Long = BUDGET_MS): Boolean =
+        waitFor(rule).run(label, budgetMs) { rule.waitForIdle() }
+
+    fun diagnosis(rule: ComposeTestRule): String = waitFor(rule).stuckDiagnosis()
+}
+
+/**
+ * `compose.waitForIdle()` with a deadline.
+ *
+ * Drop-in for every `waitForIdle()` call in this suite: identical behaviour on a
+ * healthy run (it returns as soon as Compose is idle), and a `false` return
+ * instead of an unbounded park when it is not. [label] names the wait in the
+ * timeout log line and in [idleWedgeNote].
+ */
+fun ComposeTestRule.awaitIdle(
+    label: String,
+    budgetMs: Long = ComposeIdle.BUDGET_MS,
+): Boolean = ComposeIdle.await(this, label, budgetMs)
+
+/**
+ * `"\n" + diagnosis` when an idle wait has blown its budget in this test, `""`
+ * otherwise — ready to append to an assertion message.
+ */
+fun ComposeTestRule.idleWedgeNote(): String =
+    ComposeIdle.diagnosis(this).let { if (it.isEmpty()) "" else "\n$it" }

--- a/app2/src/androidTest/java/com/pocketshell/next/connect/BoundedWaitTest.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/connect/BoundedWaitTest.kt
@@ -1,0 +1,137 @@
+package com.pocketshell.next.connect
+
+import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The bound in [BoundedWait] is the thing #2479 asked for, so it is asserted
+ * against a wait that genuinely never returns — not eyeballed.
+ *
+ * ## Why these run on the device rather than the JVM
+ *
+ * [BoundedWait] is journey-harness code and lives in `app2/src/androidTest`,
+ * which the JVM unit lane does not compile; and its callers pass it
+ * `ComposeTestRule.waitForIdle`, which only exists on a device. Wiring is
+ * automatic: `.github/workflows/app2.yml`'s `app2-journey` job runs
+ * `:app2:connectedDebugAndroidTest` ONCE, unfiltered, so every class under
+ * `app2/src/androidTest/` runs. These four cases add ~4 seconds to that lane
+ * and need no fixture, no Activity and no network.
+ *
+ * The budgets here are deliberately small (hundreds of milliseconds against a
+ * wait parked for hours) — the property under test is "the caller regains
+ * control at its deadline", and a small budget proves it as well as a 15-second
+ * one while keeping the lane fast.
+ */
+@RunWith(AndroidJUnit4::class)
+class BoundedWaitTest {
+
+    /**
+     * The #2479 shape itself: a wait that never returns must not consume more
+     * than its budget.
+     *
+     * `Long.MAX_VALUE` rather than a long sleep on purpose — a wait that
+     * "eventually" returns could pass this by accident.
+     */
+    @Test
+    fun aWaitThatNeverReturnsGivesUpWithinItsBudget() {
+        val bounded = BoundedWait("never-returns")
+        val started = SystemClock.elapsedRealtime()
+
+        val completed = bounded.run("parked-forever", budgetMs = 500L) {
+            parkForever()
+        }
+
+        val elapsed = SystemClock.elapsedRealtime() - started
+        assertFalse("a wait that never returns must not report completion", completed)
+        assertTrue("the budget must actually bound the call (took ${elapsed}ms)", elapsed < 5_000L)
+        assertTrue("the wedge must be reported for the failure message", bounded.isStuck())
+        assertTrue(
+            "the diagnosis must name the wait: ${bounded.stuckDiagnosis()}",
+            bounded.stuckDiagnosis().contains("parked-forever"),
+        )
+    }
+
+    /**
+     * The regression this issue is actually about, in miniature: a poll loop
+     * shaped exactly like `J03AttachAndTypeJourney.rotate()` — bounded loop,
+     * blocking wait in the body, condition that never comes true — must reach
+     * its own deadline and fail.
+     *
+     * Before the fix the equivalent loop parked on its FIRST iteration and
+     * never came back; the whole point is that the loop below still owns its
+     * clock.
+     */
+    @Test
+    fun aPollLoopWithAWedgedWaitStillReachesItsDeadline() {
+        val bounded = BoundedWait("wedged-poll")
+        val loopBudgetMs = 3_000L
+        val started = SystemClock.elapsedRealtime()
+        val deadline = started + loopBudgetMs
+        var iterations = 0
+        // The oracle `rotate()` polls for, standing in for "the terminal laid
+        // out landscape": here it never comes true, so only the loop's own
+        // deadline can end this.
+        val laidOut = { false }
+
+        while (SystemClock.elapsedRealtime() < deadline) {
+            bounded.run("idle-sync", budgetMs = 400L) { parkForever() }
+            iterations += 1
+            if (laidOut()) break
+            SystemClock.sleep(50L)
+        }
+
+        val elapsed = SystemClock.elapsedRealtime() - started
+        assertFalse("the fixture's condition never comes true", laidOut())
+        assertTrue(
+            "the loop must exit at its own deadline, not the wait's (took ${elapsed}ms)",
+            elapsed in loopBudgetMs..(loopBudgetMs + 5_000L),
+        )
+        // The first iteration pays the 400 ms budget; every later one is told
+        // immediately that the wait is already parked, which is what keeps the
+        // remaining budget available for real polling.
+        assertTrue("the loop must keep polling after the wedge ($iterations)", iterations > 3)
+    }
+
+    /** A healthy wait is unchanged: it completes, and nothing is reported stuck. */
+    @Test
+    fun aWaitThatReturnsIsReportedComplete() {
+        val bounded = BoundedWait("healthy")
+        var ran = 0
+
+        repeat(3) { assertTrue(bounded.run("quick", budgetMs = 5_000L) { ran += 1 }) }
+
+        assertEquals("the block must run every time", 3, ran)
+        assertFalse("nothing timed out, so nothing is stuck", bounded.isStuck())
+        assertEquals("no diagnosis when nothing wedged", "", bounded.stuckDiagnosis())
+    }
+
+    /**
+     * A real failure inside a wrapped wait must reach the test, not be laundered
+     * into "the wait timed out" or swallowed on the worker thread — otherwise
+     * the bound would hide the assertion failures it wraps.
+     */
+    @Test
+    fun aFailureInsideTheWaitReachesTheCaller() {
+        val bounded = BoundedWait("throwing")
+
+        val thrown = runCatching {
+            bounded.run("boom", budgetMs = 5_000L) { throw IllegalStateException("boom") }
+        }.exceptionOrNull()
+
+        assertTrue("expected the block's own exception, got $thrown", thrown is IllegalStateException)
+        assertEquals("boom", thrown?.message)
+        assertFalse("a thrown block is not a wedge", bounded.isStuck())
+    }
+
+    /** A wait that outlives its budget and never returns; the worker is a daemon. */
+    private fun parkForever() {
+        CountDownLatch(1).await(1L, TimeUnit.DAYS)
+    }
+}

--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/J03AttachAndTypeJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/J03AttachAndTypeJourney.kt
@@ -20,9 +20,12 @@ import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.SshKeyEntity
 import com.pocketshell.next.MainActivity
 import com.pocketshell.next.connect.AgentsFixture
+import com.pocketshell.next.connect.BoundedWait
 import com.pocketshell.next.connect.JourneyScreenshots
 import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.appGraph
+import com.pocketshell.next.connect.awaitIdle
+import com.pocketshell.next.connect.idleWedgeNote
 import com.pocketshell.next.hosts.hostRowTag
 import com.pocketshell.next.tree.SESSION_TREE_TAG
 import com.pocketshell.next.tree.sessionRowTag
@@ -93,6 +96,16 @@ class J03AttachAndTypeJourney {
         .around(compose)
 
     private var hostId: Long = 0
+
+    /**
+     * The bound around the FAILURE path's own Compose reads (#2479).
+     *
+     * [screenDiagnosis] reads the semantics tree, and every semantics read
+     * waits for Compose to be idle first — so the diagnosis gathered for a
+     * timeout caused by Compose never going idle would park forever and take
+     * the whole job down anyway, one line after the deadline finally fired.
+     */
+    private val diagnosisWait = BoundedWait("j03-diagnosis")
 
     /**
      * Puts the device back the way it was found.
@@ -378,7 +391,7 @@ class J03AttachAndTypeJourney {
         // and no Ctrl.
         compose.onNodeWithText(KEY_LABEL_CTRL).assertIsDisplayed()
         compose.onNodeWithText(KEY_LABEL_CTRL).performClick()
-        compose.waitForIdle()
+        compose.awaitIdle("after the Ctrl key-bar tap")
         typeCharacter('c')
 
         awaitHostSleep(running = false)
@@ -482,7 +495,7 @@ class J03AttachAndTypeJourney {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         var last = ""
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("transcript poll: $what")
             last = renderedTranscript()
             if (predicate(last)) return last
             SystemClock.sleep(POLL_MS)
@@ -490,10 +503,10 @@ class J03AttachAndTypeJourney {
         val shot = JourneyScreenshots.capture("failure-${what.replace(' ', '-')}", JOURNEY)
         throw AssertionError(
             "the terminal never rendered $what within ${TIMEOUT_MS}ms.\n" +
-                "Screen state: ${screenDiagnosis()}\n" +
+                "Screen state: ${safeScreenDiagnosis()}\n" +
                 "Rendered viewport was:\n$last\n" +
                 "The host's own capture-pane says:\n" + capturePane() + "\n" +
-                "Screenshot: ${shot.absolutePath}",
+                "Screenshot: ${shot.absolutePath}" + compose.idleWedgeNote(),
         )
     }
 
@@ -507,6 +520,26 @@ class J03AttachAndTypeJourney {
      * hierarchy — and each failed run would cost another round trip to tell
      * them apart.
      */
+    /**
+     * [screenDiagnosis] with a deadline, for use from a failing assertion.
+     *
+     * See [diagnosisWait]: a diagnosis that hangs is worse than no diagnosis,
+     * because it costs the run every other test's results.
+     */
+    private fun safeScreenDiagnosis(): String {
+        var text = ""
+        val read = diagnosisWait.run("screenDiagnosis", DIAGNOSIS_BUDGET_MS) {
+            text = screenDiagnosis()
+        }
+        return if (read) {
+            text
+        } else {
+            "UNAVAILABLE — reading the semantics tree did not return within " +
+                "${DIAGNOSIS_BUDGET_MS}ms, which means Compose is not going idle " +
+                "(see issue #2479)"
+        }
+    }
+
     private fun screenDiagnosis(): String {
         fun present(tag: String) =
             compose.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()
@@ -607,7 +640,7 @@ class J03AttachAndTypeJourney {
      */
     private fun focusTerminal() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
-        compose.waitForIdle()
+        compose.awaitIdle("before taking terminal focus")
         instrumentation.runOnMainSync {
             val view = terminalView()
             checkNotNull(view) { "no TerminalView on screen to type into" }
@@ -695,7 +728,7 @@ class J03AttachAndTypeJourney {
         throw AssertionError(
             "$what: the phone and the host never agreed on a terminal size within " +
                 "${TIMEOUT_MS}ms (last host pane=$host).\n" +
-                "Screen state: ${screenDiagnosis()}\n" +
+                "Screen state: ${safeScreenDiagnosis()}\n" +
                 "Rendered viewport was:\n" + renderedTranscript() + "\n" +
                 "The host's own capture-pane says:\n" + capturePane() + "\n" +
                 "Screenshot: ${shot.absolutePath}",
@@ -716,7 +749,7 @@ class J03AttachAndTypeJourney {
         val deadline = SystemClock.elapsedRealtime() + SIZE_REPLY_TIMEOUT_MS
         var nextHostCheck = SystemClock.elapsedRealtime() + SIZE_SETTLE_MS
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("stty reply poll")
             val replies = sizeLines(renderedTranscript())
             if (replies.size > repliesBefore && replies.last() == expected) return true
             if (SystemClock.elapsedRealtime() >= nextHostCheck) {
@@ -752,13 +785,16 @@ class J03AttachAndTypeJourney {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         var previous: RemoteSize? = null
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("host pane-size poll: $what")
             val current = hostPaneSize()
             if (current != null && current == previous) return current
             previous = current
             SystemClock.sleep(SIZE_SETTLE_MS)
         }
-        throw AssertionError("$what: the host's pane size never settled (last=$previous)")
+        throw AssertionError(
+            "$what: the host's pane size never settled (last=$previous)" +
+                compose.idleWedgeNote(),
+        )
     }
 
     /** `tmux display-message`, over the fixture's own connection, never the app's. */
@@ -816,7 +852,7 @@ class J03AttachAndTypeJourney {
      */
     /** The framework's own IME inset, in pixels. 0 when the keyboard is down. */
     private fun imeInsetBottom(): Int {
-        compose.waitForIdle()
+        compose.awaitIdle("before reading the IME inset")
         return compose.runOnUiThread {
             ViewCompat.getRootWindowInsets(compose.activity.window.decorView)
                 ?.getInsets(WindowInsetsCompat.Type.ime())
@@ -840,7 +876,8 @@ class J03AttachAndTypeJourney {
         val shot = JourneyScreenshots.capture("failure-ime-${visible}", JOURNEY)
         throw AssertionError(
             "the keyboard never became ${if (visible) "visible" else "hidden"} " +
-                "(ime inset bottom=$bottom). Screenshot: ${shot.absolutePath}",
+                "(ime inset bottom=$bottom). Screenshot: ${shot.absolutePath}" +
+                compose.idleWedgeNote(),
         )
     }
 
@@ -850,6 +887,24 @@ class J03AttachAndTypeJourney {
      * The Activity is recreated, so the vendored view is rebuilt and re-attached
      * to the SAME `TerminalSession` the ViewModel still owns — which is the U-4
      * design this exercises for the first time.
+     *
+     * ## The wait inside the loop is BOUNDED, and that is the point (#2479)
+     *
+     * This loop used to call `compose.waitForIdle()`, which has no timeout of
+     * its own — so when Compose refused to call the recreated Activity idle
+     * (twice on CI, repeatedly locally, always on the second rotation back to
+     * portrait) the FIRST iteration parked forever and the 60-second deadline
+     * below was unreachable. The instrumentation process then outlived the
+     * job's 45-minute step timeout, Gradle was killed before writing any
+     * `TEST-*.xml`, and the fifteen journeys that had already passed lost their
+     * evidence along with this one.
+     *
+     * [awaitIdle] gives that sync a budget and returns instead of parking, so a
+     * recurrence costs this one test, at the time it promised, with a
+     * screenshot and [idleWedgeNote]'s explanation of what actually stalled.
+     * The oracle is unaffected: the loop's real question — has the view been
+     * laid out the new way — is read on the main thread either way, and the
+     * idle sync only ever made that read cheaper to trust.
      */
     private fun rotate(orientation: Int) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
@@ -859,10 +914,11 @@ class J03AttachAndTypeJourney {
         instrumentation.waitForIdleSync()
 
         val wantWide = orientation == ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        val want = if (wantWide) "landscape" else "portrait"
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         var seen = "none"
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("rotation to $want")
             var laidOut = false
             instrumentation.runOnMainSync {
                 val view = terminalView()
@@ -877,9 +933,12 @@ class J03AttachAndTypeJourney {
             }
             SystemClock.sleep(POLL_MS)
         }
+        val shot = JourneyScreenshots.capture("failure-rotate-$want", JOURNEY)
         throw AssertionError(
-            "the terminal never laid out ${if (wantWide) "landscape" else "portrait"} " +
-                "(last seen $seen)",
+            "the terminal never laid out $want within ${TIMEOUT_MS}ms " +
+                "(last seen $seen).\n" +
+                "Screen state: ${safeScreenDiagnosis()}\n" +
+                "Screenshot: ${shot.absolutePath}" + compose.idleWedgeNote(),
         )
     }
 
@@ -901,7 +960,7 @@ class J03AttachAndTypeJourney {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         var count = -1
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("host sleep poll")
             count = AgentsFixture.exec(
                 "ps -eo args= | grep -c '^sleep $SLEEP_SECONDS\$' || true",
             ).trim().toIntOrNull() ?: -1
@@ -913,7 +972,7 @@ class J03AttachAndTypeJourney {
             "the host never reported `sleep $SLEEP_SECONDS` as " +
                 "${if (running) "running" else "gone"} (count=$count).\n" +
                 "The rendered viewport was:\n" + renderedTranscript() + "\n" +
-                "Screenshot: ${shot.absolutePath}",
+                "Screenshot: ${shot.absolutePath}" + compose.idleWedgeNote(),
         )
     }
 
@@ -967,6 +1026,14 @@ class J03AttachAndTypeJourney {
          * retry rather than the whole budget.
          */
         const val SIZE_REPLY_TIMEOUT_MS = 10_000L
+
+        /**
+         * How long the FAILURE path may spend gathering a screen diagnosis
+         * before giving up on it (#2479). Short on purpose: by the time this
+         * runs the test has already failed, and the only thing left to protect
+         * is the rest of the suite's results.
+         */
+        const val DIAGNOSIS_BUDGET_MS = 10_000L
 
         const val JOURNEY = "j03-attach-type"
 

--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/J05ReconnectAfterDropJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/J05ReconnectAfterDropJourney.kt
@@ -22,6 +22,7 @@ import com.pocketshell.next.connect.JourneyScreenshots
 import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.ToxiproxyControl
 import com.pocketshell.next.connect.appGraph
+import com.pocketshell.next.connect.awaitIdle
 import com.pocketshell.next.hosts.hostRowTag
 import com.pocketshell.next.tree.SESSION_TREE_TAG
 import com.pocketshell.next.tree.sessionRowTag
@@ -313,7 +314,7 @@ class J05ReconnectAfterDropJourney {
      * vacuous pass had the check been `contains` rather than a full match.
      */
     private fun bannerText(): String {
-        compose.waitForIdle()
+        compose.awaitIdle("before reading the reconnect banner")
         val node = compose.onNodeWithTag(SESSION_RECONNECT_BANNER_TAG).fetchSemanticsNode()
         return collectText(node).trim()
     }
@@ -338,7 +339,7 @@ class J05ReconnectAfterDropJourney {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         var last = ""
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("transcript poll: $what")
             last = renderedTranscript()
             if (predicate(squashed(last))) return last
             SystemClock.sleep(POLL_MS)
@@ -410,7 +411,7 @@ class J05ReconnectAfterDropJourney {
      */
     private fun typeLine(line: String) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
-        compose.waitForIdle()
+        compose.awaitIdle("before typing a line")
         instrumentation.runOnMainSync {
             val view = terminalView()
             checkNotNull(view) { "no TerminalView on screen to type into" }

--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/J06BackgroundGraceReturnJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/J06BackgroundGraceReturnJourney.kt
@@ -20,6 +20,7 @@ import com.pocketshell.next.connect.AgentsFixture
 import com.pocketshell.next.connect.JourneyScreenshots
 import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.appGraph
+import com.pocketshell.next.connect.awaitIdle
 import com.pocketshell.next.hosts.hostRowTag
 import com.pocketshell.next.tree.SESSION_TREE_TAG
 import com.pocketshell.next.tree.sessionRowTag
@@ -377,7 +378,7 @@ class J06BackgroundGraceReturnJourney {
      * semantics tree AT ALL, not merely "not currently displayed".
      */
     private fun assertNoReconnectBanner(`when`: String) {
-        compose.waitForIdle()
+        compose.awaitIdle("before asserting the reconnect banner is absent")
         assertTrue(
             "the reconnect banner must never render $`when`",
             compose.onAllNodesWithTag(SESSION_RECONNECT_BANNER_TAG).fetchSemanticsNodes().isEmpty(),
@@ -388,7 +389,7 @@ class J06BackgroundGraceReturnJourney {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         var last = ""
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("transcript poll: $what")
             last = renderedTranscript()
             if (predicate(squashed(last))) return last
             SystemClock.sleep(POLL_MS)
@@ -424,7 +425,7 @@ class J06BackgroundGraceReturnJourney {
 
     private fun typeLine(line: String) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
-        compose.waitForIdle()
+        compose.awaitIdle("before typing a line")
         instrumentation.runOnMainSync {
             val view = terminalView()
             checkNotNull(view) { "no TerminalView on screen to type into" }

--- a/app2/src/androidTest/java/com/pocketshell/next/usage/J12UsagePanelJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/usage/J12UsagePanelJourney.kt
@@ -18,6 +18,7 @@ import com.pocketshell.next.connect.AgentsFixture
 import com.pocketshell.next.connect.JourneyScreenshots
 import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.appGraph
+import com.pocketshell.next.connect.awaitIdle
 import com.pocketshell.next.hosts.hostRowTag
 import com.pocketshell.next.terminal.SESSION_SCREEN_TAG
 import com.pocketshell.next.tree.SESSION_TREE_TAG
@@ -178,7 +179,7 @@ class J12UsagePanelJourney {
     private fun awaitTag(tag: String, what: String = tag) {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         while (SystemClock.elapsedRealtime() < deadline) {
-            compose.waitForIdle()
+            compose.awaitIdle("tag poll: $what")
             if (compose.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()) return
             SystemClock.sleep(POLL_MS)
         }


### PR DESCRIPTION
## Summary
- `J03AttachAndTypeJourney.rotate()`'s "60s" poll loop wrapped an unbounded `compose.waitForIdle()`, so an unresponsive device wedged the whole Gradle process instead of failing the test — this is what turned an intermittent device hang into a 45-minute CI timeout with zero test results on main run 33888824496.
- Adds `BoundedWait`, a harness helper enforcing a real `Future`-backed timeout, with an instant-return on a still-parked previous call instead of queueing.
- Swaps the highest-risk `waitForIdle()` call sites (J03/J05/J06/J07/J08/J12) and bounds J03's failure-path diagnostics too.

## Verification
- Induced a permanent wedge: pre-fix shape hangs indefinitely with zero `TEST-*.xml`; bounded shape fails in ~60s with a screenshot, job completes with the other results intact.
- Full unfiltered app2 journey suite: 34 tests, 32 executed, 2 skipped (pre-existing #2478 quarantine), 0 failures, ~7m.
- Reviewer independently reproduced the wedge/fix mechanism and confirmed the root-cause lead (Compose's `waitForNextChoreographerFrame()` is a genuine unbounded busy-spin).

## Known residual (non-blocking, documented)
Several sibling journeys' swapped call sites are followed by `fetchSemanticsNodes()`, which re-enters an unbounded wait — so a wedge deeper in those journeys could still park. `J03.rotate()` itself (the site this issue names) is bounded end-to-end via `runOnMainSync`, not a semantics read. Four non-blocking follow-ups are on the issue.

**This does not close #2479** — the underlying device busy-spin root cause is still open; this only makes the symptom cheap to observe instead of destroying 45 minutes and all other test evidence.

Reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2479#issuecomment-5544583645

Refs #2479