### PR TITLE
fix: wire Settings terminal text size into TerminalHostView

### DIFF
--- a/app2/src/main/java/com/pocketshell/next/terminal/TerminalGeometry.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/TerminalGeometry.kt
@@ -5,6 +5,7 @@ import android.graphics.Typeface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import com.pocketshell.next.settings.LocalAppSettings
 import kotlin.math.ceil
 
 /**
@@ -59,11 +60,26 @@ import kotlin.math.ceil
  *   reserves above the first row's baseline. Subtracted from the viewport
  *   height before dividing, so a viewport exactly N rows tall reports N rows
  *   rather than N + a sliver.
+ * @param textSizePx raw-pixel text size these metrics were measured at. Kept
+ *   so a host-JVM test can tell a 40 px measurement from a 28 px one even
+ *   when Robolectric's `Paint` reports the same 1 px glyph for both.
  */
 data class TerminalCellMetrics(
     val cellWidthPx: Float,
     val lineHeightPx: Int,
     val lineSpacingAndAscentPx: Int,
+    /**
+     * Raw-pixel text size these metrics were measured at.
+     *
+     * Recorded (not re-derived from [cellWidthPx]) because Robolectric's
+     * `Paint` reports a 1 px glyph at every size, so the only way a host-JVM
+     * test can tell a 40 px measurement from a 28 px one is to keep the input.
+     * Production still measures at this size; the field is how the wiring test
+     * proves [rememberTerminalCellMetrics] used the Settings value and not the
+     * [TERMINAL_TEXT_SIZE_RAW_PX] literal. Defaults to the shipped size so
+     * fixtures that stand in for "28 px on a device" stay as they were.
+     */
+    val textSizePx: Int = TERMINAL_TEXT_SIZE_RAW_PX,
 )
 
 /** A terminal size in character cells. */
@@ -109,21 +125,27 @@ fun terminalCells(
 
 /**
  * The metrics of the face the terminal actually renders with, measured once
- * per context.
+ * per context and text size.
  *
  * A `@Composable` rather than a plain function so the session screen can take
  * it as a defaulted parameter — the same seam shape `AppNavHost` uses for its
  * screens. That matters for more than tidiness: Robolectric's `Paint` reports
  * a 1 px glyph with zero ascent and descent, so a host-JVM test that could not
  * substitute real metrics could never see the size-reporting path run at all.
+ *
+ * The size is [LocalAppSettings]'s `terminalTextSizePx`, not the
+ * [TERMINAL_TEXT_SIZE_RAW_PX] literal: that constant is only the fresh-install
+ * default, and measuring at a different size than [TerminalHostView] paints
+ * would make the geometry estimate disagree with the glyphs (issue #2512).
  */
 @Composable
 fun rememberTerminalCellMetrics(): TerminalCellMetrics {
     val context = LocalContext.current
-    return remember(context) {
+    val textSizePx = LocalAppSettings.current.terminalTextSizePx
+    return remember(context, textSizePx) {
         measureTerminalCellMetrics(
             typeface = terminalTypeface(context),
-            textSizePx = TERMINAL_TEXT_SIZE_RAW_PX,
+            textSizePx = textSizePx,
         )
     }
 }
@@ -152,6 +174,7 @@ fun measureTerminalCellMetrics(typeface: Typeface, textSizePx: Int): TerminalCel
         cellWidthPx = paint.measureText("X"),
         lineHeightPx = lineHeight,
         lineSpacingAndAscentPx = lineHeight + ascent,
+        textSizePx = textSizePx,
     )
 }
 

--- a/app2/src/main/java/com/pocketshell/next/terminal/TerminalHostView.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/TerminalHostView.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.viewinterop.AndroidView
+import com.pocketshell.next.settings.LocalAppSettings
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.termux.terminal.TerminalSession
 import com.termux.terminal.TerminalSessionClient
