### PR TITLE
fix: GraceService cross-journey FGS race

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/J06BackgroundGraceReturnJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/J06BackgroundGraceReturnJourney.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -284,6 +285,139 @@ class J06BackgroundGraceReturnJourney {
     }
 
     /**
+     * Regression for issue #2483, on the real device path.
+     *
+     * ## What broke
+     *
+     * A process can end up with more than one [GraceCoordinator] — Hilt's
+     * Android test harness rebuilds the whole `SingletonComponent` per
+     * `@HiltAndroidTest` method on top of ONE real `Application`, which is why
+     * [GraceCoordinator.register] hands over between instances at all (#2477).
+     * That hand-over used to only UNREGISTER the outgoing instance, leaving its
+     * already-armed window — and its expiry timer — running. Up to
+     * [GraceCoordinator.DEFAULT_GRACE_MS] later that zombie timer called
+     * `stop()` on the ONE process-global [GraceService], taking down whichever
+     * hold the CURRENT coordinator had open by then. The observable result is
+     * the exact failure the `app2` journey lane hit (CI run 33888824496):
+     * `isHolding == true` with NO notification, no foreground service and no
+     * wake lock — a session held with nothing keeping it alive and nothing to
+     * tell the user about it.
+     *
+     * ## Why it is driven this way
+     *
+     * The landmine's fuse is a full 90 s in production, and it is planted by a
+     * SUPERSEDED coordinator, so the only way to observe it inside a journey is
+     * to build the retired instance explicitly with a short window. Everything
+     * else here is real: the real [ConnectionsRegistry] with a real SSH session
+     * on the Docker fixture, the real [AndroidGraceServiceControl], the real
+     * foreground service, the real notification tray, and the real Activity
+     * stop/start boundary that arms the surviving coordinator's window.
+     */
+    @Test
+    fun aRetiredCoordinatorsExpiryCannotTakeDownTheLiveHold() {
+        openSession()
+        awaitTranscript("the fixture's banner line") { it.contains(BANNER) }
+        assertNoReconnectBanner("before the retired-coordinator scenario")
+
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val application =
+            instrumentation.targetContext.applicationContext as android.app.Application
+        val registry = appGraph().connectionsRegistry()
+
+        // The coordinator that is about to be retired, with a window short
+        // enough to observe. It opens a REAL hold over the REAL live
+        // connection this journey just dialled.
+        val retired = GraceCoordinator(
+            connections = registry,
+            service = AndroidGraceServiceControl(application),
+            graceMs = RETIRED_GRACE_MS,
+        )
+        instrumentation.runOnMainSync {
+            retired.register(application)
+            retired.enterBackground()
+        }
+        val retiredArmedAt = SystemClock.elapsedRealtime()
+        assertTrue(
+            "the retired-to-be coordinator must really open a window",
+            retired.isHolding,
+        )
+        awaitGraceNotification("for the soon-to-be-retired coordinator's own hold")
+
+        // A later Hilt component's coordinator takes over — the hand-over that
+        // has to leave NOTHING of the previous instance pending.
+        val current = GraceCoordinator(
+            connections = registry,
+            service = AndroidGraceServiceControl(application),
+        )
+        instrumentation.runOnMainSync { current.register(application) }
+
+        // The surviving coordinator opens its own window off the REAL activity
+        // stop boundary, exactly as a user switching apps would.
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        awaitHolding(current, "after backgrounding under the current coordinator")
+        awaitGraceNotification("after backgrounding under the current coordinator")
+        JourneyScreenshots.capture("06-current-hold-armed", JOURNEY)
+
+        // Anti-vacuous guard: if the retired coordinator's window had already
+        // elapsed by now there would be no zombie left to fire and this test
+        // would pass without testing anything.
+        val elapsed = SystemClock.elapsedRealtime() - retiredArmedAt
+        assertTrue(
+            "the current hold must be open BEFORE the retired window elapses, " +
+                "or this test proves nothing (took ${elapsed}ms of ${RETIRED_GRACE_MS}ms)",
+            elapsed < RETIRED_GRACE_MS,
+        )
+
+        // Sleep past the retired coordinator's deadline — the instant its
+        // zombie expiry used to stop the shared service out from under the
+        // current hold.
+        val wakeAt = retiredArmedAt + RETIRED_GRACE_MS + ZOMBIE_MARGIN_MS
+        while (SystemClock.elapsedRealtime() < wakeAt) {
+            SystemClock.sleep(POLL_MS)
+        }
+
+        assertTrue(
+            "the current coordinator's window must still be open",
+            current.isHolding,
+        )
+        assertNotNull(
+            "issue #2483: a retired coordinator's expiry must never take down the " +
+                "grace notification the CURRENT coordinator is holding — that leaves " +
+                "the session held with nothing user-visible and nothing keeping it alive",
+            graceNotification(),
+        )
+        assertTrue(
+            "and the retired coordinator's armed close must have been cancelled when it " +
+                "was retired, not left to close the live session minutes later",
+            registry.liveConnections().isNotEmpty(),
+        )
+        JourneyScreenshots.capture("07-hold-survived-retired-expiry", JOURNEY)
+
+        // Coming back must still be free: same session, no reconnect, no
+        // leftover notification.
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        awaitHolding(current, "after returning", expected = false)
+        awaitNoGraceNotification("after returning")
+        assertNoReconnectBanner("after returning from the retired-coordinator scenario")
+        compose.onNodeWithTag(SESSION_ERROR_BANNER_TAG).assertDoesNotExist()
+
+        typeLine("echo $RETIRED_MARKER")
+        awaitTranscript("the echoed marker twice") {
+            squashed(it).split(RETIRED_MARKER).size >= 3
+        }
+        val pane = capturePane()
+        assertTrue(
+            "the host's pane must show the command typed after the retired window elapsed, got:\n$pane",
+            squashed(pane).contains("echo$RETIRED_MARKER"),
+        )
+        JourneyScreenshots.capture("08-retired-scenario-session-still-usable", JOURNEY)
+
+        // Same reason as the sibling test: leave no live connection behind for
+        // the Activity teardown to arm a real window over.
+        runBlocking { registry.closeAll() }
+    }
+
+    /**
      * A user who never opened a host and only backgrounds the app must not
      * find PocketShell holding a notification in their tray.
      */
