### PR TITLE
fix: wire the persisted grace-window setting into GraceCoordinator

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/connect/AppGraph.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/connect/AppGraph.kt
@@ -7,6 +7,7 @@ import com.pocketshell.core.storage.dao.SentMessageDao
 import com.pocketshell.core.storage.dao.SshKeyDao
 import com.pocketshell.next.composer.ComposerAttachmentStager
 import com.pocketshell.next.composer.ComposerDraftStore
+import com.pocketshell.next.settings.SettingsRepository
 import com.pocketshell.next.terminal.GraceCoordinator
 import com.pocketshell.next.voice.PendingTranscriptionStore
 import dagger.hilt.EntryPoint
@@ -51,6 +52,14 @@ interface AppGraph {
      * inferring the D21 window's state from the notification tray alone.
      */
     fun graceCoordinator(): GraceCoordinator
+
+    /**
+     * Task P-6. The app's own settings store, so a journey can change a
+     * preference the way the Settings screen does — through the SAME
+     * `@Singleton` the production graph reads from — and then assert on what
+     * the app actually did with it (issue #2488).
+     */
+    fun settingsRepository(): SettingsRepository
 
     /**
      * Task P-2. The offline-dictation queue, so a journey can seed a

--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/J06BackgroundGraceReturnJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/J06BackgroundGraceReturnJourney.kt
@@ -22,6 +22,8 @@ import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.appGraph
 import com.pocketshell.next.connect.awaitIdle
 import com.pocketshell.next.hosts.hostRowTag
+import com.pocketshell.next.settings.AppSettings
+import com.pocketshell.next.settings.SettingsRepository
 import com.pocketshell.next.tree.SESSION_TREE_TAG
 import com.pocketshell.next.tree.sessionRowTag
 import com.termux.view.TerminalView
@@ -124,6 +126,12 @@ class J06BackgroundGraceReturnJourney {
         // clean slate rather than racing the previous test's teardown.
         graph.connectionsRegistry().closeAll()
         graph.graceCoordinator().enterForeground()
+        // The grace window is now a real preference (issue #2488), stored in a
+        // process-wide SharedPreferences file that outlives any one test
+        // method. Resetting it here means no method inherits a shortened window
+        // from a sibling that failed before its own restore ran.
+        graph.settingsRepository()
+            .setBackgroundGraceMillis(AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS)
         graph.hostDao().getAll().first().forEach { graph.hostDao().deleteById(it.id) }
         graph.sshKeyDao().getAll().first().forEach { graph.sshKeyDao().deleteById(it.id) }
 
@@ -330,7 +338,7 @@ class J06BackgroundGraceReturnJourney {
         val retired = GraceCoordinator(
             connections = registry,
             service = AndroidGraceServiceControl(application),
-            graceMs = RETIRED_GRACE_MS,
+            graceMs = { RETIRED_GRACE_MS },
         )
         instrumentation.runOnMainSync {
             retired.register(application)
@@ -494,7 +502,7 @@ class J06BackgroundGraceReturnJourney {
         val shortWindow = GraceCoordinator(
             connections = registry,
             service = AndroidGraceServiceControl(application),
-            graceMs = EXPIRING_GRACE_MS,
+            graceMs = { EXPIRING_GRACE_MS },
         )
         instrumentation.runOnMainSync { shortWindow.register(application) }
 
@@ -562,6 +570,92 @@ class J06BackgroundGraceReturnJourney {
         // Same reason as the sibling tests: leave no live connection behind for
         // the Activity teardown to arm a real window over.
         runBlocking { registry.closeAll() }
+    }
+
+    /**
+     * Regression for issue #2488, on the real device path: the Settings row
+     * that says how long a backgrounded session is held has to be the window
+     * the running app actually uses.
+     *
+     * ## What broke
+     *
+     * `AppModule.provideGraceCoordinator` built the app's `@Singleton`
+     * coordinator as `GraceCoordinator(connections, service)` — no window
+     * argument — so [AppSettings.backgroundGraceMillis] was persisted, shown as
+     * a selected option, and read by nothing. Every window was
+     * [GraceCoordinator.DEFAULT_GRACE_MS]. A user who set "30 sec" to save
+     * battery still held the transport and a wake lock for 90 s, and a user who
+     * set "10 min" lost their session after 90.
+     *
+     * ## Why it is a journey and not only [GraceWindowSettingWiringTest]
+     *
+     * The JVM test drives the provider function directly; it cannot see whether
+     * the RUNNING app's Hilt graph builds its one real coordinator that way, and
+     * that graph is exactly where the bug lived. So this uses no test-built
+     * coordinator at all: it writes the preference through the app's own
+     * [SettingsRepository] singleton, backgrounds the real Activity, and reads
+     * the window back out of the REAL posted notification — whose `when` is the
+     * deadline [GraceService] anchors the system count-down on, i.e. the number
+     * the user is looking at.
+     *
+     * The preference is process-wide and outlives this test method, so it is
+     * restored in a `finally` (and again by every [seed]) — a leftover 30 s
+     * window would otherwise expire under a later journey's live session.
+     */
+    @Test
+    fun theGraceWindowSettingChangesTheRealHoldTheAppArms() {
+        val settings = appGraph().settingsRepository()
+        try {
+            // Exactly what tapping the Settings row does — the same @Singleton
+            // the Settings screen writes through.
+            settings.setBackgroundGraceMillis(SHORT_GRACE_OPTION_MS)
+            assertEquals(
+                "the fixture setting must really be stored before backgrounding",
+                SHORT_GRACE_OPTION_MS,
+                settings.settings.value.backgroundGraceMillis,
+            )
+
+            openSession()
+            awaitTranscript("the fixture's banner line") { it.contains(BANNER) }
+            assertTrue(
+                "the window must be armed over a REAL live connection",
+                appGraph().connectionsRegistry().liveConnections().isNotEmpty(),
+            )
+
+            // Background the app for real: the app's OWN coordinator arms the
+            // window, with no test-built instance anywhere in the picture.
+            val armedAt = System.currentTimeMillis()
+            compose.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+            awaitGraceHolding(true, "after backgrounding with a 30s window configured")
+            val notification = awaitGraceNotification("after backgrounding")
+            JourneyScreenshots.capture("12-configured-window-notification", JOURNEY)
+
+            // `setWhen(deadlineMs)` is what the system count-down is anchored
+            // on, so this IS the window the user sees and the one the transport
+            // is dropped at.
+            val window = notification.notification.`when` - armedAt
+            assertTrue(
+                "issue #2488: the app must hold for the CONFIGURED " +
+                    "${SHORT_GRACE_OPTION_MS}ms, but the real notification counts down " +
+                    "${window}ms (the inert-setting bug always armed " +
+                    "${GraceCoordinator.DEFAULT_GRACE_MS}ms)",
+                window >= SHORT_GRACE_OPTION_MS && window <= SHORT_GRACE_OPTION_MS + SETTING_SLACK_MS,
+            )
+
+            // Come back well inside even the short window, so nothing is
+            // dropped and the next test starts clean.
+            compose.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+            awaitGraceHolding(false, "after returning")
+            awaitNoGraceNotification("after returning")
+            assertNoReconnectBanner("after returning from the configured-window scenario")
+            compose.onNodeWithTag(SESSION_ERROR_BANNER_TAG).assertDoesNotExist()
+
+            // Same reason as the sibling tests: leave no live connection behind
+            // for the Activity teardown to arm a real window over.
+            runBlocking { appGraph().connectionsRegistry().closeAll() }
+        } finally {
+            settings.setBackgroundGraceMillis(AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS)
+        }
     }
 
     // --- helpers ------------------------------------------------------------
@@ -766,6 +860,21 @@ class J06BackgroundGraceReturnJourney {
         const val EXPIRED_MARKER = "j06-back-after-expiry"
 
         /**
+         * Issue #2488 picks the SHORTEST offered option: it is the furthest
+         * from [GraceCoordinator.DEFAULT_GRACE_MS], so a coordinator still
+         * using the inert default misses it by a minute, and it is short enough
+         * that a test which failed to come back leaves nothing held for long.
+         */
+        const val SHORT_GRACE_OPTION_MS = AppSettings.BACKGROUND_GRACE_30_SECONDS_MS
+
+        /**
+         * Head-room between arming the window and reading the posted
+         * notification back. Far below the 60 s gap to the inert default, so a
+         * regression cannot slip through this band.
+         */
+        const val SETTING_SLACK_MS = 15_000L
+
+        /**
          * Issue #2487's window has to actually ELAPSE inside a test, so it is
          * seconds rather than [GraceCoordinator.DEFAULT_GRACE_MS]. Long enough
          * that arming it over the real connection finishes first — the test
@@ -783,6 +892,7 @@ class J06BackgroundGraceReturnJourney {
             "aRetiredCoordinatorsExpiryCannotTakeDownTheLiveHold" to 9_603L,
             "returningAfterTheGraceWindowExpiresReattachesInsteadOfReportingTheSessionEnded"
                 to 9_604L,
+            "theGraceWindowSettingChangesTheRealHoldTheAppArms" to 9_605L,
         )
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/di/AppModule.kt
+++ b/app2/src/main/java/com/pocketshell/next/di/AppModule.kt
@@ -25,6 +25,7 @@ import com.pocketshell.next.hostcli.HostCliClientFactory
 import com.pocketshell.next.hostcli.asRemoteExec
 import com.pocketshell.next.hosts.HostImporter
 import com.pocketshell.next.hosts.SshKeyStore
+import com.pocketshell.next.settings.SettingsRepository
 import com.pocketshell.next.terminal.AndroidGraceServiceControl
 import com.pocketshell.next.terminal.ForegroundSignal
 import com.pocketshell.next.terminal.GraceCoordinator
@@ -270,16 +271,41 @@ object AppModule {
      * close on every connection and cancel only its own.
      *
      * Provided rather than `@Inject`-annotated so the class keeps the plan's
-     * §C.4 constructor — a clock and a grace default a test can substitute
+     * §C.4 constructor — a clock and a grace window a test can substitute
      * without a graph. [com.pocketshell.next.MainActivity] is what calls
      * `register()`; nothing here starts anything eagerly.
+     *
+     * ## The window comes from Settings (task P-6, issue #2488)
+     *
+     * [com.pocketshell.next.settings.AppSettings.backgroundGraceMillis] is a
+     * user-facing Settings row. This provider used to build the coordinator
+     * with no window argument at all, so the row was inert: every window was
+     * the class default no matter which option was picked.
+     *
+     * It is passed as a SUPPLIER over [SettingsRepository]'s hot snapshot, not
+     * as the value read here, because BOTH of these are process-lifetime
+     * `@Singleton`s: a value read at graph-construction time is read once per
+     * process, so changing the setting would only take effect after the process
+     * died — an inert setting with extra steps. The supplier is called once per
+     * armed window (see [GraceCoordinator.graceMs]), which is the moment the
+     * value is actually needed and the only moment it can be fresh.
+     *
+     * Reading `settings.value` costs nothing here: [SettingsRepository] holds
+     * the snapshot in memory and its one lazy disk read has already happened —
+     * `MainActivity` collects the same flow to seed `LocalAppSettings`, and
+     * there is no window to arm before a UI existed to open a connection from.
      */
     @Provides
     @Singleton
     fun provideGraceCoordinator(
         connections: ConnectionsRegistry,
         service: GraceServiceControl,
-    ): GraceCoordinator = GraceCoordinator(connections = connections, service = service)
+        settings: SettingsRepository,
+    ): GraceCoordinator = GraceCoordinator(
+        connections = connections,
+        service = service,
+        graceMs = { settings.settings.value.backgroundGraceMillis },
+    )
 
     // -------------------------------------------------------------------------
     // Diagnostics (task P-10): generic bounded event-log recorder. `crash/`

--- a/app2/src/main/java/com/pocketshell/next/settings/SettingsRepository.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/SettingsRepository.kt
@@ -48,11 +48,17 @@ import kotlinx.coroutines.flow.asStateFlow
  * [AppSettings.voiceLanguage] is written here and read by nothing yet: app2's
  * dictation calls the recognizer with no language hint until task P-2 lands the
  * voice stack, which owns that call site. [AppSettings.usageWarnThresholdPercent]
- * is likewise the usage panel's (task P-5) to read.
- * [AppSettings.backgroundGraceMillis] is task U-8's. Each is a settings-surface
+ * is likewise the usage panel's (task P-5) to read. Each is a settings-surface
  * value its owning task consumes; the alternative — landing the screen without
  * them and editing it three more times — is worse. They are called out here so
  * "nothing reads this" is a known state, not a discovery.
+ *
+ * [AppSettings.backgroundGraceMillis] WAS on that list and no longer is: issue
+ * #2488 is what "a known state" turns into when nobody comes back for it — the
+ * row shipped, `AppModule.provideGraceCoordinator` never passed it, and the
+ * picker changed nothing for a user who moved it. It is now read per armed
+ * background window straight off [settings], so a change takes effect on the
+ * next background rather than the next process.
  */
 @Singleton
 class SettingsRepository @Inject constructor(

--- a/app2/src/main/java/com/pocketshell/next/terminal/GraceCoordinator.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/GraceCoordinator.kt
@@ -51,7 +51,7 @@ interface GraceServiceControl {
  *
  * ## What runs while backgrounded
  *
- * Exactly two timers, both bounded by [graceMs] and both cancelled on return:
+ * Exactly two timers, both bounded by the window [graceMs] returns and both cancelled on return:
  * the transport's own delayed close ([com.pocketshell.core.transport.HostConnection.scheduleGraceClose],
  * task T-5) and this class's expiry job, whose ONLY job is to take the service
  * down at the same instant so no wake lock outlives the connection it was held
@@ -91,7 +91,24 @@ class GraceCoordinator(
     private val connections: ConnectionsRegistry,
     private val service: GraceServiceControl,
     private val clock: () -> Long = { System.currentTimeMillis() },
-    private val graceMs: Long = DEFAULT_GRACE_MS,
+    /**
+     * How long the next window lasts, in millis. A SUPPLIER, read once each
+     * time a window is armed, for the same reason [clock] is one: the value is
+     * a user setting ([com.pocketshell.next.settings.AppSettings.backgroundGraceMillis],
+     * task P-6) and this class is a process-lifetime `@Singleton`, so a value
+     * captured when the Hilt graph was built would pin the window to whatever
+     * was stored at launch — changing the Settings row would do nothing until
+     * the process died, which is the inert-setting bug issue #2488 filed (the
+     * provider simply never passed the value at all, so the window was always
+     * the 90 s default).
+     *
+     * Reading it per-arm rather than per-instance is what makes "change it and
+     * background the app" take effect immediately. It is read ONCE per window
+     * inside [enterBackground]'s lock, so the transport's deadline, the
+     * notification's count-down and this class's expiry timer can never be
+     * three different numbers because the user tapped a new option mid-arm.
+     */
+    private val graceMs: () -> Long = { DEFAULT_GRACE_MS },
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : DefaultLifecycleObserver, Application.ActivityLifecycleCallbacks {
 
@@ -215,13 +232,15 @@ class GraceCoordinator(
         // Nothing to hold: no service, no notification, no wake lock.
         if (live.isEmpty()) return
         armed = true
-        handles = live.map { it.scheduleGraceClose(graceMs) }
+        // ONE read of the user's setting for this whole window — see [graceMs].
+        val window = graceMs()
+        handles = live.map { it.scheduleGraceClose(window) }
         // Arming, showing and timing the window happen under ONE lock so a
         // foreground return landing mid-sequence cannot cancel a close that has
         // not been armed yet, or stop a service that is started a line later.
-        service.start(clock() + graceMs)
+        service.start(clock() + window)
         expiry = scope.launch {
-            delay(graceMs)
+            delay(window)
             onGraceExpired()
         }
     }
@@ -343,11 +362,20 @@ class GraceCoordinator(
         private val activeInstance = AtomicReference<GraceCoordinator?>(null)
 
         /**
-         * The ONE grace default (D21, #1159): 90 seconds. Long enough to answer
-         * a message, check a calendar or paste something in from another app;
+         * The grace DEFAULT (D21, #1159): 90 seconds. Long enough to answer a
+         * message, check a calendar or paste something in from another app;
          * short enough that a phone left in a pocket is not holding an SSH
-         * transport and a wake lock. There is deliberately no setting for it —
-         * plan §U-8 non-goal.
+         * transport and a wake lock.
+         *
+         * It is the value a coordinator built with no [graceMs] supplier uses
+         * — i.e. every test that does not care about the window, and nothing
+         * in production: [com.pocketshell.next.di.AppModule.provideGraceCoordinator]
+         * supplies the user's stored
+         * [com.pocketshell.next.settings.AppSettings.backgroundGraceMillis],
+         * whose own default is this same 90 s (pinned by
+         * `AppSettingsTest`), so a fresh install behaves identically. Task
+         * U-8 called a setting a non-goal; task P-6 shipped the row, and
+         * issue #2488 is what it cost to ship the row without the wire.
          */
         const val DEFAULT_GRACE_MS: Long = 90_000L
     }

--- a/app2/src/test/java/com/pocketshell/next/di/GraceWindowSettingWiringTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/di/GraceWindowSettingWiringTest.kt
@@ -1,0 +1,298 @@
+package com.pocketshell.next.di
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.core.transport.ConnectResult
+import com.pocketshell.core.transport.FakeHostConnection
+import com.pocketshell.next.connect.ConnectionsRegistry
+import com.pocketshell.next.connect.FakeHostConnectionFactory
+import com.pocketshell.next.connect.RoomTrustStore
+import com.pocketshell.next.settings.AppSettings
+import com.pocketshell.next.settings.SettingsRepository
+import com.pocketshell.next.terminal.FakeGraceServiceControl
+import com.pocketshell.next.terminal.GraceCoordinator
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression for issue #2488 — the background-grace SETTING has to reach the
+ * thing that implements it.
+ *
+ * ## What was broken
+ *
+ * [AppSettings.backgroundGraceMillis] is persisted by [SettingsRepository] and
+ * rendered as a user-facing Settings row (task P-6), but
+ * [AppModule.provideGraceCoordinator] built the coordinator as
+ * `GraceCoordinator(connections, service)` — with no window argument at all. So
+ * every background window was [GraceCoordinator.DEFAULT_GRACE_MS] no matter
+ * which option the user picked: a control that changes nothing, which is worse
+ * than no control, because the user believes their session is being held for
+ * ten minutes when it is dropped after ninety seconds.
+ *
+ * ## Why the assertions are on the PROVIDER, not on a hand-built coordinator
+ *
+ * The bug was never in [GraceCoordinator] — it always honoured whatever window
+ * it was handed, and `GraceCoordinatorTest` proved that with a literal. The
+ * defect lived entirely in the wiring, so the only test that can fail on it is
+ * one that goes through the REAL provider function with the REAL repository:
+ * store a value the way the Settings screen does, then ask
+ * [AppModule.provideGraceCoordinator] for the coordinator the app would get and
+ * watch what window it actually arms.
+ *
+ * Everything below the provider is real too — the real [ConnectionsRegistry]
+ * over `core-transport`'s scripted connection, the real
+ * `SharedPreferences`-backed repository on Robolectric's on-disk file. Only the
+ * Android foreground-service mechanics sit behind [FakeGraceServiceControl],
+ * which is the seam that exists for exactly this (see its class doc).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class GraceWindowSettingWiringTest {
+
+    private lateinit var db: AppDatabase
+    private var hostId: Long = 0
+
+    @Before
+    fun setUp() = runBlocking {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext<Context>(),
+            AppDatabase::class.java,
+        ).allowMainThreadQueries().build()
+
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(name = "fixture", privateKeyPath = "/tmp/fixture_ed25519"),
+        )
+        hostId = db.hostDao().insert(
+            HostEntity(
+                name = "dev box",
+                hostname = "dev.invalid",
+                port = 2222,
+                username = "tester",
+                keyId = keyId,
+            ),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    /**
+     * The bug itself: a user who chooses "10 min" must get a ten-minute window.
+     *
+     * Both halves of the window are asserted, because both are what the user
+     * feels: the deadline the coordinator hands the foreground service is the
+     * count-down the notification renders, and the delay it arms on the
+     * transport is when the SSH session is actually dropped. Before the fix
+     * both were 90 s.
+     */
+    @Test
+    fun `the stored grace window is the one the provided coordinator arms`() = runBlocking {
+        val settings = SettingsRepository(ApplicationProvider.getApplicationContext())
+        // Exactly what tapping the Settings row does.
+        settings.setBackgroundGraceMillis(AppSettings.BACKGROUND_GRACE_10_MINUTES_MS)
+
+        val (registry, connection) = registryWithOneLiveConnection()
+        val service = FakeGraceServiceControl()
+        val coordinator = AppModule.provideGraceCoordinator(registry, service, settings)
+
+        val armedAt = System.currentTimeMillis()
+        coordinator.enterBackground()
+
+        assertTrue("a background window must be open", coordinator.isHolding)
+        assertDeadline(
+            what = "the count-down the grace notification shows",
+            expectedWindowMs = AppSettings.BACKGROUND_GRACE_10_MINUTES_MS,
+            armedAt = armedAt,
+            deadlineMs = service.startedDeadlines.single(),
+        )
+        assertDeadline(
+            what = "the transport's own delayed close",
+            expectedWindowMs = AppSettings.BACKGROUND_GRACE_10_MINUTES_MS,
+            armedAt = armedAt,
+            deadlineMs = connection.graceHandles.single().deadlineMs,
+        )
+
+        // Leaves nothing armed behind this test (the provider's coordinator
+        // runs its expiry on Dispatchers.Default, not a test scheduler).
+        coordinator.enterForeground()
+    }
+
+    /**
+     * The half a value captured at graph-construction time would fail.
+     *
+     * [GraceCoordinator] and [SettingsRepository] are BOTH process-lifetime
+     * `@Singleton`s, so a provider that read `settings.value.backgroundGraceMillis`
+     * once, at injection time, would pin the window to whatever was stored when
+     * the app launched — the user changes the setting, sees the row update, and
+     * still gets the old window until they kill the app. That is the same inert
+     * control this issue is about, so the provider passes a supplier and the
+     * coordinator reads it per armed window.
+     */
+    @Test
+    fun `changing the setting on a live coordinator changes the next window`() = runBlocking {
+        val settings = SettingsRepository(ApplicationProvider.getApplicationContext())
+        settings.setBackgroundGraceMillis(AppSettings.BACKGROUND_GRACE_30_SECONDS_MS)
+
+        val (registry, connection) = registryWithOneLiveConnection()
+        val service = FakeGraceServiceControl()
+        val coordinator = AppModule.provideGraceCoordinator(registry, service, settings)
+
+        val firstArmedAt = System.currentTimeMillis()
+        coordinator.enterBackground()
+        assertDeadline(
+            what = "the first window",
+            expectedWindowMs = AppSettings.BACKGROUND_GRACE_30_SECONDS_MS,
+            armedAt = firstArmedAt,
+            deadlineMs = service.startedDeadlines.single(),
+        )
+        coordinator.enterForeground()
+
+        // The user opens Settings mid-session and picks a longer window.
+        settings.setBackgroundGraceMillis(AppSettings.BACKGROUND_GRACE_5_MINUTES_MS)
+
+        val secondArmedAt = System.currentTimeMillis()
+        coordinator.enterBackground()
+
+        assertEquals("the second background must arm a second window", 2, service.startCount)
+        assertDeadline(
+            what = "the window armed AFTER the setting changed",
+            expectedWindowMs = AppSettings.BACKGROUND_GRACE_5_MINUTES_MS,
+            armedAt = secondArmedAt,
+            deadlineMs = service.startedDeadlines.last(),
+        )
+        assertDeadline(
+            what = "the transport close armed AFTER the setting changed",
+            expectedWindowMs = AppSettings.BACKGROUND_GRACE_5_MINUTES_MS,
+            armedAt = secondArmedAt,
+            deadlineMs = connection.graceHandles.last().deadlineMs,
+        )
+
+        coordinator.enterForeground()
+    }
+
+    /**
+     * A value that survived a process restart is what the next window uses —
+     * the same repository instance is not what production has (the graph is
+     * rebuilt on every cold start), so the read has to come off the PERSISTED
+     * file, not off the object that happened to write it.
+     */
+    @Test
+    fun `a window stored by a previous process run is honoured after a restart`() = runBlocking {
+        SettingsRepository(ApplicationProvider.getApplicationContext())
+            .setBackgroundGraceMillis(AppSettings.BACKGROUND_GRACE_1_MINUTE_MS)
+
+        // A cold start: a brand-new repository reading the file from scratch,
+        // exactly as the next launch's Hilt graph would build it.
+        val restarted = SettingsRepository(ApplicationProvider.getApplicationContext())
+        val (registry, _) = registryWithOneLiveConnection()
+        val service = FakeGraceServiceControl()
+        val coordinator = AppModule.provideGraceCoordinator(registry, service, restarted)
+
+        val armedAt = System.currentTimeMillis()
+        coordinator.enterBackground()
+
+        assertDeadline(
+            what = "the window after a cold start",
+            expectedWindowMs = AppSettings.BACKGROUND_GRACE_1_MINUTE_MS,
+            armedAt = armedAt,
+            deadlineMs = service.startedDeadlines.single(),
+        )
+
+        coordinator.enterForeground()
+    }
+
+    /**
+     * A fresh install must behave exactly as it did before this wiring existed:
+     * the settings default and the coordinator's own default are the same 90 s
+     * (D21, #1159), so passing the setting through changes nothing for a user
+     * who never opens Settings.
+     */
+    @Test
+    fun `a fresh install still gets the ninety-second default`() = runBlocking {
+        val settings = SettingsRepository(ApplicationProvider.getApplicationContext())
+        assertEquals(
+            "the settings default and the coordinator default must not drift apart",
+            GraceCoordinator.DEFAULT_GRACE_MS,
+            AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS,
+        )
+
+        val (registry, _) = registryWithOneLiveConnection()
+        val service = FakeGraceServiceControl()
+        val coordinator = AppModule.provideGraceCoordinator(registry, service, settings)
+
+        val armedAt = System.currentTimeMillis()
+        coordinator.enterBackground()
+
+        assertDeadline(
+            what = "an untouched install's window",
+            expectedWindowMs = GraceCoordinator.DEFAULT_GRACE_MS,
+            armedAt = armedAt,
+            deadlineMs = service.startedDeadlines.single(),
+        )
+
+        coordinator.enterForeground()
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    /**
+     * Both deadlines under test are `wall-clock now + window`, computed inside
+     * `enterBackground` off a real clock, so they are asserted as an interval
+     * anchored on the instant the test armed them: no earlier than [armedAt] +
+     * the window (the call cannot have happened before the test made it) and no
+     * later than that plus a slack far smaller than the gap between ANY two
+     * options in [AppSettings.BACKGROUND_GRACE_OPTIONS] — so a wrong option can
+     * never satisfy the assertion.
+     */
+    private fun assertDeadline(
+        what: String,
+        expectedWindowMs: Long,
+        armedAt: Long,
+        deadlineMs: Long,
+    ) {
+        val actualWindow = deadlineMs - armedAt
+        assertTrue(
+            "$what must be the STORED window of ${expectedWindowMs}ms, but the coordinator " +
+                "armed ${actualWindow}ms (issue #2488: the Settings row was inert and every " +
+                "window was the ${GraceCoordinator.DEFAULT_GRACE_MS}ms default)",
+            actualWindow >= expectedWindowMs && actualWindow <= expectedWindowMs + SLACK_MS,
+        )
+    }
+
+    private suspend fun registryWithOneLiveConnection(): Pair<ConnectionsRegistry, FakeHostConnection> {
+        val factory = FakeHostConnectionFactory()
+        val registry = ConnectionsRegistry(
+            factory = factory,
+            trustStore = RoomTrustStore(db.hostDao(), Dispatchers.Unconfined),
+            hostDao = db.hostDao(),
+            dispatcher = Dispatchers.Unconfined,
+        )
+        val connected = registry.getOrConnect(hostId)
+        check(connected is ConnectResult.Connected) { "fixture dial must succeed, got $connected" }
+        return registry to factory.connections.single()
+    }
+
+    private companion object {
+        /**
+         * Head-room for the wall-clock milliseconds spent inside
+         * `enterBackground`. 10 s is generous for a JVM test and still an order
+         * of magnitude below the 30 s gap between the two closest offered
+         * options, so it cannot let one option pass for another.
+         */
+        const val SLACK_MS = 10_000L
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/terminal/GraceCoordinatorTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/GraceCoordinatorTest.kt
@@ -96,7 +96,7 @@ class GraceCoordinatorTest {
             connections = registry,
             service = service,
             clock = { nowMs },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
 
@@ -133,7 +133,7 @@ class GraceCoordinatorTest {
             connections = registry,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
 
@@ -156,7 +156,7 @@ class GraceCoordinatorTest {
             connections = registry,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
 
@@ -198,7 +198,7 @@ class GraceCoordinatorTest {
             connections = registry,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
 
@@ -219,7 +219,7 @@ class GraceCoordinatorTest {
             connections = registry,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
 
@@ -262,7 +262,7 @@ class GraceCoordinatorTest {
             connections = registry,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
 
@@ -313,7 +313,7 @@ class GraceCoordinatorTest {
             connections = registryOne,
             service = serviceOne,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
         coordinatorOne.register(application)
@@ -324,7 +324,7 @@ class GraceCoordinatorTest {
             connections = registryTwo,
             service = serviceTwo,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
         // Simulates a later test method's fresh Hilt component handing a NEW
@@ -393,7 +393,7 @@ class GraceCoordinatorTest {
             connections = registryOne,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
         coordinatorOne.register(application)
@@ -414,7 +414,7 @@ class GraceCoordinatorTest {
             connections = registryTwo,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
         coordinatorTwo.register(application)
@@ -477,7 +477,7 @@ class GraceCoordinatorTest {
             connections = registryOne,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
         coordinatorOne.register(application)
@@ -490,7 +490,7 @@ class GraceCoordinatorTest {
             connections = registryTwo,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
         coordinatorTwo.register(application)
@@ -533,7 +533,7 @@ class GraceCoordinatorTest {
             connections = registryOne,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
         coordinatorOne.register(application)
@@ -542,7 +542,7 @@ class GraceCoordinatorTest {
             connections = registryTwo,
             service = service,
             clock = { 0L },
-            graceMs = GRACE_MS,
+            graceMs = { GRACE_MS },
             dispatcher = dispatcher,
         )
         coordinatorTwo.register(application)

--- a/scripts/test-areas.txt
+++ b/scripts/test-areas.txt
@@ -246,6 +246,7 @@ full   shared/test-support/*         the ONE audited settle pump; every runTest 
 # hard cut (D22): the same blast radii exist, in the module that now holds
 # them. `app/src/proofTest/*` has no app2 successor and is simply gone.
 full   app2/src/main/java/com/pocketshell/next/di/*           the Hilt/DI graph wires every area together
+full   app2/src/test/java/com/pocketshell/next/di/*           tests of the Hilt/DI graph verify real cross-area wiring (#2488)
 full   app2/src/main/java/com/pocketshell/next/nav/*          the navigation graph reaches every screen
 full   app2/src/main/java/com/pocketshell/next/App.kt         application object: lifecycle fan-out to every surface
 full   app2/src/main/java/com/pocketshell/next/MainActivity.kt  single activity host for every destination
@@ -367,12 +368,17 @@ test   tools/pocketshell/tests/*     host-cli             full
 # ---------------------------------------------------------------------------
 # PER-CLASS OVERRIDES
 #
-# EMPTY since the rewrite's hard cut (D22). The only overrides this file ever
-# carried were the six conversation-source classes that lived in the old
+# The six conversation-source classes that lived in the old
 # com.pocketshell.app.tmux package while belonging to the conversation-agents
-# area; both the package and the area are gone. app2 has no class whose
-# regression class differs from its package's area — add a row here (and say
-# why) the first time one appears.
+# area are gone with that package and area (D22 hard cut).
+#
+# GraceWindowSettingWiringTest lives in com.pocketshell.next.di (the DI graph
+# package, `full` — no package-level area of its own to inherit), but its own
+# regression class is the grace window: it proves AppModule.provideGraceCoordinator
+# actually carries AppSettings.backgroundGraceMillis into GraceCoordinator
+# (#2488). GraceCoordinator is the tmux-session area's own subject, so that is
+# this class's area even though SettingsRepository is its secondary dependency.
+class  com.pocketshell.next.di.GraceWindowSettingWiringTest  tmux-session
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`AppSettings.backgroundGraceMillis` was persisted and shown as a Settings row, but `AppModule.provideGraceCoordinator` never passed it to `GraceCoordinator` — the window was always the 90s default regardless of configuration.

`graceMs` is now a supplier (`() -> Long`), not a captured value: both `GraceCoordinator` and `SettingsRepository` are process-lifetime singletons, so a captured value would just move the inertness to "takes effect next launch." Read once per armed window.

## Verification
- Red on both lanes: JVM wiring test showed `armed 90001ms` against a stored `30000ms`; on-device, the real notification's countdown read `90907ms` against the same configured value.
- Green with the fix; full unfiltered `J06BackgroundGraceReturnJourney` 5/5 on the emulator, real `StatusBarNotification.when` read as the oracle.
- No interaction with #2487's `supersede()`/retired-instance handling — a retired instance returns before ever reading `graceMs()`.

Reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2488#issuecomment-5547030676

Closes #2488