### PR TITLE
fix: grace expiry misclassified as deliberate close; retry after it produces a dead terminal

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/J06BackgroundGraceReturnJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/J06BackgroundGraceReturnJourney.kt
@@ -443,7 +443,142 @@ class J06BackgroundGraceReturnJourney {
         awaitTag(hostRowTag(hostId))
     }
 
+    /**
+     * Regression for issue #2487, on the real device path — the OTHER half of
+     * this journey's question, and the one a user hits far more often than the
+     * within-grace case above: come back after the window has ELAPSED.
+     *
+     * ## What broke
+     *
+     * D21 lets the app drop the transport once the background window ends;
+     * `RealHostConnection`'s grace scheduler does that by calling the
+     * connection's own `close()`. [SessionViewModel] read any deliberate close
+     * as "somebody ended this session on purpose" (issue #2477's discriminator,
+     * whose own comment claimed "nothing in production calls that today" —
+     * every 90-second background does) and put a `Failed` banner reading "the
+     * connection was closed" on screen, with no reconnect, over a tmux session
+     * that was still running on the host. Tapping Retry from that banner then
+     * reattached onto an emulator whose byte queues `settleEnd` had already
+     * closed one-way: `Live` on screen, frozen, swallowing every keystroke.
+     *
+     * ## Why it is driven this way
+     *
+     * The production window is [GraceCoordinator.DEFAULT_GRACE_MS] (90 s), so
+     * observing an expiry inside a journey means building a coordinator with a
+     * short one and letting it take over the process — the same technique the
+     * sibling issue-#2483 scenario uses, and [GraceCoordinator.register]'s
+     * documented hand-over is exactly what makes it legitimate. Everything else
+     * is real and unmocked: the real registry, a real SSH connection to the
+     * Docker fixture, the real transport-owned grace close, the real Activity
+     * stop/start boundary, and the real terminal the user types into.
+     *
+     * The oracle is deliberately not "the state says Live": it is that no error
+     * banner is on screen, that the pane is the SAME session (`capture-pane` on
+     * the host agrees), and that typing after the return reaches the HOST.
+     */
+    @Test
+    fun returningAfterTheGraceWindowExpiresReattachesInsteadOfReportingTheSessionEnded() {
+        openSession()
+        awaitTranscript("the fixture's banner line") { it.contains(BANNER) }
+        JourneyScreenshots.capture("09-attached-before-expiry", JOURNEY)
+        compose.onNodeWithTag(SESSION_ERROR_BANNER_TAG).assertDoesNotExist()
+
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val application =
+            instrumentation.targetContext.applicationContext as android.app.Application
+        val registry = appGraph().connectionsRegistry()
+
+        // A coordinator with a window short enough to elapse inside a test.
+        // It takes over the process from the app's own singleton exactly the
+        // way a later Hilt component's would.
+        val shortWindow = GraceCoordinator(
+            connections = registry,
+            service = AndroidGraceServiceControl(application),
+            graceMs = EXPIRING_GRACE_MS,
+        )
+        instrumentation.runOnMainSync { shortWindow.register(application) }
+
+        // 1. Pocket the phone. The real Activity stop boundary arms the window
+        //    over the real live connection this journey dialled.
+        compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        awaitHoldingOn(shortWindow, expected = true, what = "after backgrounding")
+        assertTrue(
+            "the window must be armed over a REAL live connection, or the expiry " +
+                "below closes nothing and this test proves nothing",
+            registry.liveConnections().isNotEmpty(),
+        )
+
+        // 2. Stay away past the window. The transport closes ITSELF — that is
+        //    the close #2487 is about.
+        val deadline = SystemClock.elapsedRealtime() + EXPIRING_GRACE_MS + EXPIRY_MARGIN_MS
+        while (SystemClock.elapsedRealtime() < deadline &&
+            registry.liveConnections().isNotEmpty()
+        ) {
+            SystemClock.sleep(POLL_MS)
+        }
+        assertTrue(
+            "the expired grace window must really have dropped the transport (D21), " +
+                "or there is nothing to come back to",
+            registry.liveConnections().isEmpty(),
+        )
+
+        // 3. Take the phone back out.
+        compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+
+        // 4. The session comes BACK. No "session ended" error, ever — the tmux
+        //    session was alive on the host the whole time.
+        val afterReturn = awaitTranscript("the fixture's banner line again") {
+            it.contains(BANNER)
+        }
+        JourneyScreenshots.capture("10-returned-after-expiry", JOURNEY)
+        compose.onNodeWithTag(SESSION_TERMINAL_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(SESSION_ERROR_BANNER_TAG).assertDoesNotExist()
+        assertTrue(
+            "the SAME pane must be back on screen after a return past the grace " +
+                "window, got:\n$afterReturn",
+            squashed(afterReturn).contains(BANNER),
+        )
+        awaitNoGraceNotification("after returning past the window")
+
+        // 5. And it is genuinely usable, not a frozen last frame: typing has to
+        //    reach the HOST's own pane. This is the assertion bug 2 fails —
+        //    a bridge stopped rather than detached leaves a terminal that is
+        //    `Live` and completely deaf.
+        typeLine("echo $EXPIRED_MARKER")
+        val afterTyping = awaitTranscript("the echoed marker twice") {
+            squashed(it).split(EXPIRED_MARKER).size >= 3
+        }
+        assertTrue(
+            "the reattached viewport must show the command's output, got:\n$afterTyping",
+            squashed(afterTyping).contains(EXPIRED_MARKER),
+        )
+        val pane = capturePane()
+        assertTrue(
+            "the host's pane must show the command typed after the return, got:\n$pane",
+            squashed(pane).contains("echo$EXPIRED_MARKER"),
+        )
+        JourneyScreenshots.capture("11-usable-after-expiry", JOURNEY)
+
+        // Same reason as the sibling tests: leave no live connection behind for
+        // the Activity teardown to arm a real window over.
+        runBlocking { registry.closeAll() }
+    }
+
     // --- helpers ------------------------------------------------------------
+
+    /**
+     * [awaitGraceHolding] against a coordinator the test built itself, rather
+     * than the app's Hilt singleton — issue #2487's scenario needs a window
+     * short enough to elapse, which the singleton's 90 s is not.
+     */
+    private fun awaitHoldingOn(coordinator: GraceCoordinator, expected: Boolean, what: String) {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (coordinator.isHolding == expected) return
+            SystemClock.sleep(POLL_MS)
+        }
+        throw AssertionError("the coordinator's isHolding never became $expected $what")
+    }
 
     private fun openTree() {
         awaitTag(hostRowTag(hostId))
@@ -628,10 +763,26 @@ class J06BackgroundGraceReturnJourney {
         /** Head-room past the retired window, so the zombie has provably had its chance. */
         const val ZOMBIE_MARGIN_MS = 5_000L
 
+        const val EXPIRED_MARKER = "j06-back-after-expiry"
+
+        /**
+         * Issue #2487's window has to actually ELAPSE inside a test, so it is
+         * seconds rather than [GraceCoordinator.DEFAULT_GRACE_MS]. Long enough
+         * that arming it over the real connection finishes first — the test
+         * asserts the connection was still live when it armed, rather than
+         * assuming it.
+         */
+        const val EXPIRING_GRACE_MS = 8_000L
+
+        /** Head-room past the window, so the transport has provably had its chance to close. */
+        const val EXPIRY_MARGIN_MS = 20_000L
+
         val HOST_IDS: Map<String, Long> = mapOf(
             "returningWithinGraceKeepsTheSessionAliveWithNoReconnectBanner" to 9_601L,
             "backgroundingWithNoOpenSessionShowsNoHoldAndNoNotification" to 9_602L,
             "aRetiredCoordinatorsExpiryCannotTakeDownTheLiveHold" to 9_603L,
+            "returningAfterTheGraceWindowExpiresReattachesInsteadOfReportingTheSessionEnded"
+                to 9_604L,
         )
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/connect/ConnectionsRegistry.kt
+++ b/app2/src/main/java/com/pocketshell/next/connect/ConnectionsRegistry.kt
@@ -166,7 +166,10 @@ class ConnectionsRegistry(
     private companion object {
         fun TransportState.isLive(): Boolean = when (this) {
             TransportState.Connecting, TransportState.Connected -> true
-            is TransportState.Lost, TransportState.Closed -> false
+            // Both terminal states are spent, whatever the close's reason: a
+            // grace-expired connection is as unusable as a requested-close one
+            // (issue #2487), and the caller gets a fresh dial either way.
+            is TransportState.Lost, is TransportState.Closed -> false
         }
 
         /**

--- a/app2/src/main/java/com/pocketshell/next/terminal/GraceCoordinator.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/GraceCoordinator.kt
@@ -246,6 +246,14 @@ class GraceCoordinator(
      * The window elapsed. The transport closes itself (task T-5 owns that
      * timer); all that is left here is releasing the wake lock and the
      * notification, so an expired grace leaves NOTHING alive.
+     *
+     * What the user sees on their return is NOT this class's business, but it
+     * is worth saying where it is decided: the transport's own close carries
+     * [com.pocketshell.core.transport.CloseReason.GraceExpired], which is how
+     * [SessionViewModel] knows an expired window is a link to reattach rather
+     * than a session that ended. Reading that close as a disconnect is what
+     * put a false "the connection was closed" error on screen after every
+     * background longer than [DEFAULT_GRACE_MS] (issue #2487).
      */
     private fun onGraceExpired(): Unit = synchronized(lock) {
         if (!armed) return

--- a/app2/src/main/java/com/pocketshell/next/terminal/SessionViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/SessionViewModel.kt
@@ -2,6 +2,7 @@ package com.pocketshell.next.terminal
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.core.transport.CloseReason
 import com.pocketshell.core.transport.ConnectResult
 import com.pocketshell.core.transport.HostConnection
 import com.pocketshell.core.transport.PtyChannel
@@ -106,11 +107,15 @@ sealed interface SessionUiState {
  * distinction is the transport's own: sshj carries `exit-status` on the channel
  * close, and a dropped socket has none to carry.
  *
- * A third case (issue #2477) also ends with no status: [HostConnection.close]
- * called on the connection this screen is watching — deliberately, by
- * something other than a network failure. That is NOT a drop either, even
- * though the channel dies the same way a dropped socket's does; see
- * [isDeliberateClose].
+ * A third case (issue #2477) also ends with no status: the connection this
+ * screen is watching being closed deliberately, by something other than a
+ * network failure. The channel dies the same way a dropped socket's does, so
+ * the discriminator has to come from the transport's own
+ * [TransportState.Closed] — and, since issue #2487, from the [CloseReason] it
+ * carries, because "closed on purpose" is two opposite cases: a close someone
+ * ASKED for ends this screen, while the D21 grace window expiring is the app
+ * letting go of a link whose remote session is still alive, and is a reconnect
+ * exactly like a dropped one. See [isFinalClose].
  *
  * ## Nothing runs while the app is away
  *
@@ -174,11 +179,11 @@ class SessionViewModel @Inject constructor(
      * The connection [channel] is currently attached through (issue #2477).
      *
      * Kept only so a channel that ends with NO exit status can be told apart
-     * from a genuine network drop: [HostConnection.close] tears the PTY down
-     * the same way a dead socket does (no clean exit-status), but it also
-     * flips THIS field's state to [TransportState.Closed] rather than
-     * [TransportState.Lost] — the one signal that distinguishes "someone
-     * closed this on purpose" from "the link went away". See [isDeliberateClose].
+     * from a genuine network drop: a deliberate close tears the PTY down the
+     * same way a dead socket does (no clean exit-status), but it also flips
+     * THIS field's state to [TransportState.Closed] rather than
+     * [TransportState.Lost], carrying the [CloseReason] that says which kind of
+     * deliberate it was. See [isFinalClose].
      */
     private var connection: HostConnection? = null
 
@@ -293,7 +298,7 @@ class SessionViewModel @Inject constructor(
                 // ended the screen while a drop noticed by the output pump
                 // reconnected.
                 val status = withTimeoutOrNull(EXIT_STATUS_GRACE_MS) { target.exit.await() }
-                settleEnd(target, status, deliberateClose = status == null && isDeliberateClose())
+                settleEnd(target, status, finalClose = status == null && isFinalClose())
             }
         }
     }
@@ -482,36 +487,64 @@ class SessionViewModel @Inject constructor(
         watchJob = viewModelScope.launch {
             launch {
                 val status = pty.exit.await()
-                settleEnd(pty, status, deliberateClose = status == null && isDeliberateClose())
+                settleEnd(pty, status, finalClose = status == null && isFinalClose())
             }
             launch {
-                connection.state.first { it is TransportState.Lost }
-                settleEnd(pty, status = null)
+                // EVERY terminal transport state, not just [TransportState.Lost]
+                // (issue #2487): a connection dropped by the D21 grace window
+                // settles to [TransportState.Closed], and a watcher that only
+                // ever woke for `Lost` would sit here until the PTY's own exit
+                // happened to resolve — or forever, if it never did. What the
+                // state MEANS is then the same question everywhere else asks.
+                val ended = connection.state.first {
+                    it is TransportState.Lost || it is TransportState.Closed
+                }
+                settleEnd(pty, status = null, finalClose = ended.endsTheSession())
             }
         }
         return AttachOutcome.Attached
     }
 
     /**
-     * True when [connection] ended up [TransportState.Closed] rather than
-     * [TransportState.Lost] (issue #2477).
+     * True when [connection] was closed because someone ASKED for it to end
+     * (issues #2477 and #2487) — the one close that means this screen is over.
      *
      * A PTY that ends with no exit status ordinarily means the link dropped —
-     * worth a reconnect. But [HostConnection.close] tears the channel down the
-     * exact same way (no clean exit-status) when something OTHER than a
-     * network failure closed the connection deliberately: nothing in
-     * production calls that today, but a test's own end-of-test hygiene
-     * (`ConnectionsRegistry.closeAll()`, run while this screen's watcher is
-     * still alive) does, and so would a future "disconnect" action. Redialling
-     * in that case does not reconnect anything the user asked for — it opens a
-     * BRAND NEW connection nobody is watching, orphaned in the registry until
-     * the next background/grace cycle finds it "live" and holds it open for a
-     * session that no longer has a screen (exactly what stranded J06's
-     * `backgroundingWithNoOpenSessionShowsNoHoldAndNoNotification` on a shared
-     * full-suite run — a PREVIOUS test's deliberate close redialled and left
-     * this orphan behind).
+     * worth a reconnect. A deliberate close tears the channel down the exact
+     * same way (no clean exit-status), so [TransportState] is the only place
+     * the difference survives. But "deliberate" is not one thing:
+     *
+     * - [CloseReason.Requested] — a test's own end-of-test hygiene
+     *   (`ConnectionsRegistry.closeAll()`, run while this screen's watcher is
+     *   still alive), and so would a future "disconnect" action. Redialling
+     *   here does not reconnect anything the user asked for; it opens a BRAND
+     *   NEW connection nobody is watching, orphaned in the registry until the
+     *   next background/grace cycle finds it "live" and holds it open for a
+     *   session that no longer has a screen (exactly what stranded J06's
+     *   `backgroundingWithNoOpenSessionShowsNoHoldAndNoNotification` on a shared
+     *   full-suite run — issue #2477). So: the screen ends.
+     *
+     * - [CloseReason.GraceExpired] — the D21 background window elapsing, which
+     *   is the app deliberately dropping the LINK, with the remote session
+     *   still running on the host. Issue #2477's version of this check read
+     *   `Closed` alone and swept this case up with the one above, on the stated
+     *   (and wrong) assumption that "nothing in production calls close today":
+     *   every 90-second background does, through
+     *   [HostConnection.scheduleGraceClose]. That turned the single most common
+     *   daily journey — pocket the phone, come back later — into a false
+     *   "the connection was closed" error over a live session (issue #2487).
+     *   So: reconnect, exactly like a dropped link.
      */
-    private fun isDeliberateClose(): Boolean = connection?.state?.value is TransportState.Closed
+    private fun isFinalClose(): Boolean = connection?.state?.value?.endsTheSession() == true
+
+    /**
+     * Whether a terminal [TransportState] means the SESSION is over, rather
+     * than just this attach. Only a [CloseReason.Requested] close does;
+     * [TransportState.Lost] and a [CloseReason.GraceExpired] close are both
+     * "the link went away under a session that is still there".
+     */
+    private fun TransportState.endsTheSession(): Boolean =
+        this is TransportState.Closed && reason == CloseReason.Requested
 
     private suspend fun openPty(connection: HostConnection, command: String): PtyChannel =
         withContext(dispatcher) {
@@ -532,35 +565,38 @@ class SessionViewModel @Inject constructor(
         if (channel !== ended) return
         viewModelScope.launch {
             val status = withTimeoutOrNull(EXIT_STATUS_GRACE_MS) { ended.exit.await() }
-            settleEnd(ended, status, deliberateClose = status == null && isDeliberateClose())
+            settleEnd(ended, status, finalClose = status == null && isFinalClose())
         }
     }
 
     /**
      * The channel [ended] is over. [status] is the remote's exit status, or
      * null when there was none — which is the whole discriminator between an
-     * ended session and a dropped link (see the class doc). [deliberateClose]
-     * (issue #2477, see [isDeliberateClose]) is the finer discriminator WITHIN
-     * "no status": a connection closed on purpose is reported as ended, the
-     * same as a clean remote exit, rather than redialled.
+     * ended session and a dropped link (see the class doc). [finalClose]
+     * (issues #2477/#2487, see [isFinalClose]) is the finer discriminator
+     * WITHIN "no status": a connection someone ASKED to close is reported as
+     * ended, the same as a clean remote exit, rather than redialled.
+     *
+     * The spent channel is retired the SAME way in both outcomes, through
+     * [releaseChannel]. That is not tidiness: "the screen has failed" is not
+     * "this ViewModel is dead" — a [SessionUiState.Failed] screen still offers
+     * [retryNow], which reattaches onto THIS terminal. Ending the bridge with
+     * [TerminalPtyBridge.stop] here (as this did before issue #2487) closed the
+     * vendored session's byte queues one-way, so that Retry attached
+     * successfully onto a permanently unwritable emulator: `Live` on screen, a
+     * frozen last frame, and every keystroke and output frame dropped. Only
+     * [onCleared] — where the ViewModel really is over — stops the bridge.
      */
-    private fun settleEnd(ended: PtyChannel, status: Int?, deliberateClose: Boolean = false) {
+    private fun settleEnd(ended: PtyChannel, status: Int?, finalClose: Boolean = false) {
         if (channel !== ended) return
-        if (status != null || deliberateClose) {
-            // Both watchers of `attachOnce`'s watchJob have now been overtaken
-            // by events: the one that just fired settled us here, and the
-            // sibling watching `connection.state` for Lost must stop too — a
-            // deliberately CLOSED connection's state is terminal and sticky
-            // (never becomes Lost), so leaving that watcher running would park
-            // it forever. Pre-existing for a clean remote exit too (status !=
-            // null): once the screen has failed there is nothing left for
-            // either watcher to report.
-            watchJob?.cancel()
-            watchJob = null
-            bridge?.stop()
-            bridge = null
-            channel = null
-            fail(if (deliberateClose) closedMessage() else endedMessage(status))
+        // Both watchers of `attachOnce`'s watchJob have now been overtaken by
+        // events: the one that just fired settled us here, and its sibling has
+        // nothing left to report either. [releaseChannel] cancels them — a
+        // CLOSED connection's state is terminal and sticky, so a watcher left
+        // waiting on it would park forever.
+        releaseChannel()
+        if (status != null || finalClose) {
+            fail(if (finalClose) closedMessage() else endedMessage(status))
             return
         }
         beginReconnect()
@@ -570,11 +606,11 @@ class SessionViewModel @Inject constructor(
 
     /**
      * The link went away under a live session: keep the last frame, say so, and
-     * start the ladder.
+     * start the ladder. The spent channel has already been retired by
+     * [settleEnd], this ladder's only caller.
      */
     private fun beginReconnect() {
         val emulator = terminal ?: return fail(endedMessage(null))
-        releaseChannel()
         // Said immediately, before the first rung, so a user coming back to the
         // screen never sees a stale "attached" over a dead session.
         _uiState.value = SessionUiState.Reconnecting(attempt = 0, retryInMs = 0, terminal = emulator)
@@ -643,6 +679,12 @@ class SessionViewModel @Inject constructor(
      * exists. `ByteQueue.close()` is one-way, so stopping the bridge the normal
      * way would make this screen's [TerminalSession] permanently unwritable and
      * force the reattach to build a fresh, empty one: a cleared screen.
+     *
+     * The single retire path for EVERY way an attach can end (issue #2487):
+     * a drop, a clean remote exit and a requested close all leave a screen that
+     * can still be reattached from — by the ladder or by [retryNow] — so none
+     * of them may take the emulator's queues down with them. Only [onCleared],
+     * where the ViewModel itself is over, stops the bridge.
      */
     private fun releaseChannel() {
         watchJob?.cancel()
@@ -678,8 +720,9 @@ class SessionViewModel @Inject constructor(
     }
 
     /**
-     * What the user reads when THIS screen's connection was closed on purpose
-     * rather than lost (issue #2477, [isDeliberateClose]).
+     * What the user reads when THIS screen's connection was closed because
+     * someone asked for it to end, rather than lost or handed back by the grace
+     * window (issues #2477/#2487, [isFinalClose]).
      */
     private fun closedMessage(): String {
         val name = sessionLabel

--- a/app2/src/test/java/com/pocketshell/next/terminal/SessionViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/SessionViewModelTest.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pocketshell.core.hostapi.HostCliClient
+import com.pocketshell.core.transport.CloseReason
 import com.pocketshell.core.transport.FakeHostConnection
 import com.pocketshell.core.transport.FakePtyChannel
 import com.pocketshell.next.connect.TestConnectStack
@@ -402,6 +403,19 @@ class SessionViewModelTest {
      * or [SessionUiState.Live]), must not dial again, and must leave the
      * registry with nothing live for this host — the orphan-connection class
      * this whole regression is about.
+     *
+     * ## Which close this is, and which it is NOT (issue #2487)
+     *
+     * This test's close is `closeAll()`: a
+     * [com.pocketshell.core.transport.CloseReason.Requested] one, someone
+     * asking for the connection to END. Issue #2477's original fix keyed off
+     * [com.pocketshell.core.transport.TransportState.Closed] alone, which also
+     * swept up the D21 grace window expiring — a close that means the exact
+     * opposite (see `a grace-expiry close reattaches on return instead of
+     * ending the session`, the #2487 sibling of this test). The reason is
+     * asserted explicitly below so the two can never quietly merge again: it is
+     * what makes this test's "ends the session" claim true, rather than an
+     * accident of both closes looking alike.
      */
     @Test
     fun `a connection closed on purpose ends the session instead of redialling`() =
@@ -417,6 +431,7 @@ class SessionViewModelTest {
                 viewModel.uiState.value is SessionUiState.Live,
             )
             assertEquals(1, stack.factory.dialCount)
+            val closed = connection()
 
             // The exact call J06BackgroundGraceReturnJourney's own test body
             // makes on a real device, while this screen (this ViewModel) is
@@ -427,8 +442,15 @@ class SessionViewModelTest {
             settleFor(2_000)
 
             val state = viewModel.uiState.value
+            assertEquals(
+                "this scenario's close must be a REQUESTED one — if it ever became a " +
+                    "grace-expiry close the assertions below would be testing the " +
+                    "opposite contract (issue #2487)",
+                CloseReason.Requested,
+                closed.closeReason,
+            )
             assertTrue(
-                "a DELIBERATE close must end the session, not start a reconnect " +
+                "a REQUESTED close must end the session, not start a reconnect " +
                     "ladder — got $state",
                 state is SessionUiState.Failed,
             )
@@ -450,6 +472,169 @@ class SessionViewModelTest {
             // for the same reason every other `livePty()` test above calls it,
             // and load-bearing here specifically because THIS test is the one
             // that used to leave a connection nothing was watching.
+            clear()
+        }
+
+    /**
+     * Regression for issue #2487, bug 1 — the single most common daily journey:
+     * pocket the phone for more than the grace window, take it back out.
+     *
+     * D21 lets the app drop the transport once the background window elapses;
+     * [com.pocketshell.core.transport.HostConnection.scheduleGraceClose] is the
+     * whole mechanism, and its deadline calls the connection's own `close()`.
+     * That is a DELIBERATE close as far as the transport is concerned — but it
+     * is emphatically not the session ending: the tmux session is untouched on
+     * the host, and the rewrite plan's foreground-return contract says coming
+     * back reattaches to it.
+     *
+     * Before the fix, [SessionViewModel] read any [TransportState.Closed] as
+     * "somebody ended this on purpose" (issue #2477's discriminator) and put a
+     * `Failed` "the connection was closed" banner on screen with no reconnect —
+     * a false end-of-session error over a session that was still alive.
+     *
+     * Driven backgrounded, the way it happens on a phone, so the D21 half is
+     * asserted in the same breath: no dial may fire behind the launcher, and
+     * the return is what reattaches.
+     */
+    @Test
+    fun `a grace-expiry close reattaches on return instead of ending the session`() =
+        runTest(dispatcher) {
+            val hostId = stack.seedHost()
+            livePty()
+            val viewModel = viewModel()
+
+            viewModel.open(hostId, SESSION)
+            settle()
+            val attached = terminalOf(viewModel)
+            assertEquals(1, stack.factory.dialCount)
+
+            // The phone goes in a pocket: GraceCoordinator arms exactly one
+            // bounded delayed close per live connection.
+            val held = connection()
+            foreground.background()
+            held.scheduleGraceClose(GraceCoordinator.DEFAULT_GRACE_MS)
+            settle()
+
+            // 90 seconds later the transport closes ITSELF — the T-5 grace
+            // scheduler's deadline calling `close()`, which is what a real
+            // RealHostConnection does.
+            held.fireGraceClose()
+            // Far longer than the whole reconnect ladder, so a dial that was
+            // going to happen behind the launcher has had every chance.
+            settleFor(60_000)
+
+            assertTrue(
+                "the grace close must really have spent the connection",
+                held.isClosed,
+            )
+            assertEquals(
+                "no dial may happen behind the launcher (D21)",
+                1,
+                stack.factory.dialCount,
+            )
+            val backgrounded = viewModel.uiState.value
+            assertTrue(
+                "a grace-expiry close is the app letting go of the transport, not the " +
+                    "session ending — the screen must be waiting to reattach, got $backgrounded",
+                backgrounded is SessionUiState.Reconnecting,
+            )
+
+            // Taking the phone back out is what reattaches, at once.
+            foreground.foreground()
+            settleFor(2_000)
+
+            val state = viewModel.uiState.value
+            assertTrue("expected Live after returning, got $state", state is SessionUiState.Live)
+            assertSame("the reattach must reuse the same terminal", attached, terminalOf(viewModel))
+            assertEquals(
+                "a FRESH connection, never the closed one",
+                2,
+                stack.factory.dialCount,
+            )
+
+            // And it is genuinely usable, not merely green.
+            terminalOf(viewModel).write("echo back-from-grace\r")
+            settle()
+            assertEquals(
+                "keystrokes must reach the reattached channel",
+                "echo back-from-grace\r",
+                latestPty().writtenText,
+            )
+
+            clear()
+        }
+
+    /**
+     * Regression for issue #2487, bug 2 — Retry from a `Failed` screen must
+     * produce a terminal that is genuinely alive, not merely one the state says
+     * is `Live`.
+     *
+     * `settleEnd`'s ended path used to call [TerminalPtyBridge.stop], which
+     * CLOSES the vendored session's two byte queues, and `ByteQueue.close()` is
+     * one-way. It never nulled `terminal` either, so [SessionViewModel.retryNow]
+     * reattached onto that same permanently-unwritable session: SSH attached,
+     * the state flipped to `Live`, and then every output frame was rejected by
+     * the closed queue and the input pump's first read returned -1 and retired.
+     * A frozen last frame that swallows every keystroke — recoverable only by
+     * leaving the screen.
+     *
+     * Reachable on its own (type `exit` in the remote shell, then Retry) and
+     * compounded with bug 1 into "background two minutes → false error → Retry
+     * → dead terminal", which is why both directions of I/O are asserted here
+     * rather than the UI state alone.
+     */
+    @Test
+    fun `retrying an ended session comes back to a terminal that still carries IO`() =
+        runTest(dispatcher) {
+            val hostId = stack.seedHost()
+            livePty()
+            val viewModel = viewModel()
+
+            viewModel.open(hostId, SESSION)
+            settle()
+            val attached = terminalOf(viewModel)
+            val ended = pty()
+
+            // The remote shell exits: a real, clean end of session, which is
+            // the one thing that is genuinely `Failed` rather than a drop.
+            ended.finish(0)
+            settle()
+            assertTrue(
+                "expected Failed after a clean remote exit, got ${viewModel.uiState.value}",
+                viewModel.uiState.value is SessionUiState.Failed,
+            )
+
+            // The user taps Retry — the session is back on the host, so the
+            // reattach lands.
+            viewModel.retryNow()
+            settleFor(2_000)
+
+            val state = viewModel.uiState.value
+            assertTrue("expected Live after Retry, got $state", state is SessionUiState.Live)
+            assertSame(
+                "Retry must reattach onto the same emulator, not a cleared one",
+                attached,
+                terminalOf(viewModel),
+            )
+
+            // `Live` is not the assertion — bytes are. Keystrokes out...
+            terminalOf(viewModel).write("echo retry-alive\r")
+            settle()
+            assertEquals(
+                "keystrokes typed after Retry must reach the reattached channel",
+                "echo retry-alive\r",
+                latestPty().writtenText,
+            )
+
+            // ...and remote output back in.
+            latestPty().emitText("retry-output-marker\r\n")
+            settle()
+            assertTrue(
+                "remote output after Retry must reach the emulator's screen buffer, got: " +
+                    transcriptOf(viewModel),
+                transcriptOf(viewModel).contains("retry-output-marker"),
+            )
+
             clear()
         }
 

--- a/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarderSupervisor.kt
+++ b/shared/core-portfwd/src/main/java/com/pocketshell/core/portfwd/AutoForwarderSupervisor.kt
@@ -706,8 +706,13 @@ public class AutoForwarderSupervisor(
         // socket can't pin the teardown worker.
         private const val CONNECTION_CLOSE_TIMEOUT_MS = 5_000L
 
-        /** Spent: the instance can never come back, so the supervisor must re-dial. */
+        /**
+         * Spent: the instance can never come back, so the supervisor must
+         * re-dial. Every [TransportState.Closed] reason counts (issue #2487) —
+         * forwarding dials its OWN connection precisely so a grace close never
+         * reaches it, but a closed one is spent whichever way it got there.
+         */
         private fun TransportState.isTerminal(): Boolean =
-            this is TransportState.Lost || this == TransportState.Closed
+            this is TransportState.Lost || this is TransportState.Closed
     }
 }

--- a/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/AutoForwarderSupervisorTest.kt
+++ b/shared/core-portfwd/src/test/java/com/pocketshell/core/portfwd/AutoForwarderSupervisorTest.kt
@@ -876,7 +876,7 @@ class AutoForwarderSupervisorTest {
         /** True while the transport has not settled into Lost/Closed. */
         val isConnected: Boolean
             get() = when (delegate.state.value) {
-                is TransportState.Lost, TransportState.Closed -> false
+                is TransportState.Lost, is TransportState.Closed -> false
                 else -> true
             }
 

--- a/shared/core-transport/src/integrationTest/java/com/pocketshell/core/transport/RealHostConnectionGraceIntegrationTest.kt
+++ b/shared/core-transport/src/integrationTest/java/com/pocketshell/core/transport/RealHostConnectionGraceIntegrationTest.kt
@@ -169,7 +169,7 @@ class RealHostConnectionGraceIntegrationTest {
             assertEquals("still-alive", connection.exec("echo still-alive").stdout.trim())
 
             val closed = withTimeoutOrNull(30_000) {
-                connection.state.first { it == TransportState.Closed }
+                connection.state.first { it is TransportState.Closed }
             }
             assertNotNull(
                 "grace close should have fired; state is still ${connection.state.value}",
@@ -245,7 +245,7 @@ class RealHostConnectionGraceIntegrationTest {
             )
 
             val closed = withTimeoutOrNull(30_000) {
-                connection.state.first { it == TransportState.Closed }
+                connection.state.first { it is TransportState.Closed }
             }
             assertNotNull(
                 "the replacement close should fire; state is still ${connection.state.value}",
@@ -254,7 +254,10 @@ class RealHostConnectionGraceIntegrationTest {
             // Cancelling the superseded handle after the fact is a no-op, and
             // the connection stays closed (nothing resurrects it).
             longWindow.cancel()
-            assertEquals(TransportState.Closed, connection.state.value)
+            assertEquals(
+                TransportState.Closed(CloseReason.GraceExpired),
+                connection.state.value,
+            )
         } finally {
             connection.close()
         }
@@ -270,13 +273,26 @@ class RealHostConnectionGraceIntegrationTest {
         val connection = connect()
         val closed = withTimeoutOrNull(30_000) {
             connection.scheduleGraceClose(GRACE_MS)
-            connection.state.first { it is TransportState.Lost || it == TransportState.Closed }
+            connection.state.first { it is TransportState.Lost || it is TransportState.Closed }
         }
-        assertEquals("a grace close is deliberate: Closed, never Lost", TransportState.Closed, closed)
+        // ...and it says WHY it is closed: `GraceExpired`, never `Requested`.
+        // The two are opposite instructions to a session screen — a requested
+        // close ends it, an expired grace window reattaches on return (issue
+        // #2487) — so this is the load-bearing half of the assertion, not a
+        // decoration on it.
+        assertEquals(
+            "a grace close is deliberate: Closed(GraceExpired), never Lost",
+            TransportState.Closed(CloseReason.GraceExpired),
+            closed,
+        )
 
-        // An explicit close afterwards is a harmless no-op.
+        // An explicit close afterwards is a harmless no-op — and must NOT
+        // rewrite the reason under a screen that already read it.
         connection.close()
-        assertEquals(TransportState.Closed, connection.state.value)
+        assertEquals(
+            TransportState.Closed(CloseReason.GraceExpired),
+            connection.state.value,
+        )
 
         // SFTP/PTY are separate tasks; exec is the channel type this task can
         // assert on, and it must not hang.
@@ -287,7 +303,7 @@ class RealHostConnectionGraceIntegrationTest {
         assertTrue("expected an IOException, got $failure", failure is IOException)
         assertNull(
             "no further state change should follow",
-            withTimeoutOrNull(1_000) { connection.state.first { it != TransportState.Closed } },
+            withTimeoutOrNull(1_000) { connection.state.first { it !is TransportState.Closed } },
         )
     }
 }

--- a/shared/core-transport/src/integrationTest/java/com/pocketshell/core/transport/RealHostConnectionIntegrationTest.kt
+++ b/shared/core-transport/src/integrationTest/java/com/pocketshell/core/transport/RealHostConnectionIntegrationTest.kt
@@ -403,11 +403,14 @@ class RealHostConnectionIntegrationTest {
         val connection = connectTrusted(newFactory(), targetFor(container!!), InMemoryTrustStore())
 
         connection.close()
-        assertEquals(TransportState.Closed, connection.state.value)
+        // `Requested`, because a caller asked: that is what tells a session
+        // screen the session is over rather than merely handed back for the
+        // background window (issue #2487).
+        assertEquals(TransportState.Closed(CloseReason.Requested), connection.state.value)
 
         // Idempotent: a second close neither throws nor changes the state.
         connection.close()
-        assertEquals(TransportState.Closed, connection.state.value)
+        assertEquals(TransportState.Closed(CloseReason.Requested), connection.state.value)
 
         try {
             connection.exec("echo nope")

--- a/shared/core-transport/src/main/java/com/pocketshell/core/transport/RealHostConnection.kt
+++ b/shared/core-transport/src/main/java/com/pocketshell/core/transport/RealHostConnection.kt
@@ -19,7 +19,7 @@ import net.schmizz.sshj.transport.DisconnectListener
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * The sshj-backed [HostConnection] (rewrite task T-2).
@@ -32,8 +32,10 @@ import java.util.concurrent.atomic.AtomicBoolean
  *   and a non-zero remote exit that is a normal result, never an exception.
  * - [state]: flips to [TransportState.Lost] from sshj's disconnect listener the
  *   moment the transport drops (network failure or a far-end close), and to
- *   [TransportState.Closed] on a deliberate [close]. Both are terminal — a
- *   spent instance is replaced by dialling a new one via the factory.
+ *   [TransportState.Closed] — carrying WHICH deliberate path closed it, see
+ *   [CloseReason] — on [close] or on the grace scheduler's deadline. Both are
+ *   terminal: a spent instance is replaced by dialling a new one via the
+ *   factory.
  *
  * [openPty] delegates to [PtyChannelImpl] (T-3), [sftp] to a cached
  * [SftpChannelImpl] (T-4), and [scheduleGraceClose] to [GraceCloseScheduler]
@@ -67,8 +69,19 @@ internal class RealHostConnection(
     private val _state = MutableStateFlow<TransportState>(TransportState.Connected)
     override val state: StateFlow<TransportState> = _state.asStateFlow()
 
-    /** True once [close] started; makes the disconnect listener report Closed, not Lost. */
-    private val closing = AtomicBoolean(false)
+    /**
+     * Non-null once [closeWith] started, holding WHY — which both makes the
+     * close one-shot (the CAS from null is the whole idempotence gate) and
+     * lets the disconnect listener report `Closed(thatReason)` rather than
+     * `Lost`.
+     *
+     * One atomic rather than a boolean plus a separate field because the
+     * listener can fire from sshj's own thread at any instant: a two-step
+     * "flag, then reason" would leave a window where a deliberate close is
+     * seen with the wrong (default) reason and settles the sticky terminal
+     * state to it forever.
+     */
+    private val closeReason = AtomicReference<CloseReason?>(null)
 
     init {
         // Installed after connect+auth (the factory hands over a live client),
@@ -76,14 +89,14 @@ internal class RealHostConnection(
         // isConnected re-check below rather than silently missed. sshj fires
         // this listener from BOTH TransportImpl.die(...) (network failure /
         // far-end close / reader EOF) and an explicit local disconnect —
-        // the `closing` flag disambiguates the deliberate path.
+        // `closeReason` disambiguates the deliberate path, and says which
+        // deliberate path it was (issue #2487).
         client.transport.setDisconnectListener(
             DisconnectListener { reason, message ->
                 settle(
-                    if (closing.get()) {
-                        TransportState.Closed
-                    } else {
-                        TransportState.Lost(describeDisconnect(reason?.toString(), message))
+                    when (val deliberate = closeReason.get()) {
+                        null -> TransportState.Lost(describeDisconnect(reason?.toString(), message))
+                        else -> TransportState.Closed(deliberate)
                     },
                 )
             },
@@ -261,15 +274,24 @@ internal class RealHostConnection(
      * in [GraceCloseScheduler]; it runs on this connection's [ioDispatcher], so
      * a test that injects a virtual-time dispatcher controls the grace timer.
      */
-    private val grace = GraceCloseScheduler(ioDispatcher) { close() }
+    private val grace = GraceCloseScheduler(ioDispatcher) { closeWith(CloseReason.GraceExpired) }
 
     override fun scheduleGraceClose(graceMs: Long): GraceHandle = grace.schedule(graceMs)
 
-    override suspend fun close() {
-        // Idempotent: only the first call touches the transport. Set `closing`
-        // BEFORE disconnecting so the disconnect listener classifies the drop
-        // as deliberate.
-        if (!closing.compareAndSet(false, true)) return
+    /**
+     * Closes because someone ASKED for this connection to end. The grace
+     * scheduler above is the other caller of [closeWith], and the difference
+     * between the two is exactly what [CloseReason] exists to record — see it
+     * for why a consumer must not treat them alike (issue #2487).
+     */
+    override suspend fun close() = closeWith(CloseReason.Requested)
+
+    private suspend fun closeWith(reason: CloseReason) {
+        // Idempotent: only the first call touches the transport. Recording the
+        // reason IS the gate, and it happens BEFORE disconnecting so the
+        // disconnect listener classifies the drop as deliberate — and as the
+        // right KIND of deliberate.
+        if (!closeReason.compareAndSet(null, reason)) return
         // Issue #2477: settle [state] to Closed BEFORE disconnecting, not
         // after. `client.disconnect()` cascades into closing every open
         // channel (sshj tears each one down as part of the same transport
@@ -286,7 +308,7 @@ internal class RealHostConnection(
         // #2477 reports). Setting the terminal state FIRST, before any
         // teardown that could resolve a channel's exit even begins, makes that
         // observation impossible by construction rather than by timing.
-        settle(TransportState.Closed)
+        settle(TransportState.Closed(reason))
         withContext(ioDispatcher) {
             runCatching { client.disconnect() }
         }
@@ -343,7 +365,7 @@ internal class RealHostConnection(
     private fun settle(terminal: TransportState) {
         _state.update { current ->
             when (current) {
-                is TransportState.Lost, TransportState.Closed -> current
+                is TransportState.Lost, is TransportState.Closed -> current
                 else -> terminal
             }
         }
@@ -353,8 +375,8 @@ internal class RealHostConnection(
         when (val current = _state.value) {
             is TransportState.Lost ->
                 throw IOException("$operation: connection lost (${current.cause})")
-            TransportState.Closed ->
-                throw IOException("$operation: connection closed")
+            is TransportState.Closed ->
+                throw IOException("$operation: connection closed (${current.reason})")
             else -> Unit
         }
     }

--- a/shared/core-transport/src/main/java/com/pocketshell/core/transport/TransportState.kt
+++ b/shared/core-transport/src/main/java/com/pocketshell/core/transport/TransportState.kt
@@ -16,6 +16,53 @@ sealed interface TransportState {
     /** The transport dropped unexpectedly. [cause] is a human-readable reason. */
     data class Lost(val cause: String) : TransportState
 
-    /** The transport was closed deliberately (via [HostConnection.close]). */
-    data object Closed : TransportState
+    /**
+     * The transport was closed on purpose rather than lost — but WHY it was
+     * closed is not one fact, it is two, and they mean opposite things to
+     * anything watching a session over this connection. Hence [reason]: see
+     * [CloseReason] (issue #2487).
+     */
+    data class Closed(val reason: CloseReason) : TransportState
+}
+
+/**
+ * Why a [HostConnection] was closed deliberately (issue #2487).
+ *
+ * ## Why the transport carries this at all
+ *
+ * A closed transport tears its channels down exactly the way a dead socket
+ * does — no clean exit-status on the PTY — so a screen watching a session
+ * cannot tell "the app let go of the link" from "the session is over" by
+ * looking at the channel. It used to try, by reading `Closed` alone as
+ * "somebody ended this on purpose"; that conflated the two cases below and
+ * produced a false "the connection was closed" error over a tmux session that
+ * was still perfectly alive on the host, every time a phone spent more than 90
+ * seconds in a pocket (issue #2487).
+ *
+ * The distinction is the transport's own — it knows which of its APIs started
+ * the close — so it is recorded here rather than re-derived by guesswork
+ * upstream. It is deliberately a property of [TransportState.Closed] and not a
+ * separate flag: a consumer that reads the state cannot forget to also ask why.
+ */
+enum class CloseReason {
+
+    /**
+     * Someone asked for this connection to END: a user disconnect action, app
+     * teardown, or a test's `ConnectionsRegistry.closeAll()` hygiene. Nothing
+     * that was using it should redial — a fresh connection here is one nobody
+     * asked for and nothing is watching (issue #2477).
+     */
+    Requested,
+
+    /**
+     * The D21 background grace window elapsed and
+     * [HostConnection.scheduleGraceClose]'s deadline dropped the transport to
+     * save the battery and the wake lock.
+     *
+     * The remote is untouched: the tmux session the user was attached to is
+     * still running on the host, and the rewrite plan's foreground-return
+     * contract says coming back reattaches to it. So this is a RECONNECT case,
+     * exactly like a dropped link, and not the end of anything.
+     */
+    GraceExpired,
 }

--- a/shared/core-transport/src/test/java/com/pocketshell/core/transport/FakeHostConnectionTest.kt
+++ b/shared/core-transport/src/test/java/com/pocketshell/core/transport/FakeHostConnectionTest.kt
@@ -233,7 +233,11 @@ class FakeHostConnectionTest {
 
         host.close()
 
-        assertEquals(TransportState.Closed, host.state.value)
+        // `close()` is the "someone asked for this to end" path, so the fake
+        // must report the same reason a real transport does (issue #2487) —
+        // consumers branch on it.
+        assertEquals(TransportState.Closed(CloseReason.Requested), host.state.value)
+        assertEquals(CloseReason.Requested, host.closeReason)
         assertTrue(host.isClosed)
         assertTrue(pty.isEnded)
         assertNull(pty.exit.await())
@@ -279,7 +283,11 @@ class FakeHostConnectionTest {
 
         host.fireGraceClose()
 
-        assertEquals(TransportState.Closed, host.state.value)
+        // ...as `GraceExpired`, never `Requested`: the remote session is still
+        // alive, so a consumer must be able to tell this from a disconnect and
+        // reattach instead of reporting the session over (issue #2487).
+        assertEquals(TransportState.Closed(CloseReason.GraceExpired), host.state.value)
+        assertEquals(CloseReason.GraceExpired, host.closeReason)
         assertNull(host.pendingGrace)
     }
 

--- a/shared/core-transport/src/test/java/com/pocketshell/core/transport/RealHostConnectionCloseReasonTest.kt
+++ b/shared/core-transport/src/test/java/com/pocketshell/core/transport/RealHostConnectionCloseReasonTest.kt
@@ -1,0 +1,184 @@
+package com.pocketshell.core.transport
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import net.schmizz.sshj.SSHClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * [RealHostConnection] must say WHY it closed (issue #2487).
+ *
+ * ## Why this matters at all
+ *
+ * A closed transport tears its channels down exactly the way a dead socket
+ * does — no clean exit-status on the PTY — so the ONLY place the difference
+ * between "someone asked for this connection to end" and "the D21 background
+ * window expired" survives is [TransportState.Closed]'s [CloseReason]. Those
+ * two are opposite instructions to `app2`'s session screen: the first ends it,
+ * the second reattaches on foreground return, because the tmux session on the
+ * host is untouched. Reading `Closed` without the reason is what turned the
+ * single most common daily journey — pocket the phone for more than 90 seconds,
+ * take it back out — into a false "the connection was closed" error over a live
+ * session.
+ *
+ * ## Why it is a JVM test
+ *
+ * The classification is made entirely inside this class: the grace scheduler's
+ * deadline calls one entry point, [HostConnection.close] calls the other, and
+ * both settle [TransportState]. No SSH server is needed to observe it, so it is
+ * pinned here in milliseconds rather than only in the Docker integration suite
+ * (which asserts the same thing end-to-end over a real socket). Everything
+ * below the sshj wire protocol is faked exactly as
+ * [RealHostConnectionChannelBudgetTest] documents: a [FakeSshClient] for the
+ * one required [SSHClient] argument, and a scripted [HostChannels].
+ */
+class RealHostConnectionCloseReasonTest {
+
+    /** As in [RealHostConnectionChannelBudgetTest]: never dials, never disconnects a socket. */
+    private class FakeSshClient : SSHClient() {
+        val disconnectCalls = AtomicInteger(0)
+        override fun isConnected(): Boolean = true
+        override fun disconnect() {
+            disconnectCalls.incrementAndGet()
+        }
+    }
+
+    private class StubPtyChannel : PtyChannel {
+        private val exitDeferred = CompletableDeferred<Int?>()
+        override val output = kotlinx.coroutines.flow.emptyFlow<ByteArray>()
+        override suspend fun write(bytes: ByteArray) = Unit
+        override suspend fun resize(cols: Int, rows: Int) = Unit
+        override val exit: Deferred<Int?> get() = exitDeferred
+        override suspend fun close() {
+            exitDeferred.complete(null)
+        }
+    }
+
+    private class StubChannels : HostChannels {
+        override fun openExec(command: String): ExecChannel = object : ExecChannel {
+            override val stdout: InputStream = ByteArrayInputStream(ByteArray(0))
+            override val stderr: InputStream = ByteArrayInputStream(ByteArray(0))
+            override val exitStatus: Int? = 0
+            override fun join() = Unit
+            override fun close() = Unit
+        }
+
+        override suspend fun openPty(command: String, cols: Int, rows: Int, term: String): PtyChannel =
+            StubPtyChannel()
+
+        override fun sftp(): SftpChannel = throw UnsupportedOperationException()
+
+        override suspend fun openPortForward(
+            remoteHost: String,
+            remotePort: Int,
+            localPort: Int,
+        ): PortForward = throw UnsupportedOperationException()
+    }
+
+    private fun newConnection(): RealHostConnection = RealHostConnection(
+        target = HostTarget(
+            hostId = 1L,
+            hostname = "fake.invalid",
+            port = 22,
+            username = "tester",
+            auth = AuthMaterial.KeyRef(1L),
+        ),
+        client = FakeSshClient(),
+        ioDispatcher = Dispatchers.IO,
+        channels = StubChannels(),
+        budget = ChannelBudget(),
+    )
+
+    /** A close somebody asked for. The session over it is over. */
+    @Test
+    fun `an explicit close settles Closed with the Requested reason`() = runBlocking {
+        val connection = newConnection()
+
+        connection.close()
+
+        assertEquals(TransportState.Closed(CloseReason.Requested), connection.state.value)
+    }
+
+    /**
+     * The grace scheduler's deadline. Same terminal state, opposite meaning:
+     * the remote session is still running, and the screen must reattach rather
+     * than report it ended (issue #2487).
+     */
+    @Test
+    fun `a grace-window expiry settles Closed with the GraceExpired reason`() = runBlocking {
+        val connection = newConnection()
+
+        // A zero-length window so the real scheduler — not a stand-in — fires
+        // its own deadline immediately.
+        connection.scheduleGraceClose(graceMs = 0)
+
+        val settled = withTimeoutOrNull(5_000) {
+            connection.state.first { it is TransportState.Closed }
+        }
+        assertNotNull("the grace deadline must have closed the connection", settled)
+        assertEquals(
+            "a grace expiry is not a requested disconnect: the remote session is " +
+                "still alive and the screen has to be able to tell (issue #2487)",
+            TransportState.Closed(CloseReason.GraceExpired),
+            settled,
+        )
+    }
+
+    /**
+     * Terminal state is sticky, reason included: a later explicit close must
+     * not rewrite `GraceExpired` into `Requested` under a screen that already
+     * read it and started reconnecting.
+     */
+    @Test
+    fun `an explicit close after a grace expiry does not rewrite the reason`() = runBlocking {
+        val connection = newConnection()
+        connection.scheduleGraceClose(graceMs = 0)
+        withTimeoutOrNull(5_000) { connection.state.first { it is TransportState.Closed } }
+
+        connection.close()
+
+        assertEquals(TransportState.Closed(CloseReason.GraceExpired), connection.state.value)
+    }
+
+    /**
+     * And the reverse, which is the ordering that actually protects issue
+     * #2477: a grace timer that fires after someone already asked for the
+     * connection to end must not downgrade a `Requested` close into one the
+     * session screen would reconnect from.
+     */
+    @Test
+    fun `a grace expiry after an explicit close does not rewrite the reason`() = runBlocking {
+        val connection = newConnection()
+        connection.close()
+
+        connection.scheduleGraceClose(graceMs = 0)
+        // Give the scheduler's deadline every chance to land.
+        withTimeoutOrNull(500) { connection.state.first { it !is TransportState.Closed } }
+
+        assertEquals(TransportState.Closed(CloseReason.Requested), connection.state.value)
+    }
+
+    /** A spent connection is spent whichever reason closed it. */
+    @Test
+    fun `a grace-closed connection refuses new work the same way a requested-closed one does`() =
+        runBlocking {
+            val graceClosed = newConnection()
+            graceClosed.scheduleGraceClose(graceMs = 0)
+            withTimeoutOrNull(5_000) { graceClosed.state.first { it is TransportState.Closed } }
+
+            val failure = runCatching { graceClosed.exec("echo nope") }.exceptionOrNull()
+
+            assertTrue("expected an IOException, got $failure", failure is IOException)
+        }
+}

--- a/shared/core-transport/src/testFixtures/java/com/pocketshell/core/transport/FakeHostConnection.kt
+++ b/shared/core-transport/src/testFixtures/java/com/pocketshell/core/transport/FakeHostConnection.kt
@@ -40,7 +40,8 @@ import java.io.IOException
  *   same way a real dead transport does.
  * - No timer ever runs: [scheduleGraceClose] only records a deadline (computed
  *   from the injected [nowMs] clock). Tests fire it explicitly with
- *   [fireGraceClose].
+ *   [fireGraceClose], which closes with [CloseReason.GraceExpired] the way the
+ *   real grace scheduler does — [close] uses [CloseReason.Requested].
  *
  * Not thread-safe against concurrent *scripting*; concurrent calls from the
  * code under test are guarded by an internal lock.
@@ -200,7 +201,10 @@ class FakeHostConnection(
     val scriptedExecRules: List<String>
         get() = synchronized(lock) { execRules.map { it.description } }
 
-    val isClosed: Boolean get() = _state.value == TransportState.Closed
+    val isClosed: Boolean get() = _state.value is TransportState.Closed
+
+    /** Why this connection was closed, or null while it is not closed. */
+    val closeReason: CloseReason? get() = (_state.value as? TransportState.Closed)?.reason
 
     // ------------------------------------------------------ HostConnection impl
 
@@ -274,31 +278,44 @@ class FakeHostConnection(
      * Simulates the pending grace timer elapsing. Does nothing when there is no
      * pending close or when it was cancelled/replaced — that "nothing happens"
      * is the D21 assertion consumers want to make.
+     *
+     * Closes with [CloseReason.GraceExpired], exactly as [RealHostConnection]'s
+     * own `GraceCloseScheduler` deadline does, so a consumer test can tell an
+     * expired background window apart from a real disconnect the same way
+     * production code has to (issue #2487).
      */
     suspend fun fireGraceClose() {
         val handle = synchronized(lock) { pendingGraceHandle }
         if (handle != null && handle.isLive) {
-            close()
+            closeWith(CloseReason.GraceExpired)
         }
     }
 
-    override suspend fun close() {
+    override suspend fun close() = closeWith(CloseReason.Requested)
+
+    private suspend fun closeWith(reason: CloseReason) {
         val channels = synchronized(lock) {
             pendingGraceHandle = null
             openedPtyChannels.toList()
         }
         val forwards = synchronized(lock) { openedPortForwardHandles.toList() }
+        // Terminal state FIRST, before any teardown that resolves a channel's
+        // exit — the same ordering [RealHostConnection.close] documents for
+        // issue #2477. A consumer that reacts to a channel ending by asking the
+        // connection why must never be able to observe a still-`Connected`
+        // state here when it could not on a real transport.
+        _state.value = TransportState.Closed(reason)
         channels.forEach { it.close() }
         // A real transport takes its forwards down with it; a fake that left them
         // "active" would let a test assert a forward survived a dead connection.
         forwards.forEach { it.close() }
-        _state.value = TransportState.Closed
     }
 
     private fun requireUsable(operation: String) {
         when (val current = _state.value) {
             is TransportState.Lost -> throw IOException("$operation: connection lost (${current.cause})")
-            TransportState.Closed -> throw IOException("$operation: connection closed")
+            is TransportState.Closed ->
+                throw IOException("$operation: connection closed (${current.reason})")
             else -> Unit
         }
     }


### PR DESCRIPTION
## Summary

Two bugs that together broke the core daily journey — background the app, come back more than 90 seconds later:

1. **Grace expiry showed a false "session ended" error instead of reconnecting.** `TransportState.Closed` was a singleton meaning "closed on purpose," but both a real deliberate close (#2477's `registry.closeAll()`) and the grace scheduler's own timer-driven close reached it. `TransportState.Closed` is now `data class Closed(val reason: CloseReason)` (`Requested`/`GraceExpired`), recorded by `RealHostConnection` itself. Turning it into a data class broke every bare-value reference at compile time, forcing a real adjacency sweep — which found a second instance of the same bug in `attachOnce`'s `Lost`-only watcher.
2. **Retry from that state produced a live-looking but dead terminal.** `settleEnd()`'s ended path called `bridge?.stop()` (closes the vendored queues one-way) but never nulled `terminal`, so Retry reused a terminal whose queues were already dead. `settleEnd()` now retires the channel via `detach()` (queue-preserving) in both outcomes.

## Verification
- Emulator RED on unmodified `main` reproduces the maintainer's exact report: empty "Not attached" screen while the host's own `capture-pane` shows the session alive throughout.
- GREEN with the fix; full J01-J12 adjacency sweep clean, 35/35, two independent runs (implementer + reviewer).
- Full JVM gate 3311/3311. Docker `:shared:core-transport:integrationTest` 23/23.
- `SessionViewModelTest:406` re-verified as NOT encoding the bug — it's a genuinely `Requested` close, correctly still ends the session; made the claim explicit rather than inverted.
- Rebased onto `main` post-#2483/#2489 (orchestrator): one mechanical conflict in `J06BackgroundGraceReturnJourney.kt` (both PRs added new constants/test IDs at the same insertion point), resolved by keeping both additions, re-verified green: app2 772/772, core-transport 73/73, core-portfwd 59/59 unit, core-transport `integrationTest` 23/23.

Reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2487#issuecomment-5546166489

Closes #2487