### PR TITLE
ci: drop app2.yml workflow-level paths so the D37 cadence can start

### DIFF
--- a/.github/workflows/app2.yml
+++ b/.github/workflows/app2.yml
@@ -24,13 +24,16 @@ name: app2
 #     reason full-suite-notify.yml (#2353) was
 #     were split out.
 #
-# NOT A REQUIRED CHECK. Registering a workflow that carries trigger-level
-# `paths:` as a required status check is the #2354 footgun: GitHub never starts
-# a run for a non-matching PR, so the required context sits at "Expected"
-# forever with no admin bypass short of dropping the requirement. If these jobs
-# are ever promoted to required, the trigger-level `paths:` below must be
-# removed first and ALL selection moved into the `changes` job (which already
-# does the per-job half and reports a skipped-but-present job either way).
+# NOT A REQUIRED CHECK (#2354). Do not register these jobs as required
+# branch-protection checks. Trigger-level `paths:` / `paths-ignore` were
+# removed (issue #2509): GitHub's `on.push.paths` is the #2354 footgun
+# (non-matching PRs never start a run, required contexts sit at Expected
+# forever) AND empirically suppressed this file's `schedule:` cadence —
+# `gh run list --workflow app2.yml --event schedule` stayed empty while
+# tests.yml's schedule the same morning fired. Per-job selection stays in
+# the `changes` job (empty/unknown base → ALL lanes, which is what
+# schedule/dispatch pass). A skipped-but-present job is the honest signal;
+# a workflow GitHub never started is not.
 #
 # TWO LAYERS OF androidTest PROTECTION.
 #   * `app2-unit` COMPILES the androidTest source set on every run — cheap, no
@@ -46,45 +49,15 @@ name: app2
 #     decisions.
 
 on:
+  # No workflow-level `paths:` / `paths-ignore` (issue #2509 / D37). GitHub's
+  # own filter decides whether the WHOLE run happens; pinning it here is how
+  # the scheduled cadence silently never started. Per-JOB selection is the
+  # `changes` job's business, and it already fail-opens on empty/unknown base.
   push:
     branches:
       - main
       - stable
-    paths:
-      # The UNION of every job's filter below. Per-JOB selection is the
-      # `changes` job's business — GitHub's own `paths:` is workflow-level.
-      - "app2/**"
-      - "shared/core-transport/**"
-      - "shared/core-portfwd/**"
-      - "shared/core-hostapi/**"
-      - "gradle/**"
-      - "settings.gradle.kts"
-      - "build.gradle.kts"
-      - "gradle.properties"
-      - "gradlew"
-      - "gradlew.bat"
-      - "tests/docker/**"
-      - ".github/workflows/app2.yml"
-      - "scripts/ci-app2-changed-modules.sh"
-      - "scripts/check-app2-lane-execution.py"
-      - "scripts/ci-app2-journey-suite.sh"
   pull_request:
-    paths:
-      - "app2/**"
-      - "shared/core-transport/**"
-      - "shared/core-portfwd/**"
-      - "shared/core-hostapi/**"
-      - "gradle/**"
-      - "settings.gradle.kts"
-      - "build.gradle.kts"
-      - "gradle.properties"
-      - "gradlew"
-      - "gradlew.bat"
-      - "tests/docker/**"
-      - ".github/workflows/app2.yml"
-      - "scripts/ci-app2-changed-modules.sh"
-      - "scripts/check-app2-lane-execution.py"
-      - "scripts/ci-app2-journey-suite.sh"
   workflow_dispatch:
   # NIGHTLY CADENCE (decision D37). D37 requires the fault/journey release gate
   # to run on a scheduled cadence with no off switch; it used to be satisfied by
@@ -92,9 +65,9 @@ on:
   # the `:app` module every one of its five Gradle invocations targeted. This
   # lane is that gate's successor, so it takes the cadence too — 02:17 UTC, the
   # slot the old nightly held, kept rather than moved so the off-hours window is
