### PR TITLE
fix: a failed or truncated port scan must not tear down live forwards

### DIFF
--- a/shared/core-portfwd/src/integrationTest/java/com/pocketshell/core/portfwd/PortForwardIntegrationTest.kt
+++ b/shared/core-portfwd/src/integrationTest/java/com/pocketshell/core/portfwd/PortForwardIntegrationTest.kt
@@ -188,10 +188,13 @@ class PortForwardIntegrationTest {
     fun portScannerDiscoversSshdOnPort22InsideTheContainer() = runBlocking {
         val connection = connect()
         try {
-            val ports = PortScanner.scan(connection)
+            val scan = PortScanner.scan(connection)
             // Alpine busybox has no `ss`, so the netstat fallback wins. We accept
             // either path (different distros pick differently); what matters is
-            // that port 22 lands somewhere.
+            // that port 22 lands somewhere — and that a real container scan
+            // reports Ports, never Failed (issue #2489).
+            assertTrue("expected a successful scan, got $scan", scan is PortScanResult.Ports)
+            val ports = (scan as PortScanResult.Ports).ports
             assertTrue("expected to find sshd on port 22, got $ports", ports.any { it.port == 22 })
         } finally {
             connection.close()
@@ -266,7 +269,8 @@ class PortForwardIntegrationTest {
             assertTrue(
                 "the remote service never started listening on $REMOTE_SERVICE_PORT",
                 waitUntilTrue(ciScaled(10_000)) {
-                    runBlocking { PortScanner.scan(connection) }.any { it.port == REMOTE_SERVICE_PORT }
+                    val scan = runBlocking { PortScanner.scan(connection) }
+                    scan is PortScanResult.Ports && scan.ports.any { it.port == REMOTE_SERVICE_PORT }
                 },
             )
 

--- a/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarder.kt
+++ b/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarder.kt
@@ -331,7 +331,19 @@ public class AutoForwarder(
     }
 
     private suspend fun scanAndForward() {
-        val remotePorts = PortScanner.scan(connection)
+        // A failed scan (every strategy errored, timed out, or produced
+        // nothing) is NOT an observation that the remote's ports vanished, so
+        // it must not drive the teardown sweep below — one transient exec
+        // timeout used to close every auto-forwarded tunnel and reset the TCP
+        // connections running through them (issue #2489). We still run the
+        // rest of the tick: the user's manual desired-state ports (issue #439)
+        // are re-opened from our own state, not from the scan.
+        val scan = PortScanner.scan(connection)
+        val remotePorts = when (scan) {
+            is PortScanResult.Ports -> scan.ports
+            PortScanResult.Failed -> emptyList()
+        }
+        val scanObservedRemote = scan is PortScanResult.Ports
         val remotePortSet = remotePorts.map { it.port }.toSet()
 
         val tunnelsToClose = mutableListOf<PortForward>()
@@ -382,25 +394,34 @@ public class AutoForwarder(
             // Tear down forwards whose remote port has vanished — but keep
             // ones the user manually toggled on; those persist across
             // disappearances (the user may have just restarted the service).
-            tunnels.keys.toList().forEach { remotePort ->
-                if (remotePort !in remotePortSet && remotePort !in manualPorts) {
-                    detachTunnelLocked(remotePort)?.let(tunnelsToClose::add)
+            //
+            // Only a scan that actually observed the remote may conclude a
+            // port vanished. Without this guard a failed scan's empty port set
+            // made every forwarded port look gone (issue #2489).
+            if (scanObservedRemote) {
+                tunnels.keys.toList().forEach { remotePort ->
+                    if (remotePort !in remotePortSet && remotePort !in manualPorts) {
+                        detachTunnelLocked(remotePort)?.let(tunnelsToClose::add)
+                    }
                 }
-            }
-            localPortMap.keys.toList().forEach { remotePort ->
-                if (
-                    remotePort !in tunnels &&
-                    remotePort !in remotePortSet &&
-                    remotePort !in manualPorts
-                ) {
-                    localPortMap.remove(remotePort)
+                localPortMap.keys.toList().forEach { remotePort ->
+                    if (
+                        remotePort !in tunnels &&
+                        remotePort !in remotePortSet &&
+                        remotePort !in manualPorts
+                    ) {
+                        localPortMap.remove(remotePort)
+                    }
                 }
-            }
 
-            // Reset the failed-port memo for ports that have disappeared, so
-            // a future "service restarted on the same port" attempt gets a
-            // fresh try rather than being suppressed forever.
-            failedPorts.keys.removeAll { it !in remotePortSet }
+                // Reset the failed-port memo for ports that have disappeared,
+                // so a future "service restarted on the same port" attempt
+                // gets a fresh try rather than being suppressed forever. Also
+                // scan-derived, so it stays inside the guard: clearing the
+                // deny-list on every failed scan would turn a transport
+                // outage into an open-retry storm.
+                failedPorts.keys.removeAll { it !in remotePortSet }
+            }
 
             updateStateLocked()
             (discoveredPortsToOpen + manualPortsToOpen).distinct()

--- a/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/PortScanner.kt
+++ b/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/PortScanner.kt
@@ -11,6 +11,36 @@ public data class RemotePort(
 )
 
 /**
+ * Outcome of one [PortScanner.scan].
+ *
+ * The two cases are deliberately distinct types rather than "a list that may
+ * be empty" (issue #2489): the caller tears down forwards whose remote port
+ * has vanished, and a failed scan is NOT evidence that anything vanished. A
+ * list-shaped return let one transient exec failure look like "every port
+ * disappeared" and close every auto-forwarded tunnel.
+ */
+public sealed interface PortScanResult {
+
+    /**
+     * A strategy ran and produced at least one listening port. This is the
+     * only outcome the vanished-port sweep may act on.
+     */
+    public data class Ports(public val ports: List<RemotePort>) : PortScanResult
+
+    /**
+     * Every strategy failed: the command errored, timed out, produced no
+     * output, or produced output no parser recognised. The caller must leave
+     * its existing tunnels alone and retry on the next tick.
+     *
+     * Note there is no "succeeded with zero ports" outcome: every host we can
+     * scan is reached over SSH, so its own sshd is always listening. A scan
+     * that finds literally nothing has failed, it has not observed an idle
+     * host.
+     */
+    public data object Failed : PortScanResult
+}
+
+/**
  * Scans a remote host for TCP ports in `LISTEN` state.
  *
  * Tries three strategies in order, falling back when one fails or returns
@@ -30,23 +60,26 @@ public data class RemotePort(
 public object PortScanner {
 
     /**
-     * Run a scan over [connection] and return one [RemotePort] per discovered
-     * listening port. Returns an empty list if every strategy fails — the
-     * caller (the AutoForwarder loop) treats this as "scan failed, try
-     * again next tick" rather than "no ports listening".
+     * Run a scan over [connection]. Returns [PortScanResult.Ports] with one
+     * [RemotePort] per discovered listening port, or [PortScanResult.Failed]
+     * when every strategy fails — the caller (the AutoForwarder loop) treats
+     * that as "scan failed, try again next tick" rather than "no ports
+     * listening", so a transient exec failure never tears down live tunnels
+     * (issue #2489).
      */
-    public suspend fun scan(connection: HostConnection): List<RemotePort> {
-        return tryPrimary(connection)
+    public suspend fun scan(connection: HostConnection): PortScanResult {
+        val ports = tryPrimary(connection)
             ?: tryFallback(connection)
             ?: tryLastResort(connection)
-            ?: emptyList()
+            ?: return PortScanResult.Failed
+        return PortScanResult.Ports(ports)
     }
 
     private suspend fun tryPrimary(connection: HostConnection): List<RemotePort>? {
         val out = runOrNull(connection, "ss -tlnp 2>/dev/null | awk 'NR>1 {print \$4, \$7}'")
             ?: return null
         if (out.isBlank()) return null
-        return parseSsOutput(out)
+        return parseSsOutput(out).ifEmptyStrategyFailed()
     }
 
     private suspend fun tryFallback(connection: HostConnection): List<RemotePort>? {
@@ -55,15 +88,25 @@ public object PortScanner {
             "netstat -tlnp 2>/dev/null | awk 'NR>1 && /LISTEN/ {print \$4, \$7}'",
         ) ?: return null
         if (out.isBlank()) return null
-        return parseNetstatOutput(out)
+        return parseNetstatOutput(out).ifEmptyStrategyFailed()
     }
 
     private suspend fun tryLastResort(connection: HostConnection): List<RemotePort>? {
         val out = runOrNull(connection, "ss -tln 2>/dev/null | awk 'NR>1 {print \$4}'")
             ?: return null
         if (out.isBlank()) return null
-        return parsePortsOnly(out)
+        return parsePortsOnly(out).ifEmptyStrategyFailed()
     }
+
+    /**
+     * A strategy that produced output no parser recognised didn't work either
+     * — fall through to the next one rather than reporting "zero ports
+     * listening", which the AutoForwarder would read as "everything vanished"
+     * (issue #2489). Together with the blank-output checks above this makes
+     * `Ports(emptyList())` unreachable: no ports found is always [Failed].
+     */
+    private fun List<RemotePort>.ifEmptyStrategyFailed(): List<RemotePort>? =
+        takeIf { it.isNotEmpty() }
 
     private suspend fun runOrNull(connection: HostConnection, command: String): String? {
         // exec doesn't throw on non-zero exits — we treat "command not found"
@@ -71,7 +114,12 @@ public object PortScanner {
         // transport-level IOException alike: this strategy didn't work, fall
         // through to the next one.
         return try {
-            connection.exec(command).stdout
+            val result = connection.exec(command)
+            // A wall-clock overrun does NOT throw: exec returns timedOut=true
+            // plus whatever partial stdout it captured. Parsing that truncated
+            // listing would silently report a short port list as authoritative
+            // (issue #2489), so a timeout is a failed strategy, not output.
+            if (result.timedOut) null else result.stdout
         } catch (_: Throwable) {
             null
         }

--- a/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/AutoForwarderTest.kt
+++ b/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/AutoForwarderTest.kt
@@ -196,16 +196,26 @@ class AutoForwarderTest {
     @Test
     fun `port disappearing between scans tears down its forward`() = runTest {
         val connection = FakeConnection()
-        connection.setListening("0.0.0.0:3000 users:((\"app\",pid=1,fd=4))")
+        // sshd is always listening on a host we can scan at all, so a
+        // *successful* scan that no longer lists :3000 still lists :22. The
+        // fixture keeps it that way so this exercises a genuine vanish rather
+        // than the "scan produced nothing" case (issue #2489), which is a
+        // failure, not an observation.
+        connection.setListening(
+            """
+            0.0.0.0:22 users:(("sshd",pid=1,fd=3))
+            0.0.0.0:3000 users:(("app",pid=1,fd=4))
+            """.trimIndent(),
+        )
 
         val forwarder = AutoForwarder(connection, smallConfig())
         val job = forwarder.start(this)
         runCurrent()
-        assertEquals(1, forwarder.flowOfTunnels().first().size)
+        assertEquals(1, connection.openForwards.size)
 
         // Service stops; next scan should observe it gone and tear the
         // local forward down.
-        connection.setListening("")
+        connection.setListening("0.0.0.0:22 users:((\"sshd\",pid=1,fd=3))")
         advanceTimeBy(2_000L)
         runCurrent()
 
@@ -216,6 +226,118 @@ class AutoForwarderTest {
         )
         val firstForward = connection.openForwards.values.first()
         assertFalse("underlying forward should have been closed", firstForward.isActive)
+
+        forwarder.stop()
+        job.cancel()
+        runCurrent()
+    }
+
+    @Test
+    fun `a failed scan does not tear down existing forwards`() = runTest {
+        // Issue #2489 (bug 1): PortScanner reports "nothing found" when every
+        // strategy fails — an exec error, a dead-ish shell, a hiccup on the
+        // transport. Reading that as "every remote port vanished" closed every
+        // auto-forwarded tunnel and reset the TCP connections running through
+        // them, on ONE transient scan failure. RED on base: the forward is
+        // closed by the next tick.
+        val connection = FakeConnection()
+        connection.setListening(
+            """
+            0.0.0.0:22 users:(("sshd",pid=1,fd=3))
+            0.0.0.0:3000 users:(("app",pid=1,fd=4))
+            """.trimIndent(),
+        )
+
+        val forwarder = AutoForwarder(
+            connection,
+            smallConfig(),
+            localPortAvailability = allLocalPortsAvailable,
+        )
+        val job = forwarder.start(this)
+        runCurrent()
+        val forward = connection.openForwards.values.single()
+        assertTrue("first scan should have opened the :3000 forward", forward.isActive)
+
+        connection.failScan()
+        advanceTimeBy(2_000L)
+        runCurrent()
+
+        assertTrue(
+            "a failed scan must not close a live forward — nothing was observed to vanish",
+            forward.isActive,
+        )
+        assertEquals(
+            TunnelInfo.Status.FORWARDING,
+            forwarder.flowOfTunnels().first().single { it.remotePort == 3000 }.status,
+        )
+
+        // ...and the tunnel comes back to a healthy scan untouched: no
+        // close/reopen churn, the same forward object is still in place.
+        connection.setListening(
+            """
+            0.0.0.0:22 users:(("sshd",pid=1,fd=3))
+            0.0.0.0:3000 users:(("app",pid=1,fd=4))
+            """.trimIndent(),
+        )
+        advanceTimeBy(2_000L)
+        runCurrent()
+        assertEquals(1, connection.openForwards.size)
+        assertTrue("the forward should have survived the failed scan", forward.isActive)
+
+        forwarder.stop()
+        job.cancel()
+        runCurrent()
+    }
+
+    @Test
+    fun `a timed-out scan is not treated as a shorter port list`() = runTest {
+        // Issue #2489 (bug 2): exec does not throw on a wall-clock overrun —
+        // it returns the partial stdout with timedOut=true. Parsing that
+        // truncated `ss` listing made every port missing from the cut-off
+        // output look vanished. RED on base: the :4000 forward, absent from
+        // the truncated listing, is closed.
+        val connection = FakeConnection()
+        connection.setListening(
+            """
+            0.0.0.0:22 users:(("sshd",pid=1,fd=3))
+            0.0.0.0:3000 users:(("app",pid=1,fd=4))
+            0.0.0.0:4000 users:(("db",pid=2,fd=5))
+            """.trimIndent(),
+        )
+
+        val forwarder = AutoForwarder(
+            connection,
+            smallConfig(),
+            localPortAvailability = allLocalPortsAvailable,
+        )
+        val job = forwarder.start(this)
+        runCurrent()
+        assertEquals(2, connection.openForwards.size)
+        val truncatedAway = connection.openForwards.getValue(4000)
+
+        // The next scan is cut off mid-listing: :4000 never made it to stdout.
+        connection.timeOutScan(
+            """
+            0.0.0.0:22 users:(("sshd",pid=1,fd=3))
+            0.0.0.0:3000 users:(("app",pid=1,fd=4))
+            """.trimIndent(),
+        )
+        advanceTimeBy(2_000L)
+        runCurrent()
+
+        assertTrue(
+            "a timed-out scan is truncated output, not evidence :4000 vanished",
+            truncatedAway.isActive,
+        )
+        val snapshot = forwarder.flowOfTunnels().first()
+        assertEquals(
+            TunnelInfo.Status.FORWARDING,
+            snapshot.single { it.remotePort == 4000 }.status,
+        )
+        assertEquals(
+            TunnelInfo.Status.FORWARDING,
+            snapshot.single { it.remotePort == 3000 }.status,
+        )
 
         forwarder.stop()
         job.cancel()
@@ -970,18 +1092,52 @@ class AutoForwarderTest {
         @Volatile
         private var blockedClose: Pair<CountDownLatch, CountDownLatch>? = null
 
+        // How the primary `ss -tlnp` strategy answers. `timedOut` models the
+        // wall-clock overrun exec reports without throwing: partial stdout
+        // plus timedOut=true (issue #2489).
+        @Volatile
+        private var timedOut: Boolean = false
+
+        @Volatile
+        private var exitCode: Int = 0
+
         init {
             // Primary `ss -tlnp` returns the scripted output; netstat /
             // last-resort are not modelled here — PortScannerTest owns the
             // fallback chain.
             delegate.onExecMatching("ss -tlnp ...", match = { it.startsWith("ss -tlnp") }) {
-                ExecResult(exitCode = 0, stdout = output, stderr = "", timedOut = false)
+                ExecResult(exitCode = exitCode, stdout = output, stderr = "", timedOut = timedOut)
             }
             delegate.defaultExec = ExecResult(exitCode = 0, stdout = "", stderr = "", timedOut = false)
         }
 
         fun setListening(ssOutput: String) {
             output = ssOutput
+            timedOut = false
+            exitCode = 0
+        }
+
+        /**
+         * Every scan strategy fails from here on: `ss` exits non-zero with no
+         * output, and the fake's default exec answers netstat / last-resort
+         * with nothing. This is a transport hiccup, NOT an observation that
+         * the remote's ports went away (issue #2489).
+         */
+        fun failScan() {
+            output = ""
+            exitCode = 127
+            timedOut = false
+        }
+
+        /**
+         * The primary strategy overruns its wall-clock budget after emitting
+         * [partialOutput]. `exec` does not throw for this — it returns the
+         * partial stdout with `timedOut = true` (issue #2489).
+         */
+        fun timeOutScan(partialOutput: String) {
+            output = partialOutput
+            exitCode = 0
+            timedOut = true
         }
 
         fun blockNextOpen(entered: CountDownLatch, release: CountDownLatch) {

--- a/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/PortScannerTest.kt
+++ b/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/PortScannerTest.kt
@@ -89,9 +89,51 @@ class PortScannerTest {
     }
 
     @Test
-    fun `scan returns empty list when every strategy fails`() = runTest {
+    fun `scan reports Failed when every strategy fails`() = runTest {
+        // Issue #2489: the failure case is its own type, not an empty list —
+        // the AutoForwarder must be able to tell "the scan didn't work" from
+        // "the remote has nothing listening" before it tears tunnels down.
         val host = stubHost { _ -> exec(exitCode = 127) }
-        assertEquals(emptyList<RemotePort>(), PortScanner.scan(host))
+        assertEquals(PortScanResult.Failed, PortScanner.scan(host))
+    }
+
+    @Test
+    fun `scan reports Failed when a strategy produces output no parser recognises`() = runTest {
+        // Non-blank garbage that yields zero ports is a broken strategy, not
+        // an empty host (issue #2489) — Ports(emptyList()) is unreachable.
+        val host = stubHost { _ -> exec("bind: Address family not supported\n") }
+        assertEquals(PortScanResult.Failed, PortScanner.scan(host))
+    }
+
+    @Test
+    fun `scan treats a timed-out exec as a failed strategy, not truncated output`() = runTest {
+        // Issue #2489: exec returns partial stdout with timedOut=true instead
+        // of throwing. Parsing that half-written listing reports a short port
+        // list as authoritative. RED on base: scan returns just :22.
+        val host = stubHost { cmd ->
+            when {
+                cmd.startsWith("ss -tlnp") -> timedOutExec("0.0.0.0:22 users:((\"sshd\",pid=1,fd=3))\n")
+                else -> exec(exitCode = 127)
+            }
+        }
+        assertEquals(PortScanResult.Failed, PortScanner.scan(host))
+    }
+
+    @Test
+    fun `scan falls through to netstat when the primary times out`() = runTest {
+        // The timed-out primary must not short-circuit the chain either — the
+        // next strategy still gets its turn and its full listing wins.
+        val host = stubHost { cmd ->
+            when {
+                cmd.startsWith("ss -tlnp") -> timedOutExec("0.0.0.0:22 users:((\"sshd\",pid=1,fd=3))\n")
+                cmd.startsWith("netstat -tlnp") -> exec("0.0.0.0:22 1/sshd\n0.0.0.0:3000 7/app\n")
+                else -> error("last resort should not have run: cmd=$cmd")
+            }
+        }
+        assertEquals(
+            PortScanResult.Ports(listOf(RemotePort(22, "sshd"), RemotePort(3000, "app"))),
+            PortScanner.scan(host),
+        )
     }
 
     @Test
@@ -103,7 +145,10 @@ class PortScannerTest {
                 else -> error("primary strategy should have won: cmd=$cmd")
             }
         }
-        assertEquals(listOf(RemotePort(8080, "app")), PortScanner.scan(host))
+        assertEquals(
+            PortScanResult.Ports(listOf(RemotePort(8080, "app"))),
+            PortScanner.scan(host),
+        )
     }
 
     @Test
@@ -115,7 +160,10 @@ class PortScannerTest {
                 else -> error("last resort should not have run: cmd=$cmd")
             }
         }
-        assertEquals(listOf(RemotePort(22, "sshd")), PortScanner.scan(host))
+        assertEquals(
+            PortScanResult.Ports(listOf(RemotePort(22, "sshd"))),
+            PortScanner.scan(host),
+        )
     }
 
     @Test
@@ -128,7 +176,9 @@ class PortScannerTest {
                 else -> error("unexpected command: $cmd")
             }
         }
-        assertTrue(PortScanner.scan(host).contains(RemotePort(9000, "")))
+        val result = PortScanner.scan(host)
+        assertTrue("expected a successful scan, got $result", result is PortScanResult.Ports)
+        assertTrue((result as PortScanResult.Ports).ports.contains(RemotePort(9000, "")))
     }
 
     /**
@@ -142,4 +192,12 @@ class PortScannerTest {
     /** A finished command: the scanner only ever reads stdout and the exit code. */
     private fun exec(stdout: String = "", exitCode: Int = 0): ExecResult =
         ExecResult(exitCode = exitCode, stdout = stdout, stderr = "", timedOut = false)
+
+    /**
+     * A command whose wall-clock budget elapsed: [HostConnection.exec] does
+     * not throw for this, it hands back whatever was captured so far with
+     * `timedOut = true` and a meaningless exit code.
+     */
+    private fun timedOutExec(partialStdout: String): ExecResult =
+        ExecResult(exitCode = 0, stdout = partialStdout, stderr = "", timedOut = true)
 }


### PR DESCRIPTION
## Summary
- `PortScanner.scan` returned `List<RemotePort>`, conflating "scan failed" and "nothing listening" — `AutoForwarder`'s vanished-port sweep read an empty result as "everything vanished" and closed every non-manual tunnel on one transient exec timeout.
- `PortScanner.runOrNull` also ignored `ExecResult.timedOut`, so a truncated `ss` listing parsed as a genuinely short list.
- `PortScanner.scan` now returns `PortScanResult` (`Ports`/`Failed`), with `Ports(emptyList())` reachable only on a scan that genuinely observed zero listening ports. `AutoForwarder`'s teardown sweep, `localPortMap` prune, and `failedPorts` reset are all gated on a completed scan.

## Verification
- Red on unmodified code, green with the fix.
- Two independent mutation checks: disabling only the `AutoForwarder` guard → 2 failures; removing only the `timedOut` check → 3 failures — each half of the fix is separately load-bearing.
- `core-portfwd` unit 59/0, Docker `integrationTest` 6/0, `app2` unit 763/0.
- G6 counterweight preserved: "port disappearing between scans tears down its forward" still passes — a real vanish still tears down.

Reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2489#issuecomment-5545883229

Closes #2489