### PR TITLE
fix: wire a session-tree Ports action to Destination.Ports

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/ports/J13PortForwardOpenJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/ports/J13PortForwardOpenJourney.kt
@@ -1,0 +1,154 @@
+package com.pocketshell.next.ports
+
+import android.os.SystemClock
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.next.MainActivity
+import com.pocketshell.next.connect.AgentsFixture
+import com.pocketshell.next.connect.JourneyScreenshots
+import com.pocketshell.next.connect.SeedBeforeLaunchRule
+import com.pocketshell.next.connect.appGraph
+import com.pocketshell.next.connect.awaitIdle
+import com.pocketshell.next.hosts.hostRowTag
+import com.pocketshell.next.tree.SESSION_TREE_PORTS_TAG
+import com.pocketshell.next.tree.SESSION_TREE_TAG
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+
+/**
+ * Journey J13 — open the port-forward panel from the session-tree header
+ * (rewrite task P-4 / issue #2505).
+ *
+ * ## Why this has to be a device journey
+ *
+ * `AppNavHostTest` already proves `Destination.Ports.route` resolves when a
+ * test navigates programmatically. That is not the missing coverage: until this
+ * journey, nothing in the shipping UI called `navController.navigate` for
+ * Ports, so a user could not reach the fully-built `PortForwardScreen` at all.
+ * A Robolectric screen test can prove the header action fires a callback; only
+ * this connected path proves the tap actually lands on the production screen
+ * inside the real Hilt graph against a real sshd.
+ *
+ * ## Fixture
+ *
+ * The Docker `agents` fixture on `10.0.2.2:2222` (see [AgentsFixture]). Bring
+ * it up before running:
+ * `docker compose -f tests/docker/docker-compose.yml up -d --build agents`
+ *
+ * The host row is seeded with the fingerprint the fixture actually presents
+ * (read live in [seed]), so the dial connects without a prompt — the trust
+ * sheet is `J01ConnectAndTrustJourney`'s subject.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class J13PortForwardOpenJourney {
+
+    private val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val chain: RuleChain = RuleChain
+        .outerRule(HiltAndroidRule(this))
+        .around(SeedBeforeLaunchRule { description -> seed(description) })
+        .around(compose)
+
+    private var hostId: Long = 0
+
+    private suspend fun seed(description: Description) {
+        val graph = appGraph()
+        graph.connectionsRegistry().closeAll()
+        graph.hostDao().getAll().first().forEach { graph.hostDao().deleteById(it.id) }
+        graph.sshKeyDao().getAll().first().forEach { graph.sshKeyDao().deleteById(it.id) }
+
+        val fingerprint = AgentsFixture.probeHostKeyFingerprint()
+        println("J13_FIXTURE ${AgentsFixture.host}:${AgentsFixture.port} $fingerprint")
+
+        val keyPath = AgentsFixture.installPrivateKey(fileName = "j13_fixture_key")
+        val keyId = graph.sshKeyDao().insert(
+            SshKeyEntity(name = "j13-${description.methodName}", privateKeyPath = keyPath),
+        )
+        hostId = HOST_ID
+        graph.hostDao().insert(
+            HostEntity(
+                id = hostId,
+                name = "docker-fixture",
+                hostname = AgentsFixture.host,
+                port = AgentsFixture.port,
+                username = AgentsFixture.USER,
+                keyId = keyId,
+                trustedHostKeyAlgorithm = "SHA256",
+                trustedHostKeySha256 = fingerprint,
+            ),
+        )
+    }
+
+    /**
+     * Tapping Ports on the session tree opens the production port-forward
+     * screen (task P-4 accept: a real navigation path exists and is exercised).
+     */
+    @Test
+    fun tappingPortsOnTheSessionTreeOpensThePortForwardScreen() {
+        awaitTag(hostRowTag(hostId), "the seeded host row")
+        compose.onNodeWithTag(hostRowTag(hostId)).performClick()
+        awaitTag(SESSION_TREE_TAG, "the session tree")
+        JourneyScreenshots.capture("01-tree", JOURNEY)
+
+        awaitTag(SESSION_TREE_PORTS_TAG, "the Ports header action")
+        compose.onNodeWithTag(SESSION_TREE_PORTS_TAG).performClick()
+
+        awaitTag(FORWARDING_TOGGLE_TAG, "the port-forward Off/On toggle")
+        compose.onNodeWithTag(FORWARDING_TOGGLE_TAG).assertIsDisplayed()
+        awaitText("Forwarding is off. Turn it on to discover listening ports.")
+        compose.onNodeWithText("Forwarding is off. Turn it on to discover listening ports.")
+            .assertIsDisplayed()
+        JourneyScreenshots.capture("02-ports", JOURNEY)
+    }
+
+    private fun awaitTag(tag: String, what: String = tag) {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            compose.awaitIdle("tag poll: $what")
+            if (compose.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty()) return
+            SystemClock.sleep(POLL_MS)
+        }
+        val shot = JourneyScreenshots.capture("failure-${what.replace(' ', '-')}", JOURNEY)
+        throw AssertionError(
+            "$what never appeared within ${TIMEOUT_MS}ms.\n" +
+                "Screenshot: ${shot.absolutePath}",
+        )
+    }
+
+    private fun awaitText(text: String) {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            compose.awaitIdle("text poll: $text")
+            if (compose.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()) return
+            SystemClock.sleep(POLL_MS)
+        }
+        val shot = JourneyScreenshots.capture("failure-text", JOURNEY)
+        throw AssertionError(
+            "text '$text' never appeared within ${TIMEOUT_MS}ms.\n" +
+                "Screenshot: ${shot.absolutePath}",
+        )
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 60_000L
+        const val POLL_MS = 250L
+        const val JOURNEY = "j13-port-forward-open"
+        const val HOST_ID = 9_901L
+    }
+}

