### PR TITLE
fix: composer draft can leak or be deleted across a session hand-off

### DIFF
--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
@@ -79,7 +79,29 @@ class ComposerViewModel @Inject constructor(
     private var sink: SessionSink? = null
     private var homeDir: String? = null
 
+    /**
+     * Whether what is in [_state] is really [sessionKey]'s draft — i.e. whether
+     * it may be written back to [drafts].
+     *
+     * False from the moment [bind] points the composer at a session until
+     * either its stored draft has been read back ([loadJob] resolving) or the
+     * user has put something in the composer themselves. In that window an
+     * empty [_state] means "not read yet", NOT "this session has no draft", and
+     * persisting it would DELETE a draft the user is still expecting to find —
+     * [ComposerDraftStore.clear] wipes the mirror and the preferences file
+     * alike, so there is nothing to recover it from.
+     *
+     * The asymmetry is the whole point: writing a stale-empty draft as a `save`
+     * is recoverable noise, writing it as a `clear` is data loss. So an
+     * unauthoritative state writes NEITHER — it leaves the stored draft exactly
+     * as it was and lets the load, or the next keystroke, decide. The window is
+     * widest exactly where it matters: the load hops to disk, and the first
+     * `getSharedPreferences` on the file parses it synchronously.
+     */
+    private var draftKnown = false
+
     private var persistJob: Job? = null
+    private var loadJob: Job? = null
     private var stageJob: Job? = null
     private var historyJob: Job? = null
     private var deliveryJob: Job? = null
@@ -92,16 +114,31 @@ class ComposerViewModel @Inject constructor(
      * builds a new one over the same ViewModel) but the draft is loaded and the
      * history subscribed only once, because re-loading would overwrite whatever
      * the user has typed since.
+     *
+     * A bind with a DIFFERENT session key hands the old session off first
+     * ([handOff]), so nothing of it can be seen or written under the new one.
+     * Today the navigation graph makes that path unreachable — the screen
+     * resolves this ViewModel with `hiltViewModel()` inside the
+     * `session/{hostId}/{sessionName}` destination, so its store owner is that
+     * route's `NavBackStackEntry` and every session opens a fresh instance. The
+     * hand-off is what keeps that an implementation detail of the navigation
+     * graph rather than a load-bearing assumption of the composer: a
+     * quick-switch sheet that reuses one entry across sessions would otherwise
+     * flash session A's unsent draft in session B's composer.
      */
     fun bind(hostId: Long, sessionName: String, sink: SessionSink) {
         this.sink = sink
         _state.update { it.copy(micAvailable = dictation.isAvailable()) }
         val key = ComposerText.sessionKey(hostId, sessionName)
         if (sessionKey == key) return
+        handOff()
         this.hostId = hostId
         this.sessionKey = key
         this.homeDir = null
-        viewModelScope.launch {
+        // Nothing is known about the new session's draft until its load lands
+        // (or the user types), so nothing may be written under its key yet.
+        draftKnown = false
+        loadJob = viewModelScope.launch {
             val stored = drafts.load(key)
             // Only adopt the stored draft if nothing has been typed in the
             // meantime: the load is asynchronous and the user can beat it.
@@ -112,6 +149,9 @@ class ComposerViewModel @Inject constructor(
                     current.copy(draft = stored.text, attachments = stored.attachments)
                 }
             }
+            // Either branch leaves _state holding this session's real draft:
+            // the stored one, or the newer text the user typed over it.
+            draftKnown = true
         }
         historyJob?.cancel()
         historyJob = viewModelScope.launch {
@@ -121,9 +161,69 @@ class ComposerViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Lets go of the session this composer was pointed at, on the way to
+     * another one.
+     *
+     * Everything on screen belongs to the session being left, so all of it goes
+     * SYNCHRONOUSLY, in the same frame as the [bind] that caused the switch —
+     * the load for the new session is asynchronous, and a state that is merely
+     * "about to be replaced" is a state the user can see and send from.
+     *
+     * The four things that would otherwise cross the boundary:
+     *
+     *  - the outgoing draft's own pending writes. The debounce means the last
+     *    keystrokes may not have been persisted yet, and [writeDraft] reads
+     *    `sessionKey` when it RUNS — so a pending write would land under the new
+     *    session's key. It is cancelled and re-issued against the key it was
+     *    typed under, on its own coroutine rather than [persistJob], because the
+     *    first keystroke in the new session cancels that one. That re-issue is
+     *    subject to [draftKnown]: a switch that happens before the outgoing
+     *    session's own load resolved has NOTHING authoritative to write, and
+     *    writing the empty state would delete that session's stored draft.
+     *  - the draft load for the old key, which would resolve into the cleared
+     *    state and repaint the old session's draft as the new one's.
+     *  - an attachment upload, whose remote path is scoped to the old session.
+     *    Cancelling it drops any tile that had not landed yet, so a file already
+     *    copied to the host is orphaned out of the persisted draft — retention
+     *    prunes it, and the alternative (staging into the new session) is worse.
+     *  - a live dictation. [AndroidSpeechRecognitionDelegate.release] is the
+     *    silent stop: the recognizer is cancelled and its late partials can no
+     *    longer type the old session's speech into the new session's draft.
+     */
+    private fun handOff() {
+        val leaving = sessionKey
+        loadJob?.cancel()
+        stageJob?.cancel()
+        persistJob?.cancel()
+        persistJob = null
+        dictation.release()
+        val outgoing = _state.value
+        if (leaving != null && draftKnown) {
+            val draft = ComposerDraft(outgoing.draft, outgoing.attachments)
+            viewModelScope.launch {
+                if (draft.isEmpty) drafts.clear(leaving) else drafts.save(leaving, draft)
+            }
+        }
+        _state.update {
+            it.copy(
+                draft = "",
+                attachments = emptyList(),
+                recording = RecordingState.Idle,
+                staging = null,
+                notice = null,
+                previewing = false,
+                historyOpen = false,
+                history = emptyList(),
+            )
+        }
+    }
+
     // ---------------------------------------------------------------- editing
 
     fun onDraftChange(text: String) {
+        // What the user typed IS this session's draft, load resolved or not.
+        draftKnown = true
         _state.update {
             // Typing is the acknowledgement of an undelivered chip: the user has
             // seen it and moved on. A failure the user cannot dismiss by acting
@@ -186,6 +286,7 @@ class ComposerViewModel @Inject constructor(
      * Attachment references travel with the text, because they are text.
      */
     fun useHistoryEntry(message: SentMessage) {
+        draftKnown = true
         _state.update { it.copy(draft = message.body, historyOpen = false, notice = null) }
         persist()
     }
@@ -213,6 +314,10 @@ class ComposerViewModel @Inject constructor(
             }.getOrElse { failure ->
                 AttachmentStageResult(emptyList(), "Attachment upload failed: ${describe(failure)}")
             }
+            // A tile the user can see is content this session owns; a batch that
+            // uploaded nothing leaves the draft as unknown as it was, so the
+            // persist below cannot mistake it for "this session is empty".
+            if (result.uploaded.isNotEmpty()) draftKnown = true
             _state.update { current ->
                 current.copy(
                     attachments = merge(current.attachments, result.uploaded),
@@ -263,6 +368,7 @@ class ComposerViewModel @Inject constructor(
         deliveryJob = viewModelScope.launch {
             val recovered = runCatching { queuedDictations.deliverQueued() }.getOrDefault(emptyList())
             if (recovered.isEmpty()) return@launch
+            draftKnown = true
             _state.update { current ->
                 val merged = recovered.fold(current.draft, ComposerText::appendDictated)
                 current.copy(draft = merged, notice = ComposerNotice.Info(deliveredMessage(recovered.size)))
@@ -355,6 +461,11 @@ class ComposerViewModel @Inject constructor(
 
     private suspend fun writeDraft() {
         val key = sessionKey ?: return
+        // Same rule as the hand-off, for the same reason: an empty composer that
+        // has not read its stored draft yet is not evidence that the session has
+        // none, and `clear` is not undoable. A failed attachment upload landing
+        // inside that window is the ordinary way to reach this line.
+        if (!draftKnown) return
         val current = _state.value
         val draft = ComposerDraft(current.draft, current.attachments)
         if (draft.isEmpty) drafts.clear(key) else drafts.save(key, draft)

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
@@ -174,6 +174,255 @@ class ComposerViewModelTest {
         assertEquals("half-written thought", second.state.value.draft)
     }
 
+    // ------------------------------------------------- rebinding across sessions
+
+    /*
+     * Nothing in the app rebinds ONE ComposerViewModel across two sessions
+     * today: `SessionRoute` resolves it with `hiltViewModel()` inside the
+     * `session/{hostId}/{sessionName}` destination, so the ViewModel's store
+     * owner is that route's `NavBackStackEntry` and opening another session
+     * builds a new entry — and a new composer. These tests construct the
+     * rebind synthetically (call `bind` twice on one instance, which is exactly
+     * what a quick-switch sheet reusing one entry would do) and pin the
+     * behaviour the composer must have on its own, without leaning on the
+     * navigation graph to prevent the situation.
+     */
+
+    @Test
+    fun `a rebind to another session never shows the previous session's draft`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onDraftChange("the thing I typed in session A")
+            advanceUntilIdle()
+
+            viewModel.bind(hostId, OTHER_SESSION, sink)
+
+            // Synchronously, in the same frame as the bind: the load for the
+            // new session is asynchronous, and a draft that is merely "about to
+            // be replaced" is one the user can read and send.
+            assertEquals("", viewModel.state.value.draft)
+            assertTrue(viewModel.state.value.attachments.isEmpty())
+
+            // And it does not come back when the in-flight work settles.
+            advanceUntilIdle()
+            assertEquals("", viewModel.state.value.draft)
+            assertTrue(viewModel.state.value.attachments.isEmpty())
+        }
+
+    @Test
+    fun `a rebind to another session clears the attachments, the chip and the history`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.attach(listOf(pick("a-only.txt", "a")))
+            advanceUntilIdle()
+            sink.isLive = false
+            viewModel.onDraftChange("undelivered in A")
+            advanceUntilIdle()
+            viewModel.send()
+            advanceUntilIdle()
+            viewModel.toggleHistory()
+            assertEquals(1, viewModel.state.value.attachments.size)
+            assertEquals(1, viewModel.state.value.history.size)
+
+            viewModel.bind(hostId, OTHER_SESSION, sink)
+
+            assertTrue(viewModel.state.value.attachments.isEmpty())
+            assertNull(viewModel.state.value.notice)
+            assertTrue("session A's sent messages are not session B's", viewModel.state.value.history.isEmpty())
+            assertFalse(viewModel.state.value.historyOpen)
+
+            advanceUntilIdle()
+            assertTrue(viewModel.state.value.attachments.isEmpty())
+            assertTrue(viewModel.state.value.history.isEmpty())
+        }
+
+    /**
+     * The debounced write is the other direction of the same leak: [writeDraft]
+     * reads `sessionKey` when it RUNS, so a keystroke still inside the debounce
+     * window at the moment of the switch would be persisted under the NEW
+     * session's key — and would clobber whatever that session had stored.
+     */
+    @Test
+    fun `a rebind persists the outgoing draft under its own key, not the new one`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onDraftChange("half a thought")
+            // Deliberately not `advanceUntilIdle()`: the write is still inside
+            // its debounce, which is the window a session switch lands in.
+            runCurrent()
+
+            viewModel.bind(hostId, OTHER_SESSION, sink)
+            advanceUntilIdle()
+
+            assertEquals("half a thought", stack.drafts.load(SESSION_KEY).text)
+            assertEquals(
+                "session A's text must never be stored as session B's draft",
+                "",
+                stack.drafts.load("$hostId/$OTHER_SESSION").text,
+            )
+        }
+
+    /** Clearing the screen is not throwing the draft away: A → B → A finds it. */
+    @Test
+    fun `the draft left behind by a rebind is still there when the session is reopened`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onDraftChange("half a thought")
+            runCurrent()
+            viewModel.bind(hostId, OTHER_SESSION, sink)
+            advanceUntilIdle()
+
+            val reopened = stack.viewModel()
+            reopened.bind(hostId, SESSION, sink)
+            advanceUntilIdle()
+
+            assertEquals("half a thought", reopened.state.value.draft)
+        }
+
+    /**
+     * The stored-draft load is asynchronous, so a switch can outrun it. If the
+     * load for the session being left resolves after the switch, it finds an
+     * empty composer and would paint the old session's draft into the new one.
+     */
+    @Test
+    fun `a draft load in flight for the previous session cannot resolve into the new one`() =
+        runTest(dispatcher) {
+            hostId = stack.seedHost()
+            stack.drafts.save(SESSION_KEY, ComposerDraft("stored for session A"))
+            val viewModel = stack.viewModel()
+
+            viewModel.bind(hostId, SESSION, sink)
+            // No advance: session A's load is queued and has not resolved.
+            viewModel.bind(hostId, OTHER_SESSION, sink)
+            advanceUntilIdle()
+
+            assertEquals("", viewModel.state.value.draft)
+        }
+
+    /**
+     * The other half of the same window, and the one that costs the user
+     * something: the hand-off must not WRITE either.
+     *
+     * `_state` is only the outgoing session's draft once its load has landed.
+     * Switch away before that and the composer is empty because nothing has
+     * been read yet — not because the session has no draft — so persisting that
+     * emptiness takes the `clear` branch and deletes a real, unsent draft from
+     * the mirror and the preferences file alike. Nothing can recover it.
+     */
+    @Test
+    fun `a rebind before the outgoing draft has loaded leaves it stored`() = runTest(dispatcher) {
+        hostId = stack.seedHost()
+        stack.drafts.save(SESSION_KEY, ComposerDraft("important unsent text"))
+        val viewModel = stack.viewModel()
+
+        viewModel.bind(hostId, SESSION, sink)
+        // No advance: session A's load is queued and has NOT resolved, so the
+        // empty composer says nothing about what A has stored.
+        viewModel.bind(hostId, OTHER_SESSION, sink)
+        advanceUntilIdle()
+
+        assertEquals(
+            "a switch that outran the load must not delete the draft it never read",
+            "important unsent text",
+            stack.drafts.load(SESSION_KEY).text,
+        )
+    }
+
+    /** And the user gets it back: A → B → A, with the switch inside A's load. */
+    @Test
+    fun `a session switched away from mid-load still shows its draft on the way back`() =
+        runTest(dispatcher) {
+            hostId = stack.seedHost()
+            stack.drafts.save(SESSION_KEY, ComposerDraft("important unsent text"))
+            val viewModel = stack.viewModel()
+
+            viewModel.bind(hostId, SESSION, sink)
+            viewModel.bind(hostId, OTHER_SESSION, sink)
+            advanceUntilIdle()
+            assertEquals("session B starts empty", "", viewModel.state.value.draft)
+
+            viewModel.bind(hostId, SESSION, sink)
+            advanceUntilIdle()
+
+            assertEquals("important unsent text", viewModel.state.value.draft)
+        }
+
+    /**
+     * The same rule on the ordinary persistence path, not just the hand-off:
+     * [ComposerViewModel.writeDraft] runs on a debounce and from every "must
+     * not wait" moment, so it too can fire while the stored draft is still on
+     * its way back from disk.
+     *
+     * Reached here the way a user would: open a session and immediately attach
+     * a file that fails to upload. The failure persists an empty composer —
+     * empty only because the load has not landed — which is a `clear` of a
+     * draft the user never saw and never touched.
+     *
+     * The load is genuinely parked (a gated dispatcher inside a store with a
+     * cold mirror), not merely queued behind the test scheduler, because the
+     * production window is a real disk hop that other work overtakes.
+     */
+    @Test
+    fun `a failed upload before the draft has loaded cannot delete it`() = runTest(dispatcher) {
+        hostId = stack.seedHost()
+        // Seeded through another store instance so the one under test has to
+        // read the preferences file rather than answer from its own mirror.
+        stack.drafts.save(SESSION_KEY, ComposerDraft("important unsent text"))
+        val gate = GatedDispatcher().apply { hold() }
+        val slowDrafts = ComposerDraftStore(stack.context, gate)
+        val viewModel = ComposerViewModel(
+            registry = stack.registry,
+            drafts = slowDrafts,
+            history = stack.db.sentMessageDao(),
+            stager = stack.stager,
+            queuedDictations = stack.queuedDictations,
+            speech = stack.speech,
+        )
+
+        viewModel.bind(hostId, SESSION, sink)
+        viewModel.attach(listOf(Uri.fromFile(File(temporaryFolder.root, "not-there.txt"))))
+        advanceUntilIdle()
+        assertTrue(
+            "the upload must really have failed for this to be the right window",
+            viewModel.state.value.notice is ComposerNotice.Problem,
+        )
+        assertTrue(viewModel.state.value.attachments.isEmpty())
+
+        gate.release()
+        advanceUntilIdle()
+
+        assertEquals(
+            "the stored draft must survive a persist that ran before it was read",
+            "important unsent text",
+            ComposerDraftStore(stack.context, Dispatchers.Unconfined).load(SESSION_KEY).text,
+        )
+        assertEquals(
+            "and it lands in the composer once the load finally resolves",
+            "important unsent text",
+            viewModel.state.value.draft,
+        )
+    }
+
+    /** A recording belongs to the session it was started in, transcript included. */
+    @Test
+    fun `a dictation in flight cannot type into the session it was not started in`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onMicTap()
+            stack.speech.partial("words meant for session A")
+            advanceUntilIdle()
+            assertEquals(RecordingState.Recording, viewModel.state.value.recording)
+
+            viewModel.bind(hostId, OTHER_SESSION, sink)
+            // A recognizer callback can land after the switch; the service call
+            // is asynchronous and nothing on the device stops mid-sentence.
+            stack.speech.partial("words meant for session A, continued")
+            advanceUntilIdle()
+
+            assertEquals("", viewModel.state.value.draft)
+            assertEquals(RecordingState.Idle, viewModel.state.value.recording)
+        }
+
     // -------------------------------------------------------------- history
 
     @Test
@@ -545,5 +794,8 @@ class ComposerViewModelTest {
 
     private companion object {
         const val SESSION = "devbox"
+
+        /** A second session on the same host, for the rebind tests. */
+        const val OTHER_SESSION = "laptop"
     }
 }


### PR DESCRIPTION
## Summary
- Pre-emptive hardening: `ComposerViewModel` is scoped per `NavBackStackEntry`, so a real rebind cannot happen through any current navigation path — but the planned quick-switch sheet would reuse the backstack entry, so this closes the gap before that feature lands.
- `handOff()` closes four crossings on a `bind()` key change: on-screen state cleared synchronously; the pending debounced write re-pointed at the OLD key (not just cancelled); in-flight draft load for the old key cancelled; per-session work released.
- Round 2 (reviewer-found regression): the hand-off write itself could destroy a real stored draft if the switch happened before the outgoing session's async load resolved. Adds a `draftKnown` flag so an unconfirmed-empty state gets neither save nor clear.
- The identical hazard turned out to be independently reachable today via the ordinary `persistNow()`/`writeDraft()` path (failed upload during a parked load) — same guard closes both.

## Verification
- Red→green at each round (3 review rounds total).
- Full suite: 781/781 unit tests, 0 failures.
- One pre-existing (non-blocking) residue found and filed as follow-up: a *successful* upload during the unloaded window still drops stored draft text — reproduces identically on base `main`, not introduced here.

Reviewer: APPROVED — https://github.com/alexeygrigorev/pocketshell/issues/2493#issuecomment-5547116269

Closes #2493