### PR TITLE
fix: restore PocketShell launcher name and original icon

### DIFF
--- a/app2/src/main/AndroidManifest.xml
+++ b/app2/src/main/AndroidManifest.xml
@@ -69,7 +69,9 @@
     <application
         android:name=".App"
         android:allowBackup="false"
+        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.PocketShellNext">
 

--- a/app2/src/main/res/drawable/ic_launcher_background.xml
+++ b/app2/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    PocketShell launcher background.
+
+    Solid near-black navy (#0B0F14) from issue #612's selected D/1
+    direction — never pure black. The adaptive-icon system masks this to the OEM's preferred
+    shape (circle, squircle, rounded square, etc.), so a flat fill is
+    enough; no inner shapes here.
+
+    Drawn on a 108x108dp canvas; the inner 66dp circle is the safe zone
+    where the foreground glyph must live.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#0B0F14"
+        android:pathData="M0,0h108v108h-108z" />
+</vector>

--- a/app2/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app2/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    PocketShell launcher foreground for issue #612 — mark "C1".
+
+    The maintainer selected direction D + Brand Board Direction 1
+    ("Pocket Terminal") and, after the circular-mask clipping complaint,
+    chose the refined "C1" mark: a bold cyan shell prompt chevron (`>`)
+    with a cursor block (`_`) sitting on a dark rounded "pocket" plate.
+    The prompt itself IS the logo — it reads instantly as a terminal /
+    agent CLI and stays legible down to mdpi (48px). The earlier
+    terminal-frame mark is removed outright (hard cut, D22); we do not
+    keep both.
+
+    Adaptive-icon canvas is 108x108. OEM masks (circle, squircle,
+    rounded-square) plus Pixel Launcher folder previews crop aggressively,
+    so every painted element — INCLUDING the backdrop plate — is kept
+    inside a conservative inner safe box (viewport coords 32..76 on X,
+    30..80 on Y). LauncherIconVectorTest enforces that box. Strokes are
+    avoided in favour of filled polygons so nothing thins out after the
+    mask scales the artwork down.
+
+    Colors:
+    - Plate fill #0F1A22 — a hair lighter than the #0B0F14 background, for
+      depth without competing with the cyan.
+    - Chevron #22D3EE — the brand accent cyan, matching the token accent.
+    - Cursor block #F8FAFC — near-white for high contrast against the cyan.
+
+    Source design references (issue #612 / feedback-assets):
+    - issue-612-icon-decision-20260611.png (C1 vs alternatives, all masks)
+    - issue-612-c1-final-masks-20260611.png (C1 under each OEM mask)
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <!-- Dark rounded "pocket" plate. Filled, inside the safe box. -->
+    <path
+        android:fillColor="#0F1A22"
+        android:pathData="M41,37 L67,37 Q71,37 71,41 L71,71 Q71,75 67,75 L41,75 Q37,75 37,71 L37,41 Q37,37 41,37 Z" />
+
+    <!-- Bold prompt chevron `>`. Filled polygon so it never thins out. -->
+    <path
+        android:fillColor="#22D3EE"
+        android:pathData="M43,43 L50,43 L63,57 L50,71 L43,71 L56,57 Z" />
+
+    <!-- Cursor block `_` at the bottom-right of the plate. -->
+    <path
+        android:fillColor="#F8FAFC"
+        android:pathData="M58,65 L66,65 Q68,65 68,67 L68,69 Q68,71 66,71 L58,71 Q56,71 56,69 L56,67 Q56,65 58,65 Z" />
+</vector>

--- a/app2/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app2/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    PocketShell monochrome launcher layer for issue #612.
+
+    Android 13+ "Themed icons" (Material You) tint a single-color
+    <monochrome> silhouette with the user's wallpaper-derived palette. We
+    supply the brand `>_` shell-prompt mark (the same chevron + cursor as the
+    "C1" foreground in ic_launcher_foreground.xml) as a flat single-color
+    silhouette so the themed icon stays on-brand instead of falling back to a
+    generic system default.
+
+    The plate from the full-color foreground is intentionally DROPPED — a
+    monochrome layer is a single-color silhouette of the mark, and the system
+    draws its own circular/themed backdrop. Keeping only the `>_` glyph gives a
+    clean, recognizable silhouette under the system tint.
+
+    Color: the fill is white (#FFFFFF). The platform replaces it with the
+    themed monochrome tint at draw time, so the literal color only matters for
+    opacity (solid = fully painted silhouette).
+
+    Like the foreground, every painted element is kept inside the conservative
+    inner safe box (viewport coords 32..76 on X, 30..80 on Y) that
+    LauncherIconVectorTest enforces, so the silhouette never clips under OEM
+    masks. The chevron + cursor are bold filled polygons (no thin strokes) so
+    they stay crisp after the mask scales the artwork down.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <!-- Bold prompt chevron `>`. Same geometry as the C1 foreground mark. -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M43,43 L50,43 L63,57 L50,71 L43,71 L56,57 Z" />
+
+    <!-- Cursor block `_` at the bottom-right, echoing the C1 cursor. -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M58,65 L66,65 Q68,65 68,67 L68,69 Q68,71 66,71 L58,71 Q56,71 56,69 L56,67 Q56,65 58,65 Z" />
+</vector>

--- a/app2/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app2/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Adaptive launcher icon (API 26+). PocketShell's minSdk is 26
+    (see app2/build.gradle.kts), so this single adaptive entry covers
+    every supported device — no pre-26 PNG fallbacks shipped.
+    See app2 launcher assets for the rationale.
+-->
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <!-- Android 13+ themed-icon silhouette (issue #612). -->
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/app2/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app2/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Round-mask variant of the adaptive launcher icon. Same artwork as
+    @mipmap/ic_launcher — the platform applies the round mask itself
+    on launchers that prefer circular icons. We keep a separate entry
+    so the Manifest's android:roundIcon attribute has a valid target
+    and OEM launchers that distinguish the two pick this one.
+-->
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <!-- Android 13+ themed-icon silhouette (issue #612). -->
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/app2/src/main/res/values/strings.xml
+++ b/app2/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <!-- Distinct from the old client's label so both installs are tellable
-         apart on one device during the rewrite. Renamed at cutover (X-4). -->
-    <string name="app_name">PocketShell Next</string>
+    <!-- User-visible launcher name. This is PocketShell, not a rebrand.
+         applicationId stays com.pocketshell.next until X-3. -->
+    <string name="app_name">PocketShell</string>
 </resources>

--- a/app2/src/test/java/com/pocketshell/next/LauncherBrandingTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/LauncherBrandingTest.kt
@@ -1,0 +1,139 @@
+package com.pocketshell.next
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+
+/**
+ * Pins the shipping launcher identity (issue #2517): this is PocketShell,
+ * not a "Next" rebrand. The rewrite's side-by-side `applicationId` is a
+ * package-name cutover (X-3), not a new product name or icon.
+ */
+class LauncherBrandingTest {
+
+    @Test
+    fun launcherLabelIsPocketShellNotNext() {
+        val document = parseXml(locate("app2/src/main/res/values/strings.xml"))
+        val strings = document.getElementsByTagName("string")
+        var appName: String? = null
+        for (i in 0 until strings.length) {
+            val el = strings.item(i) as Element
+            if (el.getAttribute("name") == "app_name") {
+                appName = el.textContent.trim()
+                break
+            }
+        }
+        assertEquals("PocketShell", appName)
+        assertTrue(
+            "launcher label must not carry the rewrite's side-by-side 'Next' suffix",
+            appName != null && !appName.contains("Next"),
+        )
+    }
+
+    @Test
+    fun applicationUsesTheOriginalAdaptiveLauncherIcon() {
+        val document = parseXml(locate("app2/src/main/AndroidManifest.xml"))
+        val applications = document.getElementsByTagName("application")
+        assertEquals(1, applications.length)
+        val application = applications.item(0) as Element
+        assertEquals("@mipmap/ic_launcher", application.androidAttr("icon"))
+        assertEquals("@mipmap/ic_launcher_round", application.androidAttr("roundIcon"))
+        assertTrue(
+            "adaptive launcher entries must exist",
+            locate("app2/src/main/res/mipmap-anydpi-v26/ic_launcher.xml").isFile &&
+                locate("app2/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml").isFile,
+        )
+    }
+
+    @Test
+    fun foregroundArtworkStaysInsideCircularMaskSafeArea() {
+        assertArtworkStaysInsideSafeArea(
+            locate("app2/src/main/res/drawable/ic_launcher_foreground.xml"),
+            "launcher foreground",
+        )
+    }
+
+    @Test
+    fun monochromeArtworkStaysInsideCircularMaskSafeArea() {
+        assertArtworkStaysInsideSafeArea(
+            locate("app2/src/main/res/drawable/ic_launcher_monochrome.xml"),
+            "launcher monochrome",
+        )
+    }
+
+    private fun assertArtworkStaysInsideSafeArea(file: File, label: String) {
+        val document = parseXml(file)
+        val paths = document.getElementsByTagName("path")
+        assertTrue("$label should contain vector paths", paths.length > 0)
+        for (index in 0 until paths.length) {
+            val path = paths.item(index) as Element
+            val pathData = path.androidAttr("pathData")
+            val bounds = pathDataBounds(pathData)
+            val strokeInset = path.androidAttr("strokeWidth").toFloatOrNull()?.div(2f) ?: 0f
+            val inkLeft = bounds.left - strokeInset
+            val inkTop = bounds.top - strokeInset
+            val inkRight = bounds.right + strokeInset
+            val inkBottom = bounds.bottom + strokeInset
+            assertTrue(
+                "$label path $index should stay within x=32..76 after stroke; " +
+                    "bounds=$bounds strokeInset=$strokeInset",
+                inkLeft >= 32f && inkRight <= 76f,
+            )
+            assertTrue(
+                "$label path $index should stay within y=30..80 after stroke; " +
+                    "bounds=$bounds strokeInset=$strokeInset",
+                inkTop >= 30f && inkBottom <= 80f,
+            )
+        }
+    }
+
+    private fun pathDataBounds(pathData: String): Bounds {
+        val numbers = NUMBER.findAll(pathData).map { it.value.toFloat() }.toList()
+        require(numbers.size >= 2 && numbers.size % 2 == 0) {
+            "pathData must use absolute x,y coordinate pairs: $pathData"
+        }
+        val xs = numbers.filterIndexed { index, _ -> index % 2 == 0 }
+        val ys = numbers.filterIndexed { index, _ -> index % 2 == 1 }
+        return Bounds(
+            left = xs.minOrNull() ?: error("pathData has no x coordinates"),
+            top = ys.minOrNull() ?: error("pathData has no y coordinates"),
+            right = xs.maxOrNull() ?: error("pathData has no x coordinates"),
+            bottom = ys.maxOrNull() ?: error("pathData has no y coordinates"),
+        )
+    }
+
+    private fun parseXml(file: File) =
+        DocumentBuilderFactory.newInstance().apply { isNamespaceAware = true }
+            .newDocumentBuilder()
+            .parse(file)
+
+    private fun Element.androidAttr(name: String): String =
+        getAttributeNS(ANDROID_NS, name).ifBlank { getAttribute("android:$name") }
+
+    private fun locate(relative: String): File {
+        val stripped = relative.removePrefix("app2/")
+        val candidates = listOf(
+            File(relative),
+            File(stripped),
+            File("../$relative"),
+            File("../../$relative"),
+        )
+        return candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $relative from ${File(".").absolutePath}")
+    }
+
+    private data class Bounds(
+        val left: Float,
+        val top: Float,
+        val right: Float,
+        val bottom: Float,
+    )
+
+    private companion object {
+        const val ANDROID_NS = "http://schemas.android.com/apk/res/android"
+        val NUMBER = Regex("-?\\d+(?:\\.\\d+)?")
+    }
+}


### PR DESCRIPTION
## Summary
v0.5.0 installed as **PocketShell Next** with the default Android icon. Restore `app_name` = PocketShell and the v0.4.47 `>_` adaptive launcher. `applicationId` stays `com.pocketshell.next` (X-3).

Reviewer: APPROVED https://github.com/alexeygrigorev/pocketshell/issues/2517#issuecomment-5551452190

Closes #2517