@@ -21,7 +22,7 @@ import com.termux.view.TerminalViewClient
 const val SESSION_TERMINAL_TAG: String = "session-terminal"
 
 /**
- * Terminal glyph size in RAW DEVICE PIXELS.
+ * Default terminal glyph size in RAW DEVICE PIXELS.
  *
  * Upstream's `setTextSize` javadoc says "density-independent pixels" and is
  * wrong about its own code: the value goes straight to `Paint.setTextSize`,
@@ -29,9 +30,12 @@ const val SESSION_TERMINAL_TAG: String = "session-terminal"
  * 28 is the size the pre-rewrite client shipped — big enough to read on a phone,
  * small enough to leave a usable column count at 1080 px wide.
  *
- * Internal rather than private because the session screen measures the SAME
- * face at the SAME size to estimate the terminal's geometry before a view
- * exists (task U-5, [measureTerminalCellMetrics]); a second literal would be a
+ * The live size is [com.pocketshell.next.settings.LocalAppSettings]'s
+ * `terminalTextSizePx`, whose fresh-install default equals this constant
+ * ([com.pocketshell.next.settings.AppSettings.DEFAULT_TERMINAL_TEXT_SIZE_PX]).
+ * [TerminalHostView] applies it on the vendored view and
+ * [rememberTerminalCellMetrics] measures the same face at that same size so
+ * the geometry estimate and the glyphs agree. A second literal would be a
  * second answer to "how big is a cell".
  */
 internal const val TERMINAL_TEXT_SIZE_RAW_PX: Int = 28
@@ -142,6 +146,14 @@ fun TerminalHostView(
         keyInput.onControlBytes = onControlBytes
     }
 