-  # unchanged. `schedule` runs no `paths:` filter, and the `changes` job's
-  # selector fail-opens on a non-push event (no diff base -> ALL lanes), so a
-  # scheduled run exercises the whole suite rather than whatever a diff picked.
+  # unchanged. The `changes` job's selector fail-opens on a non-push event (no
+  # diff base -> ALL lanes), so a scheduled/dispatched run exercises the whole
+  # suite rather than whatever a diff picked.
   schedule:
     - cron: "17 2 * * *"
 

--- a/scripts/check-nightly-workflow.sh
+++ b/scripts/check-nightly-workflow.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# check-nightly-workflow.sh — issue #2252, decision D37.
+# check-nightly-workflow.sh — issue #2252, decision D37 (extended by #2509).
 #
 # WHAT THIS GUARDS, AND WHY IT MOVED.
 #
@@ -27,12 +27,26 @@
 #   5. the journey job has no bypass knob — its `if:` reads no `inputs.`, so no
 #      workflow_dispatch input can turn the gate off;
 #   6. a SCHEDULED run actually reaches the job — its `if:` excludes only
-#      pull_request, never schedule;
+#      pull_request, never schedule or workflow_dispatch;
 #   7. a scheduled run is not cancellable by an unrelated push — `schedule` gets
 #      its own concurrency group and is exempt from cancel-in-progress. Without
 #      this a push could kill the nightly mid-flight and the cadence would read
 #      as `cancelled`, not `failure`: a bypass by accident, which is precisely
 #      the D37 shape.
+#   8. on.push / on.pull_request do NOT carry paths: / paths-ignore. GitHub's
+#      workflow-level path filter is the #2354 required-check footgun AND has
+#      been observed to suppress this workflow's schedule: cadence entirely
+#      (issue #2509: gh run list --workflow app2.yml --event schedule was empty
+#      while tests.yml's schedule the same morning fired). Per-job selection
+#      stays in the `changes` job, which already fail-opens on empty/unknown
+#      base (what schedule/dispatch pass).
+#   9. a schedule/workflow_dispatch run fail-opens every lane: `changes` always
+#      runs, its --base expression yields empty on non-push/non-PR, and no
+#      fail-open lane's if: skips schedule or workflow_dispatch.
+#  10. binding-mutations still runs on schedule OR workflow_dispatch (and on
+#      workflow_call if that trigger is introduced).
+#  11. scripts/check-nightly-fault-run.sh still identifies this workflow's
+#      journey job (default --workflow app2.yml, --job-needle matching .name).
 #
 # Usage:
 #   scripts/check-nightly-workflow.sh              # check the real workflow
@@ -42,6 +56,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEFAULT_WORKFLOW="$ROOT_DIR/.github/workflows/app2.yml"
+FAULT_RUN_CONSUMER="$ROOT_DIR/scripts/check-nightly-fault-run.sh"
 JOURNEY_JOB="app2-journey"
 JOURNEY_JOB_NAME_NEEDLE="app2 journey suite"
 JOURNEY_CRON="17 2 * * *"