@@ -326,6 +460,23 @@ class J06BackgroundGraceReturnJourney {
 
     /** [GraceCoordinator.isHolding], read from the app's real Hilt singleton. */
     private fun graceHolding(): Boolean = appGraph().graceCoordinator().isHolding
+
+    /**
+     * [awaitGraceHolding] against a coordinator the test built itself, rather
+     * than the app's Hilt singleton (issue #2483's scenario retires that one).
+     */
+    private fun awaitHolding(
+        coordinator: GraceCoordinator,
+        what: String,
+        expected: Boolean = true,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (coordinator.isHolding == expected) return
+            SystemClock.sleep(POLL_MS)
+        }
+        throw AssertionError("the coordinator's isHolding never became $expected $what")
+    }
 
     private fun awaitGraceHolding(expected: Boolean, what: String) {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
@@ -463,10 +614,24 @@ class J06BackgroundGraceReturnJourney {
         const val PROMPT = "J06READY\$"
         const val BANNER = "J06-FIXTURE-PANE"
         const val MARKER = "j06-still-alive"
+        const val RETIRED_MARKER = "j06-retired-coordinator-ok"
+
+        /**
+         * Issue #2483's retired coordinator gets a SHORT window so its zombie
+         * expiry lands inside the test rather than 90 s later. Long enough that
+         * the hand-over and the current coordinator's own backgrounding
+         * comfortably finish first — and the test asserts they did, rather than
+         * assuming it.
+         */
+        const val RETIRED_GRACE_MS = 12_000L
+
+        /** Head-room past the retired window, so the zombie has provably had its chance. */
+        const val ZOMBIE_MARGIN_MS = 5_000L
 
         val HOST_IDS: Map<String, Long> = mapOf(
             "returningWithinGraceKeepsTheSessionAliveWithNoReconnectBanner" to 9_601L,
             "backgroundingWithNoOpenSessionShowsNoHoldAndNoNotification" to 9_602L,
+            "aRetiredCoordinatorsExpiryCannotTakeDownTheLiveHold" to 9_603L,
         )
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/terminal/GraceCoordinator.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/GraceCoordinator.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -116,6 +117,13 @@ class GraceCoordinator(
 
     private val registered = AtomicBoolean(false)
 
+    /**
+     * Set once this instance has been retired by a later [register] call. A
+     * retired coordinator is inert: it owns no window, drives no service and
+     * can never arm another one — see [supersede] (issue #2483).
+     */
+    private val retired = AtomicBoolean(false)
+
     /** For tests and diagnostics: is a background window open right now? */
     val isHolding: Boolean get() = synchronized(lock) { armed }
 
@@ -128,18 +136,23 @@ class GraceCoordinator(
      * main-thread-only and a `@Singleton` is created on whichever thread first
      * injects it (the same reason [ProcessForegroundSignal] posts).
      *
-     * Also unregisters whichever OTHER [GraceCoordinator] instance was
-     * previously the process's active one — see [activeInstance] for why that
-     * is load-bearing rather than defensive ceremony (issue #2477).
+     * Also RETIRES whichever OTHER [GraceCoordinator] instance was previously
+     * the process's active one — see [activeInstance] for why that is
+     * load-bearing rather than defensive ceremony (issue #2477), and
+     * [supersede] for why unregistering it is not enough on its own (issue
+     * #2483).
      */
     fun register(application: Application) {
         if (!registered.compareAndSet(false, true)) return
         val wire = Runnable {
-            val previous = activeInstance.getAndSet(this)
-            if (previous != null && previous !== this) {
-                ProcessLifecycleOwner.get().lifecycle.removeObserver(previous)
-                application.unregisterActivityLifecycleCallbacks(previous)
-            }
+            // Retire the outgoing instance BEFORE this one becomes the active
+            // one, so its own hand-over stop is still the stop of the hold it
+            // opened, and so it has provably finished touching the shared
+            // service before this instance can ever start it.
+            activeInstance.get()
+                ?.takeIf { it !== this }
+                ?.supersede(application)
+            activeInstance.set(this)
             ProcessLifecycleOwner.get().lifecycle.addObserver(this)
             application.registerActivityLifecycleCallbacks(this)
         }
@@ -148,6 +161,39 @@ class GraceCoordinator(
         } else {
             Handler(Looper.getMainLooper()).post(wire)
         }
+    }
+
+    /**
+     * Retires this instance in favour of the one now registering (issue #2483).
+     *
+     * Unregistering the observers — all #2477 did — stops a superseded
+     * coordinator REACTING to anything new, but leaves everything it had
+     * ALREADY armed running: its `armed` flag, its pending [GraceHandle]s and,
+     * worst, its [expiry] job. That job still fires up to [graceMs] later and
+     * calls `service.stop()`. There is exactly ONE [GraceService] in a process,
+     * so that late stop takes down whichever hold the CURRENT coordinator has
+     * open by then — leaving [isHolding] true with no foreground service, no
+     * notification and no wake lock behind it, which is the precise state the
+     * grace notification exists to make impossible. In the `app2` journey lane
+     * that is a [graceMs]-long landmine planted by every test class whose
+     * teardown backgrounds a live connection, and it detonated inside
+     * `J06BackgroundGraceReturnJourney` (CI run 33888824496).
+     *
+     * So the hand-over is completed HERE, synchronously, on the main thread
+     * that is doing the registering: unregister, close the window (which
+     * cancels the pending closes and takes the service down — the app is coming
+     * back to the foreground, which is exactly what [enterForeground] means),
+     * then make the instance inert so nothing can re-arm it. Every one of those
+     * steps happens strictly before the incoming coordinator becomes active, so
+     * "old stop" and "new start" can never be reordered.
+     */
+    private fun supersede(application: Application) {
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(this)
+        application.unregisterActivityLifecycleCallbacks(this)
+        enterForeground()
+        retired.set(true)
+        // Belt and braces: no job this instance ever launched may still run.
+        scope.cancel()
     }
 
     // --- the two transitions -------------------------------------------------
@@ -159,6 +205,11 @@ class GraceCoordinator(
      * Idempotent — see the class doc for why it is called from two places.
      */
     fun enterBackground(): Unit = synchronized(lock) {
+        // A retired instance must never start the ONE shared service for a
+        // graph that no longer owns it, however it is reached — the lifecycle
+        // callbacks are gone, but a direct call is still possible from anything
+        // still holding the old singleton (issue #2483).
+        if (retired.get()) return
         if (armed) return
         val live = connections.liveConnections()
         // Nothing to hold: no service, no notification, no wake lock.
@@ -269,10 +320,17 @@ class GraceCoordinator(
          * on a full, unfiltered suite run: J05's own leftover coordinator,
          * still alive and still registered, rearmed the shared notification
          * for J05's own never-closed connection while J06's test had opened
-         * none of its own. [register] now unregisters whichever instance this
-         * one is replacing, so at most one [GraceCoordinator] can ever answer
-         * a lifecycle callback — true by construction, not by assuming a
-         * component-recreation environment never happens.
+         * none of its own. [register] now RETIRES whichever instance this one
+         * is replacing ([supersede]), so at most one [GraceCoordinator] can
+         * ever answer a lifecycle callback OR still own a window — true by
+         * construction, not by assuming a component-recreation environment
+         * never happens.
+         *
+         * Unregistering alone was not enough (issue #2483): it left the
+         * superseded instance's already-armed window — and its expiry timer —
+         * running, so a stop meant for a window that ended minutes ago landed
+         * on the CURRENT coordinator's hold. [supersede] closes the window as
+         * part of the hand-over.
          */
         private val activeInstance = AtomicReference<GraceCoordinator?>(null)
 

--- a/app2/src/main/java/com/pocketshell/next/terminal/GraceService.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/GraceService.kt
@@ -16,6 +16,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.pocketshell.next.MainActivity
 import com.pocketshell.next.R
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Keeps the process (and with it the SSH transport) alive for the bounded grace
@@ -214,13 +215,41 @@ class GraceService : Service() {
         internal const val BODY = "Disconnecting in"
 
         /**
-         * Brings the service up with a count-down to [deadlineMs].
+         * The token of no hold at all. [stop] with this is always a no-op.
+         */
+        internal const val NO_HOLD: Long = 0L
+
+        /**
+         * Which hold the service is up for right now (issue #2483).
+         *
+         * There is exactly ONE [GraceService] per process, so "stop the grace
+         * service" is inherently ambiguous the moment more than one caller can
+         * issue it — and `Context.stopService()` is unconditional: it takes the
+         * service down however many `startForegroundService()` calls preceded
+         * it, so a stop meant for a window that already ended silently cancels
+         * whichever window is open NOW. Every [start] therefore mints a token,
+         * and [stop] only acts when its token is still the newest — a caller
+         * may only take down the hold it opened, never a later one.
+         *
+         * Static/companion-scoped for the same reason
+         * [GraceCoordinator.activeInstance] is: the environments where a second
+         * owner exists (Hilt's Android test harness rebuilds the whole
+         * `SingletonComponent`, and with it [AndroidGraceServiceControl], per
+         * test method) are exactly the ones where per-instance state would not
+         * see the collision.
+         */
+        private val holdGeneration = AtomicLong(NO_HOLD)
+
+        /**
+         * Brings the service up with a count-down to [deadlineMs], and returns
+         * the token identifying THIS hold — hand it back to [stop].
          *
          * MUST be called while the app is still foreground-eligible — see
          * [GraceCoordinator]'s class doc for why that is the activity-stopped
          * boundary and not `ProcessLifecycleOwner`'s debounced `ON_STOP`.
          */
-        fun start(context: Context, deadlineMs: Long) {
+        fun start(context: Context, deadlineMs: Long): Long {
+            val token = holdGeneration.incrementAndGet()
             val intent = Intent(context, GraceService::class.java)
                 .putExtra(EXTRA_DEADLINE_MS, deadlineMs)
             runCatching { ContextCompat.startForegroundService(context, intent) }
@@ -230,10 +259,19 @@ class GraceService : Service() {
                     // and the reconnect ladder covers the return.
                     Log.w(TAG, "grace foreground service start was rejected", it)
                 }
+            return token
         }
 
-        /** Takes the service down. Safe when it is not running. */
-        fun stop(context: Context) {
+        /**
+         * Takes down the hold [token] opened. Safe when it is not running, and
+         * a NO-OP when a later hold has since replaced [token]'s — see
+         * [holdGeneration].
+         */
+        fun stop(context: Context, token: Long) {
+            if (token == NO_HOLD || holdGeneration.get() != token) {
+                Log.d(TAG, "ignoring a stop for a superseded grace hold ($token)")
+                return
+            }
             runCatching { context.stopService(Intent(context, GraceService::class.java)) }
                 .onFailure { Log.w(TAG, "grace foreground service stop was rejected", it) }
         }
@@ -243,10 +281,20 @@ class GraceService : Service() {
 /**
  * The production [GraceServiceControl]: [GraceService], started and stopped
  * against the application context.
+ *
+ * Remembers the token of the hold IT opened, so its [stop] can only ever take
+ * down that hold and never a later owner's (issue #2483 — see
+ * [GraceService.holdGeneration]).
  */
 class AndroidGraceServiceControl(private val context: Context) : GraceServiceControl {
 
-    override fun start(deadlineMs: Long) = GraceService.start(context, deadlineMs)
+    private val token = AtomicLong(GraceService.NO_HOLD)
 
-    override fun stop() = GraceService.stop(context)
+    override fun start(deadlineMs: Long) {
+        token.set(GraceService.start(context, deadlineMs))
+    }
+
+    override fun stop() {
+        GraceService.stop(context, token.getAndSet(GraceService.NO_HOLD))
+    }
 }

--- a/app2/src/test/java/com/pocketshell/next/terminal/AndroidGraceServiceControlTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/AndroidGraceServiceControlTest.kt
@@ -1,0 +1,117 @@
+package com.pocketshell.next.terminal
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * The second half of issue #2483's fix: the [GraceService] seam itself.
+ *
+ * [GraceCoordinator.register] now retires the instance it replaces, so in
+ * principle no stale owner is left to issue a stop. This asserts the property
+ * that makes that safe rather than merely likely — a stop may only take down
+ * the hold ITS caller opened. There is one [GraceService] per process and
+ * `Context.stopService()` is unconditional, so without the token an owner whose
+ * window ended can cancel a window opened by someone else, which is exactly the
+ * "`isHolding == true`, no notification, no wake lock" state the `app2` journey
+ * lane caught (CI run 33888824496).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class AndroidGraceServiceControlTest {
+
+    private val application: Application = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `a stale owner's stop cannot take down a newer owner's hold`() {
+        val stale = AndroidGraceServiceControl(application)
+        val current = AndroidGraceServiceControl(application)
+
+        stale.start(DEADLINE_MS)
+        current.start(DEADLINE_MS + 1_000L)
+        drainStartedServices()
+
+        stale.stop()
+
+        assertNull(
+            "issue #2483: an owner whose window has ended must not stop the service " +
+                "a later owner is holding",
+            shadowOf(application).nextStoppedService,
+        )
+
+        // ...and the owner that DID open the live hold still can.
+        current.stop()
+        assertEquals(
+            GraceService::class.java.name,
+            shadowOf(application).nextStoppedService?.component?.className,
+        )
+    }
+
+    @Test
+    fun `the owner of the newest hold stops the service`() {
+        val control = AndroidGraceServiceControl(application)
+
+        control.start(DEADLINE_MS)
+        assertNotNull(
+            "the hold must really start the foreground service",
+            shadowOf(application).nextStartedService,
+        )
+
+        control.stop()
+        assertEquals(
+            GraceService::class.java.name,
+            shadowOf(application).nextStoppedService?.component?.className,
+        )
+    }
+
+    @Test
+    fun `stopping a control that never started anything is a no-op`() {
+        val control = AndroidGraceServiceControl(application)
+
+        control.stop()
+
+        assertNull(
+            "a control holding nothing must not take down whatever is running",
+            shadowOf(application).nextStoppedService,
+        )
+    }
+
+    @Test
+    fun `a second stop from the same owner does not take down the next hold`() {
+        val control = AndroidGraceServiceControl(application)
+        control.start(DEADLINE_MS)
+        drainStartedServices()
+        control.stop()
+        assertNotNull(shadowOf(application).nextStoppedService)
+
+        // A duplicate stop (both lifecycle paths racing to end the same window)
+        // must not survive as a pending cancel for the NEXT window.
+        control.stop()
+        val next = AndroidGraceServiceControl(application)
+        next.start(DEADLINE_MS + 2_000L)
+        drainStartedServices()
+
+        assertNull(
+            "a repeated stop must not take down a window opened afterwards",
+            shadowOf(application).nextStoppedService,
+        )
+    }
+
+    private fun drainStartedServices() {
+        while (shadowOf(application).nextStartedService != null) {
+            // Robolectric queues started services; clear it so the assertions
+            // below are about what THIS step did.
+        }
+    }
+
+    private companion object {
+        const val DEADLINE_MS = 1_700_000_000_000L
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/terminal/FakeGraceServiceControl.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/FakeGraceServiceControl.kt
@@ -19,14 +19,27 @@ class FakeGraceServiceControl : GraceServiceControl {
 
     val startCount: Int get() = startedDeadlines.size
 
-    /** True between the most recent unmatched [start] and the next [stop]. */
-    val isRunning: Boolean get() = startCount > stopCount
+    /**
+     * Is the (ONE, process-global) service up right now?
+     *
+     * Modelled as a flip-flop rather than `startCount > stopCount` because that
+     * is what the OS does: `Context.stopService()` takes [GraceService] down
+     * unconditionally, however many `startForegroundService()` calls preceded
+     * it. A counter-derived "running" cannot see the failure this fake exists
+     * to expose (issue #2483) — a STALE owner's stop landing on top of a
+     * LIVE hold reads as "still running" to a counter and as "gone" to the
+     * notification tray.
+     */
+    var isRunning: Boolean = false
+        private set
 
     override fun start(deadlineMs: Long) {
         startedDeadlines += deadlineMs
+        isRunning = true
     }
 
     override fun stop() {
         stopCount += 1
+        isRunning = false
     }
 }

--- a/app2/src/test/java/com/pocketshell/next/terminal/GraceCoordinatorTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/GraceCoordinatorTest.kt
@@ -356,6 +356,213 @@ class GraceCoordinatorTest {
         assertEquals(1, serviceTwo.startCount)
     }
 
+    /**
+     * Regression for issue #2483 — the half of the #2477 story that fix did
+     * not cover.
+     *
+     * #2477 stopped a superseded [GraceCoordinator] from REACTING to later
+     * lifecycle callbacks, but left everything it had already armed running:
+     * its `armed` flag, its pending [com.pocketshell.core.transport.GraceHandle]s
+     * and — the one that bites — its expiry [kotlinx.coroutines.Job], which
+     * still fires up to [GraceCoordinator.DEFAULT_GRACE_MS] later and calls
+     * `stop()` on a service it no longer owns. There is only ONE [GraceService]
+     * in a process, so that late stop takes down whichever hold the CURRENT
+     * coordinator has open — leaving `isHolding == true` with no foreground
+     * service, no notification and no wake lock behind it. In the `app2`
+     * journey lane that is a 90-second landmine planted by every test class
+     * whose teardown backgrounds a live connection, and it detonated inside
+     * `J06BackgroundGraceReturnJourney` (CI run 33888824496).
+     *
+     * The single [FakeGraceServiceControl] shared by both coordinators is the
+     * point: production has one service, and the two Hilt components a test
+     * process builds both drive it.
+     */
+    @Test
+    fun `a superseded coordinator's expiry can no longer take down the current hold`() = runTest {
+        val application = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val service = FakeGraceServiceControl()
+
+        // BOTH dials happen before anything is armed: `runTest` advances the
+        // virtual clock freely whenever the test body suspends, so a dial made
+        // after a window is open would silently skip past its expiry.
+        val (registryOne, connectionOne) = registryWithOneLiveConnection()
+        val (registryTwo, _) = registryWithOneLiveConnection()
+
+        val coordinatorOne = GraceCoordinator(
+            connections = registryOne,
+            service = service,
+            clock = { 0L },
+            graceMs = GRACE_MS,
+            dispatcher = dispatcher,
+        )
+        coordinatorOne.register(application)
+
+        // A previous test method's Activity is destroyed while its connection
+        // is still live: a REAL background, arming a REAL window.
+        val first = Robolectric.buildActivity(Activity::class.java)
+        first.create().start().resume()
+        runCurrent()
+        first.pause().stop()
+        runCurrent()
+        assertTrue("the first coordinator must own a real window", coordinatorOne.isHolding)
+        assertTrue(service.isRunning)
+
+        // The next test method's fresh Hilt component builds a new coordinator
+        // over the same process and the same service.
+        val coordinatorTwo = GraceCoordinator(
+            connections = registryTwo,
+            service = service,
+            clock = { 0L },
+            graceMs = GRACE_MS,
+            dispatcher = dispatcher,
+        )
+        coordinatorTwo.register(application)
+        runCurrent()
+
+        // Deliberately NOT asserting the old window is already closed here —
+        // that is the sibling test below. This one has to reach the moment the
+        // zombie expiry actually fires, so it asserts nothing until then.
+
+        // Two thirds into the superseded coordinator's original window, the
+        // CURRENT coordinator opens one of its own.
+        advanceTimeBy(GRACE_MS * 2 / 3)
+        runCurrent()
+        val second = Robolectric.buildActivity(Activity::class.java)
+        second.create().start().resume()
+        runCurrent()
+        second.pause().stop()
+        runCurrent()
+        assertTrue("the current coordinator must own the new window", coordinatorTwo.isHolding)
+        assertTrue(service.isRunning)
+
+        // Past the superseded coordinator's deadline, still well inside the
+        // current one's. This is the instant the zombie expiry used to fire.
+        advanceTimeBy(GRACE_MS / 2)
+        runCurrent()
+
+        assertTrue(
+            "the current coordinator's window must still be open",
+            coordinatorTwo.isHolding,
+        )
+        assertTrue(
+            "issue #2483: a superseded coordinator's expiry must never take down the " +
+                "process-global grace service the CURRENT coordinator is holding — that " +
+                "leaves isHolding==true with no notification and no wake lock behind it",
+            service.isRunning,
+        )
+        assertTrue(
+            "and the superseded coordinator's own armed close must have been cancelled " +
+                "when it was retired, not left to close a connection minutes later",
+            connectionOne.graceHandles.single().isCancelled,
+        )
+    }
+
+    /**
+     * Regression for issue #2483: being superseded must END the retired
+     * instance's window then and there, on the thread that retired it — so the
+     * hand-over is ordered with respect to whatever the NEW coordinator does
+     * next, rather than leaving a stop pending on a timer.
+     */
+    @Test
+    fun `superseding a coordinator ends its window immediately`() = runTest {
+        val application = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val service = FakeGraceServiceControl()
+
+        val (registryOne, connectionOne) = registryWithOneLiveConnection()
+        val (registryTwo, _) = registryWithOneLiveConnection()
+
+        val coordinatorOne = GraceCoordinator(
+            connections = registryOne,
+            service = service,
+            clock = { 0L },
+            graceMs = GRACE_MS,
+            dispatcher = dispatcher,
+        )
+        coordinatorOne.register(application)
+        coordinatorOne.enterBackground()
+        runCurrent()
+        assertTrue(coordinatorOne.isHolding)
+        assertTrue(service.isRunning)
+
+        val coordinatorTwo = GraceCoordinator(
+            connections = registryTwo,
+            service = service,
+            clock = { 0L },
+            graceMs = GRACE_MS,
+            dispatcher = dispatcher,
+        )
+        coordinatorTwo.register(application)
+        runCurrent()
+
+        assertFalse(
+            "a superseded coordinator must not still be holding a window",
+            coordinatorOne.isHolding,
+        )
+        assertTrue(
+            "a superseded coordinator's armed close must be cancelled, not left to fire",
+            connectionOne.graceHandles.single().isCancelled,
+        )
+        assertEquals(
+            "the hand-over must take the shared service down exactly once, synchronously",
+            1,
+            service.stopCount,
+        )
+        assertFalse(service.isRunning)
+    }
+
+    /**
+     * Regression for issue #2483: being superseded also has to stop the
+     * instance from ever driving the shared service again, not merely stop it
+     * reacting to lifecycle callbacks — a direct call (the app2 journeys make
+     * them, and so does anything holding a reference to the old singleton)
+     * must not be able to start a foreground service for a graph that no
+     * longer owns one.
+     */
+    @Test
+    fun `a superseded coordinator can no longer arm a window at all`() = runTest {
+        val application = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val service = FakeGraceServiceControl()
+
+        val (registryOne, _) = registryWithOneLiveConnection()
+        val (registryTwo, _) = registryWithOneLiveConnection()
+
+        val coordinatorOne = GraceCoordinator(
+            connections = registryOne,
+            service = service,
+            clock = { 0L },
+            graceMs = GRACE_MS,
+            dispatcher = dispatcher,
+        )
+        coordinatorOne.register(application)
+
+        val coordinatorTwo = GraceCoordinator(
+            connections = registryTwo,
+            service = service,
+            clock = { 0L },
+            graceMs = GRACE_MS,
+            dispatcher = dispatcher,
+        )
+        coordinatorTwo.register(application)
+        runCurrent()
+
+        coordinatorOne.enterBackground()
+        runCurrent()
+
+        assertFalse(
+            "a retired coordinator must not arm a window",
+            coordinatorOne.isHolding,
+        )
+        assertEquals(
+            "a retired coordinator must never start the shared service",
+            0,
+            service.startCount,
+        )
+        assertFalse(service.isRunning)
+    }
+
     private companion object {
         const val GRACE_MS = GraceCoordinator.DEFAULT_GRACE_MS
     }


### PR DESCRIPTION
## Summary
- `GraceCoordinator.register()`'s hand-over (#2477) unregistered a superseded instance's lifecycle observers but left its already-armed grace-expiry timer running. Since there's one `GraceService` per process and `stopService()` is unconditional, that stale timer fires later and tears down whatever hold the CURRENT coordinator has open.
- Fix: `supersede()` now cancels the superseded instance's scope (including any in-flight expiry job) before the new instance activates; `GraceService` also gets an independent monotonic hold-token guard so a stale stop can't take down a newer hold even from an unrelated path.

## Verification
- Device RED on unmodified code (both fixes neutralized) reproduces the exact symptom: `isHolding == true` with no FGS/notification/wake lock.
- 16 device runs / 48 J06 method executions, 0 failures, with the fix.
- Mutation-liveness: neutralizing `supersede()` reddens 3 new `GraceCoordinatorTest` cases; stubbing the hold-token guard reddens 3/4 `AndroidGraceServiceControlTest` cases.
- `:app2:testDebugUnitTest` 770/770.
- D31 adjacency sweep (reviewer): full app2 set minus J03 → 24 executed, 0 failures, including both J05 reconnect methods and #2477's own symptom test.
- Rebased cleanly onto current `main` (post-#2479) — auto-merge, no conflicts. Confirmatory full-suite re-run attempted 3x post-rebase; all 3 hit a known, now-filed infra bug (#2501, agents-pool port-lock collision) mid-run and were voided by the run's own disturbance guard — not a signal on this fix. The reviewer's independent pre-rebase run stands as the primary evidence.

Reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2483#issuecomment-5545322549

Closes #2483