+    // Settings stepper (issue #2512). Read here so a change recomposes this
+    // host and `AndroidView`'s `update` can push it onto the already-built
+    // view. `setTextSize` rebuilds the renderer and fires `onEmulatorSet`, so
+    // calling it on every ctrlArmed recomposition would SIGWINCH the PTY —
+    // the applied-size box is what skips the no-op.
+    val textSizePx = LocalAppSettings.current.terminalTextSizePx
+    val appliedTextSizePx = remember { intArrayOf(-1) }
+
     DisposableEffect(session) {
         session.updateTerminalSessionClient(repaintClient)
         onDispose {
@@ -178,7 +190,8 @@ fun TerminalHostView(
                 // null emulator — a permanently blank terminal with nothing in
                 // the log. `setTypeface` then reads `mRenderer.mTextSize`, so it
                 // has to come after `setTextSize`.
-                setTextSize(TERMINAL_TEXT_SIZE_RAW_PX)
+                setTextSize(textSizePx)
+                appliedTextSizePx[0] = textSizePx
                 setTypeface(terminalTypeface(context))
                 setDefaultBackgroundColor(TERMINAL_BACKGROUND_ARGB)
                 attachSession(session)
@@ -186,6 +199,10 @@ fun TerminalHostView(
             }
         },
         update = { view ->
+            if (appliedTextSizePx[0] != textSizePx) {
+                view.setTextSize(textSizePx)
+                appliedTextSizePx[0] = textSizePx
+            }
             repaintClient.view = view
             if (view.currentSession !== session) {
                 view.attachSession(session)

--- a/app2/src/test/java/com/pocketshell/next/terminal/TerminalTextSizeSettingWiringTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/TerminalTextSizeSettingWiringTest.kt
@@ -1,0 +1,243 @@
+package com.pocketshell.next.terminal
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.next.settings.AppSettings
+import com.pocketshell.next.settings.LocalAppSettings
+import com.pocketshell.next.settings.SettingsRepository
+import com.termux.view.TerminalView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression for issue #2512 — the Settings text-size stepper has to reach the
+ * thing that paints glyphs.
+ *
+ * ## What was broken
+ *
+ * [AppSettings.terminalTextSizePx] is persisted by [SettingsRepository] and
+ * rendered as a user-facing Settings stepper (task P-6). `MainActivity` even
+ * provides the snapshot through [LocalAppSettings] specifically so the
+ * terminal can read font size without a third ViewModel. Zero call sites
+ * under `app2/` actually read it. [TerminalHostView] always
+ * `setTextSize(TERMINAL_TEXT_SIZE_RAW_PX)` (hardcoded 28) and
+ * [rememberTerminalCellMetrics] measured at the same constant, so moving the
+ * stepper changed a stored Int and nothing on screen.
+ *
+ * Same class as issue #2488 (grace window): a control that persists a value
+ * the production path never reads. Worse than no control, because a fresh
+ * install at the default 28 looks fine and the hole is silent.
+ *
+ * ## Why the assertions are on the VIEW and the METRICS, not on SharedPreferences
+ *
+ * [SettingsRepositoryTest] already round-trips the Int. That cannot fail on
+ * this bug. The defect lives entirely in the consumer wiring, so the only
+ * test that can fail on it is one that composes the REAL [TerminalHostView]
+ * and the REAL [rememberTerminalCellMetrics] under a non-default
+ * [LocalAppSettings] — the same CompositionLocal `MainActivity` provides —
+ * and watches what size the vendored renderer and the geometry estimate
+ * actually used.
+ *
+ * Robolectric cannot paint the emulator's canvas (`libtermux.so` is a device
+ * artifact) and its `Paint` reports a 1 px glyph at every text size, so the
+ * metrics assertion is on [TerminalCellMetrics.textSizePx] (the input
+ * [measureTerminalCellMetrics] recorded) rather than on a cell-width that
+ * would be 1 px either way. The view assertion is on the renderer the
+ * vendored [TerminalView.setTextSize] built — not a stub, not a captured
+ * lambda.
+ */
+@RunWith(AndroidJUnit4::class)
+class TerminalTextSizeSettingWiringTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private var rootView: View? = null
+    private var capturedMetrics: TerminalCellMetrics? = null
+
+    /**
+     * The bug itself: a user who steps the size to 40 px must get 40 px glyphs
+     * and a geometry estimate measured at 40 px. Before the fix both were 28.
+     */
+    @Test
+    fun `the provided text size is the one the view and the metrics use`() {
+        setWiredContent(AppSettings(terminalTextSizePx = NON_DEFAULT_PX))
+
+        assertEquals(
+            "TerminalView.setTextSize must receive the Settings value, not the " +
+                "$TERMINAL_TEXT_SIZE_RAW_PX px literal (issue #2512: the stepper " +
+                "was inert and every glyph was the default)",
+            NON_DEFAULT_PX,
+            requireTerminalView().rendererTextSize(),
+        )
+        assertEquals(
+            "rememberTerminalCellMetrics must measure at the same Settings value " +
+                "so the geometry estimate and the glyphs agree",
+            NON_DEFAULT_PX,
+            requireMetrics().textSizePx,
+        )
+    }
+
+    /**
+     * The half a value captured at first composition would fail.
+     *
+     * The user moves the stepper while a session is open: `MainActivity`
+     * provides a new [AppSettings] snapshot and the already-hosted
+     * [TerminalView] has to pick it up in `AndroidView`'s `update` block. A
+     * factory-only read would pin the size until the view was torn down.
+     */
+    @Test
+    fun `changing the setting on a live terminal changes the glyphs and the metrics`() {
+        var settings by mutableStateOf(AppSettings(terminalTextSizePx = NON_DEFAULT_PX))
+        setWiredContent { settings }
+
+        val view = requireTerminalView()
+        assertEquals(NON_DEFAULT_PX, view.rendererTextSize())
+        assertEquals(NON_DEFAULT_PX, requireMetrics().textSizePx)
+
+        composeRule.runOnIdle {
+            settings = AppSettings(terminalTextSizePx = LIVE_UPDATE_PX)
+        }
+        composeRule.waitForIdle()
+
+        assertSame(
+            "the hosted TerminalView must be updated in place, not rebuilt " +
+                "(rebuilding would reset the viewport)",
+            view,
+            requireTerminalView(),
+        )
+        assertEquals(
+            "setTextSize must run again on the existing view when the stepper moves",
+            LIVE_UPDATE_PX,
+            view.rendererTextSize(),
+        )
+        assertEquals(LIVE_UPDATE_PX, requireMetrics().textSizePx)
+        assertNotEquals(
+            "the two sizes the stepper offers must be distinct or this " +
+                "assertion cannot catch a factory-only read",
+            NON_DEFAULT_PX,
+            LIVE_UPDATE_PX,
+        )
+    }
+
+    /**
+     * A value that survived a process restart is what the next composition
+     * uses — the same repository instance is not what production has (the
+     * graph is rebuilt on every cold start), so the snapshot has to come off
+     * the PERSISTED file, the way `MainActivity` collects it into
+     * [LocalAppSettings].
+     */
+    @Test
+    fun `a size stored by a previous process run is honoured after a restart`() {
+        SettingsRepository(ApplicationProvider.getApplicationContext())
+            .setTerminalTextSizePx(NON_DEFAULT_PX)
+
+        val restarted = SettingsRepository(ApplicationProvider.getApplicationContext())
+        setWiredContent(restarted.settings.value)
+
+        assertEquals(NON_DEFAULT_PX, requireTerminalView().rendererTextSize())
+        assertEquals(NON_DEFAULT_PX, requireMetrics().textSizePx)
+    }
+
+    /**
+     * A fresh install must behave exactly as it did before this wiring existed:
+     * the settings default and the terminal's own raw-pixel default are the
+     * same 28 px, so passing the setting through changes nothing for a user
+     * who never opens Settings.
+     */
+    @Test
+    fun `a fresh install still gets the twenty-eight-pixel default`() {
+        assertEquals(
+            "the settings default and the terminal default must not drift apart",
+            TERMINAL_TEXT_SIZE_RAW_PX,
+            AppSettings.DEFAULT_TERMINAL_TEXT_SIZE_PX,
+        )
+
+        val settings = SettingsRepository(ApplicationProvider.getApplicationContext())
+        assertEquals(TERMINAL_TEXT_SIZE_RAW_PX, settings.settings.value.terminalTextSizePx)
+
+        setWiredContent(settings.settings.value)
+
+        assertEquals(TERMINAL_TEXT_SIZE_RAW_PX, requireTerminalView().rendererTextSize())
+        assertEquals(TERMINAL_TEXT_SIZE_RAW_PX, requireMetrics().textSizePx)
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private fun setWiredContent(settings: AppSettings) = setWiredContent { settings }
+
+    private fun setWiredContent(settings: () -> AppSettings) {
+        val session = createRemoteTerminalSession()
+        composeRule.setContent {
+            rootView = LocalView.current
+            CompositionLocalProvider(LocalAppSettings provides settings()) {
+                capturedMetrics = rememberTerminalCellMetrics()
+                TerminalHostView(
+                    session = session,
+                    onResized = { _, _ -> },
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(SESSION_TERMINAL_TAG).assertExists()
+    }
+
+    private fun requireTerminalView(): TerminalView =
+        requireNotNull(findTerminalView(requireNotNull(rootView).rootView)) {
+            "no TerminalView in the composition — TerminalHostView did not host the vendored view"
+        }
+
+    private fun requireMetrics(): TerminalCellMetrics =
+        requireNotNull(capturedMetrics) { "rememberTerminalCellMetrics never ran" }
+
+    private fun findTerminalView(view: View): TerminalView? {
+        if (view is TerminalView) return view
+        if (view !is ViewGroup) return null
+        for (index in 0 until view.childCount) {
+            findTerminalView(view.getChildAt(index))?.let { return it }
+        }
+        return null
+    }
+
+    /**
+     * The size [TerminalView.setTextSize] actually built a renderer at.
+     *
+     * [com.termux.view.TerminalRenderer.mTextSize] is package-private (the
+     * vendored class is pinned byte-identical to upstream), so this is a
+     * reflective read of the field `setTextSize` writes — the same field
+     * `setTypeface` then reads. A test that stubbed `setTextSize` would still
+     * pass with the factory hard-coding 28.
+     */
+    private fun TerminalView.rendererTextSize(): Int {
+        val renderer = checkNotNull(mRenderer) {
+            "TerminalView has no renderer — setTextSize never ran"
+        }
+        val field = renderer.javaClass.getDeclaredField("mTextSize")
+        field.isAccessible = true
+        return field.getInt(renderer)
+    }
+
+    private companion object {
+        /** A stepper stop that is not the shipped default, and on the 2 px grid. */
+        const val NON_DEFAULT_PX: Int = 40
+
+        /** A different stop, used to prove the live view updates in place. */
+        const val LIVE_UPDATE_PX: Int = 48
+    }
+}


### PR DESCRIPTION
## Summary
Settings text-size stepper was inert: `LocalAppSettings` was provided and never consumed; `TerminalHostView` hardcoded 28 px. Same class as #2488. Now both the live `TerminalView` and `rememberTerminalCellMetrics` read `terminalTextSizePx`.

Reviewer: APPROVED https://github.com/alexeygrigorev/pocketshell/issues/2512#issuecomment-5550176405

Closes #2512

## Test plan
- [x] `TerminalTextSizeSettingWiringTest` red on unfixed code (`expected:<40> but was:<28>`), green with the fix
- [x] 145 terminal/settings unit tests
- [x] `scripts/assemble-debug.sh`