@@ -81,6 +96,24 @@ unless schedule.is_a?(Array) && schedule.any? { |e| e.is_a?(Hash) && e["cron"] =
   abort "FAIL: the #{cron} scheduled trigger is missing — D37 requires this lane to run on a cadence, not only on push"
 end
 
+# 8. workflow-level path filters suppress the D37 cadence (#2509) and are the
+# #2354 required-check footgun. Per-job selection already lives in `changes`.
+%w[push pull_request].each do |event_name|
+  spec = events[event_name]
+  next unless spec.is_a?(Hash)
+  filter = if spec.key?("paths")
+             "paths"
+           elsif spec.key?("paths-ignore")
+             "paths-ignore"
+           end
+  next unless filter
+  abort "FAIL: on.#{event_name} carries a #{filter}: filter — GitHub's workflow-level path filter is the #2354 required-check footgun and has been observed to suppress this workflow's schedule: cadence (issue #2509). Per-job selection belongs in the changes job, which already fail-opens on empty/unknown base"
+end
+
+unless events.key?("workflow_dispatch")
+  abort "FAIL: workflow_dispatch trigger is missing — D37's cadence must be runnable on demand as well as on schedule"
+end
+
 jobs = document["jobs"]
 abort "FAIL: jobs must be a non-empty mapping" unless jobs.is_a?(Hash) && !jobs.empty?
 
@@ -103,9 +136,17 @@ if journey_if.include?("inputs.")
   abort "FAIL: #{job_key}'s if: reads a workflow input (#{journey_if}) — D37 forbids an off switch for this gate"
 end
 
-# 6. a scheduled run must reach the job.
+# 6. a scheduled / dispatched run must reach the job. The if: excludes only
+# pull_request; naming schedule or workflow_dispatch is how the cadence skips
+# its own job.
+unless journey_if.include?("github.event_name != 'pull_request'")
+  abort "FAIL: #{job_key}'s if: must exclude only pull_request (got #{journey_if}) — schedule and workflow_dispatch must reach this job"
+end
 if journey_if.include?("schedule")
   abort "FAIL: #{job_key}'s if: mentions the schedule event (#{journey_if}) — the cadence must not be able to skip its own job"
+end
+if journey_if.include?("workflow_dispatch")
+  abort "FAIL: #{job_key}'s if: mentions workflow_dispatch (#{journey_if}) — an on-demand cadence run must not be able to skip its own job"
 end
 
 # 7. a scheduled run must not be cancellable by an unrelated push.
@@ -120,8 +161,73 @@ unless cancel.include?("schedule")
   abort "FAIL: cancel-in-progress does not exempt schedule (#{cancel}) — see the group check above"
 end
 
-puts "PASS: #{path} is valid YAML, carries the #{cron} cadence, and its #{job_key} job is fail-closed, bypass-free, schedule-reachable and cancellation-safe"
+# 9. a schedule/dispatch run fail-opens every lane.
+changes = jobs["changes"]
+abort "FAIL: the changes job is missing — schedule/dispatch fail-open every lane through it" unless changes.is_a?(Hash)
+if changes.key?("if") && !changes["if"].to_s.strip.empty?
+  abort "FAIL: the changes job has an if: (#{changes["if"]}) — it must always run so a cadence can fail-open"
+end
+
+steps = changes["steps"]
+abort "FAIL: the changes job has no steps" unless steps.is_a?(Array)
+select = steps.find { |s| s.is_a?(Hash) && s["run"].to_s.include?("ci-app2-changed-modules.sh") && s["run"].to_s.include?("--base") }
+abort "FAIL: the changes job does not invoke ci-app2-changed-modules.sh --base" unless select
+select_run = select["run"].to_s
+unless select_run.include?("github.event_name == 'pull_request'") &&
+       select_run.include?("github.event_name == 'push'") &&
+       select_run.match?(/\|\|\s*(''|\"\")/)
+  abort "FAIL: the changes job's --base expression does not fail-open on schedule/dispatch (empty-string fallback) — a cadence run would under-select and skip app2-journey"
+end
+
+fail_open_jobs = %w[
+  hostapi-test
+  transport-test
+  transport-integration
+  portfwd-test
+  portfwd-integration
+  app2-unit
+]
+fail_open_jobs.each do |key|
+  job = jobs[key]
+  abort "FAIL: fail-open lane #{key} is missing — a cadence run must execute the unit/integration lanes, not only the journey" unless job.is_a?(Hash)
+  job_if = job["if"].to_s
+  if job_if.include?("schedule") || job_if.include?("workflow_dispatch")
+    abort "FAIL: #{key}'s if: mentions schedule/workflow_dispatch (#{job_if}) — a cadence run must fail-open this lane, not skip it"
+  end
+end
+
+# 10. binding-mutations still runs on schedule OR dispatch.
+binding = jobs["binding-mutations"]
+abort "FAIL: the binding-mutations job is missing" unless binding.is_a?(Hash)
+binding_if = binding["if"].to_s
+unless binding_if.include?("github.event_name == 'schedule'") &&
+       binding_if.include?("github.event_name == 'workflow_dispatch'")
+  abort "FAIL: binding-mutations must run on schedule OR workflow_dispatch (got #{binding_if})"
+end
+if events.key?("workflow_call") && !binding_if.include?("github.event_name == 'workflow_call'")
+  abort "FAIL: binding-mutations must also run on workflow_call when that trigger exists (got #{binding_if})"
+end
+
+puts "PASS: #{path} is valid YAML, carries the #{cron} cadence, has no workflow-level paths filter, fail-opens every lane on schedule/dispatch, and its #{job_key} job is fail-closed, bypass-free, schedule-reachable and cancellation-safe"
 RUBY
+}
+
+# 11. the verdict consumer still looks at this workflow's journey job.
+check_fault_run_consumer() {
+  local fault="${1:-$FAULT_RUN_CONSUMER}"
+  if [[ ! -f "$fault" ]]; then
+    printf 'FAIL: %s is missing — D37'\''s verdict consumer\n' "$fault" >&2
+    return 1
+  fi
+  if ! grep -qE '^WORKFLOW="app2.yml"$' "$fault"; then
+    printf 'FAIL: %s WORKFLOW default is not app2.yml — the verdict consumer would look at the wrong cadence file\n' "$fault" >&2
+    return 1
+  fi
+  if ! grep -qE '^JOB_NEEDLE="app2 journey suite"$' "$fault"; then
+    printf 'FAIL: %s JOB_NEEDLE default is not '\''app2 journey suite'\'' — the verdict consumer would miss the journey job\n' "$fault" >&2
+    return 1
+  fi
+  return 0
 }
 
 self_test() {
@@ -136,9 +242,24 @@ self_test() {
   check_workflow "$valid" >/dev/null || fail "self-test control: the real workflow does not pass its own guard"
   echo "  ok: the shipped workflow is the green control"
 
+  check_fault_run_consumer >/dev/null || fail "self-test control: the real fault-run consumer does not match the cadence workflow"
+  echo "  ok: the shipped fault-run consumer points at this cadence"
+
   # Each mutation removes exactly one pinned property and must be named.
   expect_red() {  # $1 = label, $2 = mutant file, $3 = expected substring
     if check_workflow "$2" >"$temp_dir/out" 2>&1; then
+      cat "$temp_dir/out" >&2
+      fail "$1: mutant was accepted"
+    fi
+    grep -qF "$3" "$temp_dir/out" || {
+      cat "$temp_dir/out" >&2
+      fail "$1: reddened for the wrong reason (wanted: $3)"
+    }
+    echo "  ok: $1"
+  }
+
+  expect_consumer_red() {  # $1 = label, $2 = mutant file, $3 = expected substring
+    if check_fault_run_consumer "$2" >"$temp_dir/out" 2>&1; then
       cat "$temp_dir/out" >&2
       fail "$1: mutant was accepted"
     fi
@@ -177,11 +298,68 @@ self_test() {
   sed -i "s|^  group: .*$|  group: \${{ github.workflow }}-\${{ github.ref }}|" "$m"
   expect_red "a shared concurrency group is rejected" "$m" "does not special-case schedule"
 
+  # Issue #2509: a workflow-level paths: filter is the hole that let the
+  # schedule never fire while this guard stayed green. Re-adding it must fail.
+  m="$temp_dir/pushpaths.yml"; cp "$valid" "$m"
+  sed -i '/^  push:$/a\    paths: [app2/**]' "$m"
+  expect_red "on.push.paths is rejected" "$m" "on.push carries a paths: filter"
+
+  m="$temp_dir/prpaths.yml"; cp "$valid" "$m"
+  sed -i '/^  pull_request:$/a\    paths: [app2/**]' "$m"
+  expect_red "on.pull_request.paths is rejected" "$m" "on.pull_request carries a paths: filter"
+
+  m="$temp_dir/pushignore.yml"; cp "$valid" "$m"
+  sed -i '/^  push:$/a\    paths-ignore: ["**/*.md"]' "$m"
+  expect_red "on.push.paths-ignore is rejected" "$m" "on.push carries a paths-ignore: filter"
+
+  m="$temp_dir/nodispatch.yml"; cp "$valid" "$m"
+  sed -i '/^  workflow_dispatch:$/d' "$m"
+  expect_red "a missing workflow_dispatch trigger is rejected" "$m" "workflow_dispatch trigger is missing"
+
+  m="$temp_dir/skipsched.yml"; cp "$valid" "$m"
+  sed -i "s|github.event_name != 'pull_request'|github.event_name != 'pull_request' \&\& github.event_name != 'schedule'|" "$m"
+  expect_red "a journey if: that skips schedule is rejected" "$m" "mentions the schedule event"
+
+  m="$temp_dir/skipdispatch.yml"; cp "$valid" "$m"
+  sed -i "s|github.event_name != 'pull_request'|github.event_name != 'pull_request' \&\& github.event_name != 'workflow_dispatch'|" "$m"
+  expect_red "a journey if: that skips workflow_dispatch is rejected" "$m" "mentions workflow_dispatch"
+
+  m="$temp_dir/changesif.yml"; cp "$valid" "$m"
+  sed -i "/^  changes:/a\\    if: \${{ github.event_name == 'push' }}" "$m"
+  expect_red "a changes job that can skip the cadence is rejected" "$m" "the changes job has an if:"
+
+  m="$temp_dir/base.yml"; cp "$valid" "$m"
+  sed -i "s/|| ''/|| github.sha/" "$m"
+  expect_red "a --base that does not fail-open on schedule is rejected" "$m" "does not fail-open on schedule/dispatch"
+
+  m="$temp_dir/hostapiskip.yml"; cp "$valid" "$m"
+  sed -i "s|needs.changes.outputs.hostapi == 'true'|github.event_name != 'schedule' \&\& needs.changes.outputs.hostapi == 'true'|" "$m"
+  expect_red "a fail-open unit lane that skips schedule is rejected" "$m" "hostapi-test's if: mentions schedule/workflow_dispatch"
+
+  m="$temp_dir/bindnosched.yml"; cp "$valid" "$m"
+  sed -i "s#github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'#github.event_name == 'workflow_dispatch'#" "$m"
+  expect_red "binding-mutations that skip schedule is rejected" "$m" "binding-mutations must run on schedule OR workflow_dispatch"
+
+  m="$temp_dir/bindnodisp.yml"; cp "$valid" "$m"
+  sed -i "s#github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'#github.event_name == 'schedule'#" "$m"
+  expect_red "binding-mutations that skip dispatch is rejected" "$m" "binding-mutations must run on schedule OR workflow_dispatch"
+
+  m="$temp_dir/fault-workflow.sh"; cp "$FAULT_RUN_CONSUMER" "$m"
+  sed -i 's/^WORKFLOW="app2.yml"/WORKFLOW="tests.yml"/' "$m"
+  expect_consumer_red "a fault-run consumer pointed at the wrong workflow is rejected" "$m" "wrong cadence file"
+
+  m="$temp_dir/fault-needle.sh"; cp "$FAULT_RUN_CONSUMER" "$m"
+  sed -i 's/^JOB_NEEDLE="app2 journey suite"/JOB_NEEDLE="something else"/' "$m"
+  expect_consumer_red "a fault-run consumer with the wrong job needle is rejected" "$m" "would miss the journey job"
+
   echo "PASS: check-nightly-workflow self-test."
 }
 
 case "${1:-}" in
   --self-test) self_test ;;
-  "") check_workflow "$DEFAULT_WORKFLOW" ;;
+  "")
+    check_workflow "$DEFAULT_WORKFLOW"
+    check_fault_run_consumer || exit 1
+    ;;
   *) echo "unknown argument: $1" >&2; echo "usage: $0 [--self-test]" >&2; exit 1 ;;
 esac

--- a/scripts/ci-app2-changed-modules.sh
+++ b/scripts/ci-app2-changed-modules.sh
@@ -4,10 +4,12 @@
 # Per-JOB path filtering for .github/workflows/app2.yml.
 #
 # GitHub's `on.<event>.paths:` filter is WORKFLOW-level: it decides whether the
-# whole run happens, not which jobs inside it do. app2.yml wants the finer
-# grain ("only the touched module's lane runs"), so this script computes one
-# boolean per new module from the push/PR diff and writes them to
-# $GITHUB_OUTPUT for the downstream jobs' `if:` guards.
+# whole run happens, not which jobs inside it do. app2.yml used to carry that
+# filter; issue #2509 removed it because it is the #2354 required-check footgun
+# and empirically suppressed the D37 `schedule:` cadence. Per-job selection
+# stays here: this script computes one boolean per new module from the push/PR
+# diff and writes them to $GITHUB_OUTPUT for the downstream jobs' `if:` guards.
+# A schedule/dispatch run passes an empty --base and fail-opens every lane.
 #
 # Deliberately a script, not an inline `run:` block or a third-party
 # paths-filter action:
@@ -67,10 +69,9 @@ declare -a SHARED_PREFIXES=(
   "scripts/ci-app2-changed-modules.sh"
   "scripts/check-app2-lane-execution.py"
   # Issue #2474: the app2-journey lane's runner. It is app2-only in effect, but
-  # listing it here rather than under the app2 module keeps this list identical
-  # to app2.yml's trigger-level `paths:` union — the two must not drift, or a
-  # change to the runner triggers the workflow while every lane inside it
-  # deselects itself.
+  # listing it here rather than under the app2 module means a runner change
+  # fail-opens every lane instead of starting a run whose every job deselects
+  # itself (the runner path is not under app2/).
   "scripts/ci-app2-journey-suite.sh"
 )
 
@@ -229,10 +230,9 @@ self_test() {
   commit_file ".github/workflows/app2.yml"
   check "the workflow itself (shared)" true true true true
 
-  # Issue #2474: the journey lane's runner. app2.yml's trigger-level `paths:`
-  # starts a run when it changes, so this list must select a lane for it — an
-  # entry present in one place and missing in the other yields a run whose every
-  # job deselects itself.
+  # Issue #2474: the journey lane's runner. A change to it always starts a run
+  # (no trigger-level `paths:` — issue #2509); this list must still select lanes
+  # so the run is not an empty skip-fest.
   git -C "$tmp" reset -q --hard "$base"
   commit_file "scripts/ci-app2-journey-suite.sh"
   check "the journey runner (shared)" true true true true


### PR DESCRIPTION
## Summary
D37's app2.yml `schedule:` never produced a GitHub run. Workflow-level `on.push.paths` / `on.pull_request.paths` are removed; per-job selection in `scripts/ci-app2-changed-modules.sh` still fail-opens on empty/unknown base. `scripts/check-nightly-workflow.sh` now fails if those filters (or a schedule-skipping journey `if:`) return.

Reviewer: APPROVED https://github.com/alexeygrigorev/pocketshell/issues/2509#issuecomment-5549963386

Closes #2509

## Test plan
- [x] `scripts/check-nightly-workflow.sh --self-test` and live
- [x] `scripts/ci-app2-changed-modules.sh --self-test`
- [x] `scripts/check-nightly-fault-run.sh --self-test` (still `app2.yml` / `app2 journey suite`)
- [x] `scripts/check-release-gate-bypass-absent.sh` self-test + live