--- a/app2/src/main/java/com/pocketshell/next/MainActivity.kt
+++ b/app2/src/main/java/com/pocketshell/next/MainActivity.kt
@@ -159,8 +159,13 @@ fun AppNavHost(
         hostId: Long,
         onOpenSession: (String) -> Unit,
         onOpenFiles: () -> Unit,
-    ) -> Unit = { _, onOpenSession, onOpenFiles ->
-        SessionTreeRoute(onOpenSession = onOpenSession, onOpenFiles = onOpenFiles)
+        onOpenPorts: () -> Unit,
+    ) -> Unit = { _, onOpenSession, onOpenFiles, onOpenPorts ->
+        SessionTreeRoute(
+            onOpenSession = onOpenSession,
+            onOpenFiles = onOpenFiles,
+            onOpenPorts = onOpenPorts,
+        )
     },
     sessionScreen: @Composable (
         hostId: Long,
@@ -305,6 +310,9 @@ fun AppNavHost(
                 // The plan's terminal kebab will later navigate to this same
                 // route WITH the session's workspace path.
                 { navController.navigate(Destination.Files.route(hostId)) },
+                // Task P-4: the host's port-forward panel. Same host-scoped
+                // rationale as Files — forwarding is not a per-session action.
+                { navController.navigate(Destination.Ports.route(hostId)) },
             )
         }
         composable(

--- a/app2/src/main/java/com/pocketshell/next/tree/SessionTreeScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/SessionTreeScreen.kt
@@ -63,6 +63,9 @@ const val SESSION_TREE_CREATE_LABEL: String = "New session"
 /** The header action that opens this host's file explorer (task P-3a). */
 const val SESSION_TREE_FILES_TAG: String = "session-tree-files"
 
+/** The header action that opens this host's port-forward panel (task P-4). */
+const val SESSION_TREE_PORTS_TAG: String = "session-tree-ports"
+
 fun sessionRowTag(name: String): String = "session-row-$name"
 
 fun workspaceHeaderTag(label: String): String = "workspace-header-$label"
@@ -81,6 +84,7 @@ fun workspaceHeaderTag(label: String): String = "workspace-header-$label"
 fun SessionTreeRoute(
     onOpenSession: (String) -> Unit,
     onOpenFiles: () -> Unit,
+    onOpenPorts: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SessionTreeViewModel = hiltViewModel(),
 ) {
@@ -107,6 +111,7 @@ fun SessionTreeRoute(
         onSubmitCreate = viewModel::createSession,
         onDismissCreate = viewModel::dismissCreateSheet,
         onOpenFiles = onOpenFiles,
+        onOpenPorts = onOpenPorts,
         modifier = modifier,
     )
 }
@@ -146,6 +151,7 @@ fun SessionTreeScreen(
     onRefresh: () -> Unit,
     onOpenSession: (String) -> Unit,
     onOpenFiles: () -> Unit = {},
+    onOpenPorts: () -> Unit = {},
     modifier: Modifier = Modifier,
     onCreateSession: () -> Unit = {},
     onSubmitCreate: (name: String, cwd: String?) -> Unit = { _, _ -> },
@@ -158,6 +164,7 @@ fun SessionTreeScreen(
             onRefresh = onRefresh,
             onOpenSession = onOpenSession,
             onOpenFiles = onOpenFiles,
+            onOpenPorts = onOpenPorts,
             nowSec = nowSec,
         )
 
@@ -200,6 +207,7 @@ private fun SessionTreeBody(
     onRefresh: () -> Unit,
     onOpenSession: (String) -> Unit,
     onOpenFiles: () -> Unit,
+    onOpenPorts: () -> Unit,
     nowSec: Long,
 ) {
     Column(
@@ -210,11 +218,9 @@ private fun SessionTreeBody(
         ScreenHeader(
             title = "Sessions",
             subtitle = headerSubtitle(state),
-            // Task P-3a: the host's file browser. It lives in the header rather
-            // than behind a menu because this is the app's ONLY way to reach the
-            // explorer until U-4's terminal chrome lands, and browsing a host's
-            // files is a first-class job the maintainer does regularly — not a
-            // secondary action to bury.
+            // Tasks P-3a / P-4: Files and Ports are host-scoped, so they live
+            // in this header rather than behind a menu. ScreenHeader.trailing
+            // already lays its children out as a compact row.
             trailing = {
                 PocketShellButton(
                     text = "Files",
@@ -222,6 +228,13 @@ private fun SessionTreeBody(
                     variant = ButtonVariant.Text,
                     compact = true,
                     modifier = Modifier.testTag(SESSION_TREE_FILES_TAG),
+                )
+                PocketShellButton(
+                    text = "Ports",
+                    onClick = onOpenPorts,
+                    variant = ButtonVariant.Text,
+                    compact = true,
+                    modifier = Modifier.testTag(SESSION_TREE_PORTS_TAG),
                 )
             },
         )

--- a/app2/src/test/java/com/pocketshell/next/AppNavHostTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/AppNavHostTest.kt
@@ -151,7 +151,7 @@ class AppNavHostTest {
                 // resolves its ViewModel through `hiltViewModel()`. The
                 // stand-in echoes the argument the route actually delivered, so
                 // this suite still pins the Tree pattern's Long argument.
-                treeScreen = { hostId, _, _ -> Text("Tree(hostId=$hostId)") },
+                treeScreen = { hostId, _, _, _ -> Text("Tree(hostId=$hostId)") },
                 // Same rationale again for U-4's terminal: the real screen
                 // resolves `SessionViewModel` through `hiltViewModel()` AND
                 // dials a host. The stand-in echoes both route arguments, which

--- a/app2/src/test/java/com/pocketshell/next/connect/ConnectGateNavigationTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/connect/ConnectGateNavigationTest.kt
@@ -165,7 +165,7 @@ class ConnectGateNavigationTest {
                 // through `hiltViewModel()`. This suite is about the connect
                 // gate's navigation edge, so the destination is a stand-in that
                 // echoes the argument the route delivered.
-                treeScreen = { hostId, _, _ -> Text("Tree(hostId=$hostId)") },
+                treeScreen = { hostId, _, _, _ -> Text("Tree(hostId=$hostId)") },
             )
         }
         composeRule.waitForIdle()

--- a/app2/src/test/java/com/pocketshell/next/hosts/AddEditHostNavigationTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/hosts/AddEditHostNavigationTest.kt
@@ -234,7 +234,7 @@ class AddEditHostNavigationTest {
                     )
                 },
                 connectViewModel = { stack.viewModel },
-                treeScreen = { hostId, _, _ -> Text("Tree(hostId=$hostId)") },
+                treeScreen = { hostId, _, _, _ -> Text("Tree(hostId=$hostId)") },
                 hostFormScreen = { hostId, onDone, onAddKey ->
                     AddEditHostRoute(hostId = hostId, onDone = onDone, onAddKey = onAddKey, viewModel = formViewModel)
                 },

--- a/app2/src/test/java/com/pocketshell/next/hosts/HostListNavigationTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/hosts/HostListNavigationTest.kt
@@ -170,7 +170,7 @@ class HostListNavigationTest {
                 // provide. This suite is about the host-tap → Tree(hostId)
                 // edge, so the destination is a stand-in echoing the delivered
                 // argument.
-                treeScreen = { hostId, _, _ -> Text("Tree(hostId=$hostId)") },
+                treeScreen = { hostId, _, _, _ -> Text("Tree(hostId=$hostId)") },
             )
         }
         composeRule.waitForIdle()

--- a/app2/src/test/java/com/pocketshell/next/settings/SettingsNavigationTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/settings/SettingsNavigationTest.kt
@@ -202,7 +202,7 @@ class SettingsNavigationTest {
                 navController = controller,
                 hostsScreen = { Text("Hosts") },
                 connectViewModel = { stack.viewModel },
-                treeScreen = { hostId, _, _ -> Text("Tree(hostId=$hostId)") },
+                treeScreen = { hostId, _, _, _ -> Text("Tree(hostId=$hostId)") },
                 settingsScreen = { onBack, onOpenWorkspaceRoots, onOpenCrashReports ->
                     SettingsRoute(
                         onBack = onBack,

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeRouteTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeRouteTest.kt
@@ -80,6 +80,7 @@ class SessionTreeRouteTest {
                 SessionTreeRoute(
                     onOpenSession = { opened += it },
                     onOpenFiles = {},
+                    onOpenPorts = {},
                     viewModel = viewModel,
                 )
             }

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeScreenTest.kt
@@ -184,6 +184,29 @@ class SessionTreeScreenTest {
         composeRule.onNodeWithTag(SESSION_TREE_ERROR_BANNER_TAG).assertDoesNotExist()
     }
 
+    /**
+     * Issue #2505: Destination.Ports is registered but nothing in the shipping
+     * UI navigates to it. The header action next to Files is the caller; this
+     * test is RED until that action exists and fires `onOpenPorts`.
+     */
+    @Test
+    fun `tapping Ports in the header opens port forwarding`() {
+        var files = 0
+        var ports = 0
+        setContent(
+            state(loaded = true, sessions = listOf(row("claude-main", "/w", activity = NOW))),
+            onOpenFiles = { files += 1 },
+            onOpenPorts = { ports += 1 },
+        )
+
+        composeRule.onNodeWithTag(SESSION_TREE_FILES_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_TREE_PORTS_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_TREE_PORTS_TAG).performClick()
+
+        assertEquals(1, ports)
+        assertEquals("Files must stay independent of Ports", 0, files)
+    }
+
     @Test
     fun `tapping a row opens that session by its own name`() {
         val opened = mutableListOf<String>()
@@ -269,6 +292,8 @@ class SessionTreeScreenTest {
         onRefresh: () -> Unit = {},
         onOpenSession: (String) -> Unit = {},
         onCreateSession: () -> Unit = {},
+        onOpenFiles: () -> Unit = {},
+        onOpenPorts: () -> Unit = {},
     ) {
         composeRule.setContent {
             PocketShellTheme {
@@ -277,6 +302,8 @@ class SessionTreeScreenTest {
                     onRefresh = onRefresh,
                     onOpenSession = onOpenSession,
                     onCreateSession = onCreateSession,
+                    onOpenFiles = onOpenFiles,
+                    onOpenPorts = onOpenPorts,
                     nowSec = NOW,
                 )
             }


### PR DESCRIPTION
## Summary
Port forwarding (P-4) was implemented and registered at `Destination.Ports` with no navigation caller. The session-tree header now has **Ports** next to **Files**, wired to `navController.navigate(Destination.Ports.route(hostId))`. `J13PortForwardOpenJourney` drives the real `PortForwardScreen` on the emulator.

Reviewer: APPROVED https://github.com/alexeygrigorev/pocketshell/issues/2505#issuecomment-5549983201

Closes #2505

## Test plan
- [x] Robolectric `SessionTreeScreenTest` tapping Ports — red without the action, green with it
- [x] `scripts/assemble-debug.sh`
- [x] `scripts/check-test-validity.sh`
- [x] `scripts/connected-test.sh --suffix i2505rev` `J13PortForwardOpenJourney` — Off/On toggle + “Forwarding is off…”