### PR TITLE
fix: ship app2 under com.pocketshell.app so 0.5.0 upgrades v0.4.x

### DIFF
--- a/app2/build.gradle.kts
+++ b/app2/build.gradle.kts
@@ -159,10 +159,10 @@ android {
     }
 
     defaultConfig {
-        // Distinct from the old client's `com.pocketshell.app` so both can be
-        // installed side by side during the rewrite. X-4 renames this to
-        // `com.pocketshell.app` at cutover.
-        applicationId = "com.pocketshell.next"
+        // Same install identity as v0.4.x so an update replaces the existing
+        // PocketShell (same signature: debug.keystore). Kotlin namespace stays
+        // `com.pocketshell.next`; only the Play/package id is `com.pocketshell.app`.
+        applicationId = "com.pocketshell.app"
         minSdk = 26
         targetSdk = 35
         // Issue #2356: tag-derived, see derivePocketshellVersion() above. The
@@ -186,11 +186,11 @@ android {
 
             // Issue #672 scheme, adopted for app2 by task U-2: let each parallel
             // worktree install its DEBUG apk under a distinct applicationId
-            // (e.g. `com.pocketshell.next.iapp2`) so two app2 worktrees running
+            // (e.g. `com.pocketshell.app.iapp2`) so two app2 worktrees running
             // connected tests on the ONE shared emulator do not uninstall each
             // other. `scripts/connected-test.sh --suffix <token>` passes the
             // property; with no property this is byte-for-byte the plain
-            // `com.pocketshell.next` build, and the release type is untouched.
+            // `com.pocketshell.app` build, and the release type is untouched.
             //
             // Only `[A-Za-z0-9._]` is accepted (a package-segment token) so a
             // stray value cannot produce an invalid applicationId.

--- a/app2/src/main/java/com/pocketshell/next/di/AppModule.kt
+++ b/app2/src/main/java/com/pocketshell/next/di/AppModule.kt
@@ -56,16 +56,12 @@ annotation class IoDispatcher
  * app2's only DI module so far (plan §U-1): the Room database and the DAOs the
  * screens that exist actually consume, plus the IO dispatcher.
  *
- * The database file name matches the shipping client's (`pocketshell.db`) on
- * purpose — app2 reads the very same schema and, once X-4 renames the
- * `applicationId` to `com.pocketshell.app`, the very same file, so cutover is a
- * rename rather than a data migration. Until then app2 runs under its own
- * `applicationId` and therefore its own (initially empty) copy in its own
- * sandbox; that is a property of Android app sandboxing, not of this module.
+ * The database file name matches the shipping client's (`pocketshell.db`) and
+ * `applicationId` is `com.pocketshell.app`, so an upgrade from v0.4.x opens the
+ * same sandbox file. Schema bumps go through [APP_DATABASE_MIGRATIONS].
  *
- * The migration array is wired even though app2 only reads: an install that
- * later becomes the primary app must open an existing v-N file rather than
- * fail Room's schema validation.
+ * The migration array is wired so an upgraded v0.4.x install opens its
+ * existing v-N file rather than failing Room's schema validation.
  *
  * A DAO is added here when a screen consumes it, not preemptively — the old
  * client's module provided nine and the rewrite's premise is that most of them

--- a/app2/src/main/res/values/strings.xml
+++ b/app2/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <!-- User-visible launcher name. This is PocketShell, not a rebrand.
-         applicationId stays com.pocketshell.next until X-3. -->
+    <!-- User-visible launcher name. This is PocketShell, not a rebrand. -->
     <string name="app_name">PocketShell</string>
 </resources>

--- a/app2/src/test/java/com/pocketshell/next/LauncherBrandingTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/LauncherBrandingTest.kt
@@ -8,11 +8,25 @@ import org.junit.Test
 import org.w3c.dom.Element
 
 /**
- * Pins the shipping launcher identity (issue #2517): this is PocketShell,
- * not a "Next" rebrand. The rewrite's side-by-side `applicationId` is a
- * package-name cutover (X-3), not a new product name or icon.
+ * Pins the shipping launcher identity (issue #2517) and install id
+ * (issue #2519): this is PocketShell under `com.pocketshell.app`, so an
+ * upgrade replaces the v0.4.x install (same signature). Kotlin namespace
+ * stays `com.pocketshell.next`.
  */
 class LauncherBrandingTest {
+
+    @Test
+    fun shippingApplicationIdIsTheOriginalPackage() {
+        val gradle = locate("app2/build.gradle.kts").readText()
+        assertTrue(
+            "applicationId must be com.pocketshell.app so adb install -r upgrades v0.4.x",
+            Regex("""applicationId\s*=\s*"com\.pocketshell\.app"""").containsMatchIn(gradle),
+        )
+        assertTrue(
+            "applicationId must not be the rewrite side-by-side id",
+            !Regex("""applicationId\s*=\s*"com\.pocketshell\.next"""").containsMatchIn(gradle),
+        )
+    }
 
     @Test
     fun launcherLabelIsPocketShellNotNext() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,13 +61,13 @@ See [testing.md](testing.md).
 ## App identity
 
 - Display name: PocketShell
-- `applicationId` / namespace: **`com.pocketshell.next`**
+- `applicationId`: **`com.pocketshell.app`** (same as v0.4.x — upgrades in place)
+- Kotlin `namespace`: `com.pocketshell.next`
 - minSdk 26, targetSdk 35, compileSdk 36
 
-`com.pocketshell.next` is the rewrite's side-by-side id, kept so the new client
-could be installed next to the old one. Renaming it back to
-`com.pocketshell.app` (with a Room data carry-over for the maintainer's
-existing install) is task X-3 and **has not happened yet**.
+Room opens `pocketshell.db` in that sandbox, so an upgrade from v0.4.47 keeps
+hosts and keys (`MIGRATION_19_20`). The Kotlin package name is not the
+install id.
 
 Two activities (`MainActivity`, `ShareActivity`) and two foreground services
 (`GraceService`, `ForwardService`). Everything else is Compose.
@@ -528,8 +528,8 @@ one-unfiltered-run rule and the whole suite is too expensive per PR.
 
 Stated plainly so nobody reads a plan as a description:
 
-- **X-3 is unfinished.** `applicationId` is still `com.pocketshell.next`; the
-  rename to `com.pocketshell.app` plus the Room data carry-over is pending.
+- **X-3 applicationId rename is done.** `applicationId` is `com.pocketshell.app`
+  (issue #2519). Room still uses `pocketshell.db` with `MIGRATION_19_20`.
 - **X-1, the lean-core release gate, has not been declared passed.** The target
   is a tagged minor release once the confirmed-core feature set holds up in daily
   use.

--- a/docs/docker-emulator-runbook.md
+++ b/docs/docker-emulator-runbook.md
@@ -524,7 +524,7 @@ The fast pre-release gate does all of the following:
    uninstalls the package.
 
 Before the app2 instrumentation phase, the gate force-stops
-`com.pocketshell.next.test` and `com.pocketshell.next`, clears existing package
+`com.pocketshell.app.test` and `com.pocketshell.app`, clears existing package
 data if either package is already installed, and waits for the package-manager
 handler queues to go idle. This is the cold-reset walkthrough path, not the user
 update path. It then replace-installs the app/test APKs once and waits for

--- a/scripts/android-upgrade-preservation-gate.sh
+++ b/scripts/android-upgrade-preservation-gate.sh
@@ -35,22 +35,13 @@ pocketshell_acquire_avd_lock "$ROOT_DIR" "${1:-}"
 ANDROID_SDK="${ANDROID_SDK:-/home/alexey/Android/Sdk}"
 ADB="${ADB:-$ANDROID_SDK/platform-tools/adb}"
 PYTHON3="${PYTHON3:-python3}"
-# Issue #2481: no default OLD_REF any more. The old default (`v0.3.2`) is a tag
-# on the pre-rewrite `app` module, whose applicationId is `com.pocketshell.app`
-# — a DIFFERENT package from app2's `com.pocketshell.next`, so `adb install -r`
-# over it is not an upgrade at all and this gate would assert nothing. There is
-# also no tagged app2 release to compare against yet. Supply an explicit
-# `OLD_REF` on `stable`'s lineage (a commit that already contains `app2/`), or
-# an `OLD_APK_PATH`, and the gate does its real job: prove a Room database
-# survives `adb install -r`.
-#
-# The pre-rewrite -> app2 case (`com.pocketshell.app` data opened by a renamed
-# app2) is rewrite task X-3's applicationId rename + data migration, not
-# something this gate can express while the two packages differ. See
-# docs/rewrite-implementation-plan.md (X-3) and issue #2471.
+# Issue #2519: app2's applicationId is `com.pocketshell.app`, same as v0.4.x,
+# so `adb install -r` of a new APK over an old one IS an upgrade and this
+# gate can prove Room data survives. Supply OLD_REF (a v0.4.x tag or any
+# commit that builds an APK with this package) or OLD_APK_PATH.
 OLD_REF="${OLD_REF:-}"
-PACKAGE_NAME="${PACKAGE_NAME:-com.pocketshell.next}"
-ACTIVITY_NAME="${ACTIVITY_NAME:-com.pocketshell.next/.MainActivity}"
+PACKAGE_NAME="${PACKAGE_NAME:-com.pocketshell.app}"
+ACTIVITY_NAME="${ACTIVITY_NAME:-com.pocketshell.app/com.pocketshell.next.MainActivity}"
 NEW_APK_PATH="${NEW_APK_PATH:-$ROOT_DIR/app2/build/outputs/apk/debug/app2-debug.apk}"
 OLD_APK_PATH="${OLD_APK_PATH:-}"
 BUILD_NEW_APK="${BUILD_NEW_APK:-1}"
@@ -116,7 +107,7 @@ if [[ -z "$OLD_APK_PATH" ]]; then
     exit 1
   fi
   if [[ -z "$OLD_REF" ]]; then
-    printf 'OLD_REF is required when OLD_APK_PATH is empty (issue #2481: there is no safe default — a pre-rewrite ref builds com.pocketshell.app, not app2'"'"'s com.pocketshell.next, so the install would not be an upgrade).\n' >&2
+    printf 'OLD_REF is required when OLD_APK_PATH is empty.\n' >&2
     exit 1
   fi
   old_worktree="$RUN_DIR/old-$OLD_REF"

--- a/scripts/capture-walkthrough-screenshots.sh
+++ b/scripts/capture-walkthrough-screenshots.sh
@@ -53,7 +53,7 @@ COMPOSE_FILE="${COMPOSE_FILE:-tests/docker/docker-compose.yml}"
 LOG_ROOT="${LOG_ROOT:-$ROOT_DIR/build/walkthrough-visual-pass}"
 RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
 RUN_DIR="$LOG_ROOT/$RUN_ID"
-APP_PACKAGE="com.pocketshell.next"
+APP_PACKAGE="com.pocketshell.app"
 TEST_PACKAGE="$APP_PACKAGE.test"
 # JourneyScreenshots writes to getExternalFilesDir(null)/<journey>/<name>.png.
 DEVICE_OUTPUT_DIR="/sdcard/Android/data/$APP_PACKAGE/files"
@@ -281,7 +281,7 @@ visual_audit_instrumentation_log_has_failure_markers() {
 
 visual_audit_logcat_has_app_or_test_failure_markers() {
   local logcat_file="$1"
-  grep -Eq 'Process: com[.]pocketshell[.]next|FATAL EXCEPTION.*com[.]pocketshell[.]next|FATAL SIGNAL.*com[.]pocketshell[.]next|AndroidRuntime.*com[.]pocketshell[.]next|(^|[[:space:]])FAILURES!!!($|[[:space:]])|INSTRUMENTATION_STATUS: stack=|INSTRUMENTATION_RESULT: shortMsg=Process crashed' "$logcat_file"
+  grep -Eq 'Process: com[.]pocketshell[.]app|FATAL EXCEPTION.*com[.]pocketshell[.]app|FATAL SIGNAL.*com[.]pocketshell[.]app|AndroidRuntime.*com[.]pocketshell[.]app|(^|[[:space:]])FAILURES!!!($|[[:space:]])|INSTRUMENTATION_STATUS: stack=|INSTRUMENTATION_RESULT: shortMsg=Process crashed' "$logcat_file"
 }
 
 visual_audit_instrumentation_log_has_transport_drop_markers() {

--- a/scripts/ci-app2-journey-suite.sh
+++ b/scripts/ci-app2-journey-suite.sh
@@ -48,7 +48,7 @@ ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
 GRADLE_CMD="${POCKETSHELL_APP2_JOURNEY_GRADLE:-./gradlew}"
 ARTIFACT_DIR="${POCKETSHELL_APP2_JOURNEY_ARTIFACTS:-artifacts/app2-journey}"
-APP_ID="${POCKETSHELL_APP2_JOURNEY_APP_ID:-com.pocketshell.next}"
+APP_ID="${POCKETSHELL_APP2_JOURNEY_APP_ID:-com.pocketshell.app}"
 ADB="${ADB:-adb}"
 
 # The one task this lane runs. Kept in a named variable so the self-test can

--- a/scripts/connected-test.sh
+++ b/scripts/connected-test.sh
@@ -12,13 +12,13 @@ set -euo pipefail
 #      Distinct emulators retain independent locks and run concurrently.
 #   2. Threads the per-worktree applicationIdSuffix (option 2) into the gradle
 #      invocation so each worktree's DEBUG apk installs under a distinct
-#      applicationId (e.g. com.pocketshell.next.i672) and multiple test apps
+#      applicationId (e.g. com.pocketshell.app.i672) and multiple test apps
 #      coexist on ONE emulator without uninstalling each other.
 #
 # THE DEFAULT MODULE IS `app2` (issue #2481). The rewrite's hard cut deleted the
 # old `app` module, so `:app:connectedDebugAndroidTest` cannot even be
 # configured; the application module in this build is `:app2`, applicationId
-# `com.pocketshell.next` (app2/build.gradle.kts, which implements the same
+# `com.pocketshell.app` (app2/build.gradle.kts, which implements the same
 # `-PpocketshellAppIdSuffix` contract). `--module` still redirects at a
 # `shared:*` module. There is deliberately no "try app2, fall back to app"
 # branch (D22): the old module is gone, not deprecated.
@@ -36,7 +36,7 @@ set -euo pipefail
 #     -Pandroid.testInstrumentationRunnerArguments.class=com.pocketshell.terminal.core.CodexOutputBurstImeMainThreadProofTest
 #
 #   scripts/connected-test.sh --cleanup-suffixes   # uninstall leftover
-#                                                   # com.pocketshell.next.i* apps
+#                                                   # com.pocketshell.app.i* apps
 #
 # NOTE on class filters: CI's app2 journey lane runs the WHOLE instrumented set
 # unfiltered in ONE process on purpose (issue #2474 — cross-journey state
@@ -47,7 +47,7 @@ set -euo pipefail
 # Contention hardening (issue #776): even WITHOUT --pool, when more than one
 # emulator is online the wrapper now (P1) claims + pins a single FREE serial so
 # AGP can't fan the install onto every device (sibling SIGKILL), and (P0) sweeps
-# a leftover base com.pocketshell.next[.test] off the pinned device before
+# a leftover base com.pocketshell.app[.test] off the pinned device before
 # installing a suffixed APK so it can't hijack the suffixed MainActivity launch.
 # Journey/E2e/Docker classes auto-default to --pool when >1 emulator is online
 # (P2); pass --no-pool to opt out.
@@ -102,7 +102,7 @@ set -euo pipefail
 #   --no-pool            Force the legacy single-lane path even for a journey/E2e
 #                        class that would otherwise auto-default to --pool (P2).
 #                        Still honours the P0/P1 base-sweep + serial-pin hygiene.
-#   --cleanup-suffixes   Uninstall every accumulated com.pocketshell.next.i*
+#   --cleanup-suffixes   Uninstall every accumulated com.pocketshell.app.i*
 #                        (and .test) package from the target device, then exit.
 #                        Prevents install pile-up across worktrees.
 #
@@ -192,7 +192,7 @@ Flags:
   --pool               Lane pool mode: claim an isolated (emulator, agents-port)
                        lane for parallel journey testing (issues #674 + #724).
   --no-pool            Force the legacy single-lane path.
-  --cleanup-suffixes   Uninstall every accumulated com.pocketshell.next.i* package
+  --cleanup-suffixes   Uninstall every accumulated com.pocketshell.app.i* package
                        from the target device, then exit.
   --help, -h           Print this help and exit.
 
@@ -931,7 +931,7 @@ connected_test_validate_report() {
 
 cleanup_suffixed_packages() {
   # Optional first arg:
-  #   --include-base   ALSO uninstall the base com.pocketshell.next[.test] and
+  #   --include-base   ALSO uninstall the base com.pocketshell.app[.test] and
   #                    every suffixed sibling that is NOT this run's $SUFFIX.
   #                    Used as a pre-run hygiene sweep on a suffixed lane (P0,
   #                    issue #776) so a leftover base install can't hijack the
@@ -962,10 +962,10 @@ cleanup_suffixed_packages() {
   fi
   local pkg removed=0 cleanup_rc=0
   # The default (no --include-base) match: the per-worktree convention
-  # com.pocketshell.next.i<token> (and its .test sibling) ONLY. This deliberately
+  # com.pocketshell.app.i<token> (and its .test sibling) ONLY. This deliberately
   # excludes:
-  #   * the base package        com.pocketshell.next
-  #   * the base test package   com.pocketshell.next.test
+  #   * the base package        com.pocketshell.app
+  #   * the base test package   com.pocketshell.app.test
   # so the sweep can never nuke a normal (non-suffixed) install's test app.
   # Worktree suffixes follow the `i<N>` convention (e.g. i672), so the token
   # must start with `i`.
@@ -976,15 +976,15 @@ cleanup_suffixed_packages() {
   # both $SUFFIX is non-empty AND $ANDROID_SERIAL is pinned (see the pre-run
   # call site), so it can only touch the one targeted emulator and never a bare
   # non-suffixed manual install on some other device.
-  local match_re='^com\.pocketshell\.next\.i[A-Za-z0-9._]*(\.test)?$'
+  local match_re='^com\.pocketshell\.app\.i[A-Za-z0-9._]*(\.test)?$'
   if [[ "$include_base" == "1" ]]; then
-    match_re='^com\.pocketshell\.next(\.i[A-Za-z0-9._]*)?(\.test)?$'
+    match_re='^com\.pocketshell\.app(\.i[A-Za-z0-9._]*)?(\.test)?$'
   fi
   # Packages belonging to THIS run's suffix, which --include-base must skip.
   local self_pkg="" self_test_pkg=""
   if [[ -n "$SUFFIX" ]]; then
-    self_pkg="com.pocketshell.next.$SUFFIX"
-    self_test_pkg="com.pocketshell.next.$SUFFIX.test"
+    self_pkg="com.pocketshell.app.$SUFFIX"
+    self_test_pkg="com.pocketshell.app.$SUFFIX.test"
   fi
   while IFS= read -r pkg; do
     pkg="${pkg#package:}"
@@ -1039,7 +1039,7 @@ fi
 
 # P0 (issue #776) — pre-run hygiene sweep on a SUFFIXED, SERIAL-PINNED lane.
 # Before installing this lane's suffixed APK, uninstall the base
-# com.pocketshell.next[.test] AND any stale suffixed sibling that is NOT this
+# com.pocketshell.app[.test] AND any stale suffixed sibling that is NOT this
 # run's $SUFFIX, on the pinned emulator. A leftover base install shares the
 # IDENTICAL MAIN/LAUNCHER + VIEW pocketshell://import intent filters with every
 # suffixed package, so with two installed a launcher/VIEW launch is ambiguous
@@ -1059,9 +1059,9 @@ fi
 GRADLE_SUFFIX_ARGS=()
 if [[ -n "$SUFFIX" ]]; then
   GRADLE_SUFFIX_ARGS+=("-PpocketshellAppIdSuffix=$SUFFIX")
-  printf 'Running %s as com.pocketshell.next.%s\n' "$CONNECTED_TASK" "$SUFFIX" >&2
+  printf 'Running %s as com.pocketshell.app.%s\n' "$CONNECTED_TASK" "$SUFFIX" >&2
 else
-  printf 'Running %s as com.pocketshell.next (no suffix)\n' "$CONNECTED_TASK" >&2
+  printf 'Running %s as com.pocketshell.app (no suffix)\n' "$CONNECTED_TASK" >&2
 fi
 
 # Issue #724: thread the claimed (or caller-preset) agents fixture port into the

--- a/scripts/pre-release-confidence-gate.sh
+++ b/scripts/pre-release-confidence-gate.sh
@@ -777,7 +777,7 @@ for attempt in \$(seq 1 '$CORE_TERMINAL_CONNECTED_ATTEMPTS'); do
     printf 'Core-terminal connected test produced UTP no-results/transport cleanup failure on attempt %s; retrying.\n' "\$attempt" >&2
     '$ADB' reconnect >/dev/null 2>&1 || true
     '$ADB' wait-for-device >/dev/null 2>&1 || true
-    for package in com.termux.view.test com.pocketshell.next.test com.pocketshell.next; do
+    for package in com.termux.view.test com.pocketshell.app.test com.pocketshell.app; do
       '$ADB' shell am force-stop "\$package" >/dev/null 2>&1 || true
     done
     '$ADB' shell cmd package wait-for-handler --timeout 60000 >/dev/null 2>&1 || true
@@ -997,10 +997,10 @@ wait_package_manager_idle() {
   '$ADB' shell cmd package wait-for-handler --timeout 60000 >/dev/null 2>&1 || true
   '$ADB' shell cmd package wait-for-background-handler --timeout 60000 >/dev/null 2>&1 || true
 }
-for package in com.pocketshell.next.test com.pocketshell.next; do
+for package in com.pocketshell.app.test com.pocketshell.app; do
   '$ADB' shell am force-stop "\$package" >/dev/null 2>&1 || true
 done
-for package in com.pocketshell.next.test com.pocketshell.next; do
+for package in com.pocketshell.app.test com.pocketshell.app; do
   if package_installed "\$package"; then
     printf 'COLD-RESET: clearing package data without uninstalling: %s\n' "\$package"
     '$ADB' shell pm clear "\$package" || true
@@ -1009,7 +1009,7 @@ for package in com.pocketshell.next.test com.pocketshell.next; do
   fi
 done
 wait_package_manager_idle
-for package in com.pocketshell.next.test com.pocketshell.next; do
+for package in com.pocketshell.app.test com.pocketshell.app; do
   '$ADB' shell am force-stop "\$package" >/dev/null 2>&1 || true
 done
 printf 'COLD-RESET: focused app walkthrough package state reset without package deletion\n'
@@ -1024,14 +1024,14 @@ wait_package_manager_idle() {
   '$ADB' shell cmd package wait-for-background-handler --timeout 60000 >/dev/null 2>&1 || true
 }
 packages_present() {
-  for package in com.pocketshell.next com.pocketshell.next.test; do
+  for package in com.pocketshell.app com.pocketshell.app.test; do
     '$ADB' shell pm path "\$package" >/dev/null || return 1
   done
 }
 post_install_removal_seen() {
   '$ADB' logcat -d -v time -t 1000 2>/dev/null |
     grep -E 'PACKAGE_FULLY_REMOVED|PACKAGE_REMOVED|deletePackageX' |
-    grep -E 'com[.]pocketshell[.]next([.]test)?' >/dev/null
+    grep -E 'com[.]pocketshell[.]app([.]test)?' >/dev/null
 }
 uninstall_with_idle_wait() {
   local package="\$1"
@@ -1073,8 +1073,8 @@ install_or_fallback_uninstall() {
   exit "\$status"
 }
 install_pair() {
-  install_or_fallback_uninstall com.pocketshell.next '$APK_PATH'
-  install_or_fallback_uninstall com.pocketshell.next.test '$TEST_APK_PATH'
+  install_or_fallback_uninstall com.pocketshell.app '$APK_PATH'
+  install_or_fallback_uninstall com.pocketshell.app.test '$TEST_APK_PATH'
   wait_package_manager_idle
 }
 for attempt in {1..3}; do
@@ -1102,7 +1102,7 @@ for attempt in {1..3}; do
   fi
   printf 'Recent package removal context before reinstall:\n' >&2
   '$ADB' logcat -d -v time -t 500 |
-    grep -E 'PackageManager|PackageInstaller|PACKAGE_|deletePackageX|com[.]pocketshell[.]next' >&2 || true
+    grep -E 'PackageManager|PackageInstaller|PACKAGE_|deletePackageX|com[.]pocketshell[.]app' >&2 || true
   wait_package_manager_idle
   sleep 3
 done
@@ -1115,34 +1115,34 @@ quiesce_app_walkthrough_processes_script() {
   cat <<QUIESCE_SCRIPT
 set -euo pipefail
 packages_stopped() {
-  for package in com.pocketshell.next.test com.pocketshell.next; do
+  for package in com.pocketshell.app.test com.pocketshell.app; do
     if ! '$ADB' shell dumpsys package "\$package" 2>/dev/null | grep -q 'stopped=true'; then
       return 1
     fi
   done
 }
 processes_stopped() {
-  if ! '$ADB' shell ps -A | grep -E 'com[.]pocketshell[.]next(\$|:|[[:space:]])|com[.]pocketshell[.]next[.]test(\$|:|[[:space:]])' >/dev/null; then
+  if ! '$ADB' shell ps -A | grep -E 'com[.]pocketshell[.]app(\$|:|[[:space:]])|com[.]pocketshell[.]app[.]test(\$|:|[[:space:]])' >/dev/null; then
     return 0
   fi
   return 1
 }
 dump_quiesce_context() {
     printf 'Visible PocketShell processes:\n' >&2
-    '$ADB' shell ps -A | grep -E 'com[.]pocketshell[.]next(\$|:|[[:space:]])|com[.]pocketshell[.]next[.]test(\$|:|[[:space:]])' >&2 || true
+    '$ADB' shell ps -A | grep -E 'com[.]pocketshell[.]app(\$|:|[[:space:]])|com[.]pocketshell[.]app[.]test(\$|:|[[:space:]])' >&2 || true
     printf 'Package paths:\n' >&2
-    for package in com.pocketshell.next.test com.pocketshell.next; do
+    for package in com.pocketshell.app.test com.pocketshell.app; do
       '$ADB' shell pm path "\$package" >&2 || true
     done
     printf 'Package stopped state:\n' >&2
-    for package in com.pocketshell.next.test com.pocketshell.next; do
+    for package in com.pocketshell.app.test com.pocketshell.app; do
       '$ADB' shell dumpsys package "\$package" 2>/dev/null | grep 'stopped=' >&2 || true
     done
     printf 'Recent package manager and activity context:\n' >&2
-    '$ADB' logcat -d -v time -t 500 | grep -E 'PackageManager|PackageInstaller|PACKAGE_|ActivityManager.*com[.]pocketshell[.]next|Force stopping|deletePackageX' >&2 || true
+    '$ADB' logcat -d -v time -t 500 | grep -E 'PackageManager|PackageInstaller|PACKAGE_|ActivityManager.*com[.]pocketshell[.]app|Force stopping|deletePackageX' >&2 || true
 }
 for attempt in 1 2 3; do
-  for package in com.pocketshell.next.test com.pocketshell.next; do
+  for package in com.pocketshell.app.test com.pocketshell.app; do
     '$ADB' shell am force-stop "\$package" || true
   done
   '$ADB' shell cmd package wait-for-handler --timeout 60000 >/dev/null 2>&1 || true
@@ -1212,7 +1212,7 @@ install_or_fallback_uninstall() {
   fi
   if printf '%s\n' "\$output" | grep -q 'INSTALL_FAILED_UPDATE_INCOMPATIBLE'; then
     printf 'LEGACY-V1: uninstall fallback for incompatible app package before migration setup\n'
-    '$ADB' uninstall com.pocketshell.next >/dev/null 2>&1 || true
+    '$ADB' uninstall com.pocketshell.app >/dev/null 2>&1 || true
     wait_package_manager_idle
     '$ADB' install -r -d -t '$APK_PATH'
     wait_package_manager_idle
@@ -1227,7 +1227,7 @@ adb_output_has_transport_drop_markers() {
 
 logcat_has_app_crash_signature() {
   [ -f "\$1" ] || return 1
-  grep -Eiq 'Room cannot verify|Expected identity hash|Process: com[.]pocketshell[.]next|FATAL EXCEPTION.*com[.]pocketshell[.]next|AndroidRuntime.*com[.]pocketshell[.]next' "\$1"
+  grep -Eiq 'Room cannot verify|Expected identity hash|Process: com[.]pocketshell[.]app|FATAL EXCEPTION.*com[.]pocketshell[.]app|AndroidRuntime.*com[.]pocketshell[.]app' "\$1"
 }
 
 logcat_has_adb_transport_drop_markers() {
@@ -1457,23 +1457,23 @@ run_migration_scenario() {
   migrated_db_dir_host='$RUN_DIR/migrated-'"\$scenario"'-database'
   migrated_db_host="\$migrated_db_dir_host/pocketshell.db"
 
-  '$ADB' shell am force-stop com.pocketshell.next >/dev/null 2>&1 || true
+  '$ADB' shell am force-stop com.pocketshell.app >/dev/null 2>&1 || true
   install_or_fallback_uninstall
   printf 'LEGACY-V1: clearing app data before injecting %s fixture\n' "\$scenario"
-  '$ADB' shell pm clear com.pocketshell.next
+  '$ADB' shell pm clear com.pocketshell.app
   wait_package_manager_idle
   '$ADB' push "\$source_db" "\$staged_db_device"
-  '$ADB' shell run-as com.pocketshell.next sh -c "'mkdir -p databases && cp \$staged_db_device databases/pocketshell.db && chmod 600 databases/pocketshell.db && rm -f databases/pocketshell.db-wal databases/pocketshell.db-shm databases/pocketshell.db-journal'"
+  '$ADB' shell run-as com.pocketshell.app sh -c "'mkdir -p databases && cp \$staged_db_device databases/pocketshell.db && chmod 600 databases/pocketshell.db && rm -f databases/pocketshell.db-wal databases/pocketshell.db-shm databases/pocketshell.db-journal'"
   '$ADB' shell rm -f "\$staged_db_device" >/dev/null 2>&1 || true
 
   for attempt in \$(seq 1 '$LEGACY_V1_DB_MIGRATION_ATTEMPTS'); do
     attempt_logcat_file='$RUN_DIR/legacy-v1-'"\$scenario"'-attempt'"\$attempt"'.log'
     rm -f "\$attempt_logcat_file"
     '$ADB' logcat -c || true
-    '$ADB' shell am force-stop com.pocketshell.next >/dev/null 2>&1 || true
+    '$ADB' shell am force-stop com.pocketshell.app >/dev/null 2>&1 || true
 
     set +e
-    start_output=\$('$ADB' shell am start -W -n com.pocketshell.next/.MainActivity 2>&1)
+    start_output=\$('$ADB' shell am start -W -n com.pocketshell.app/com.pocketshell.next.MainActivity 2>&1)
     start_status=\$?
     set -e
     printf '%s\n' "\$start_output"
@@ -1485,7 +1485,7 @@ run_migration_scenario() {
     fi
 
     set +e
-    pid_output=\$('$ADB' shell pidof com.pocketshell.next 2>&1)
+    pid_output=\$('$ADB' shell pidof com.pocketshell.app 2>&1)
     pid_status=\$?
     set -e
     pid=""
@@ -1532,7 +1532,7 @@ run_migration_scenario() {
     break
   done
 
-  '$ADB' shell am force-stop com.pocketshell.next >/dev/null 2>&1 || true
+  '$ADB' shell am force-stop com.pocketshell.app >/dev/null 2>&1 || true
   '$ADB' shell sync >/dev/null 2>&1 || true
   mkdir -p "\$migrated_db_dir_host"
   rm -f \
@@ -1542,7 +1542,7 @@ run_migration_scenario() {
   for suffix in '' '-wal' '-shm'; do
     pulled_file="\$migrated_db_dir_host/pocketshell.db\$suffix"
     set +e
-    '$ADB' exec-out run-as com.pocketshell.next \
+    '$ADB' exec-out run-as com.pocketshell.app \
       cat "databases/pocketshell.db\$suffix" > "\$pulled_file" 2>/dev/null
     pull_status=\$?
     set -e
@@ -1724,7 +1724,7 @@ dump_instrumentation_diagnostics() {
     printf '=== filtered logcat crash context ===\n'
     if [ -f "\$full_logcat_file" ]; then
       grep -E -C 80 \
-        'AndroidRuntime|FATAL EXCEPTION|FATAL SIGNAL|Process: com[.]pocketshell[.]next|ActivityManager.*(Crash|Killing|Force stopping).*com[.]pocketshell[.]next|am_crash|TestRunner|AndroidJUnitRunner|Instrumentation' \
+        'AndroidRuntime|FATAL EXCEPTION|FATAL SIGNAL|Process: com[.]pocketshell[.]app|ActivityManager.*(Crash|Killing|Force stopping).*com[.]pocketshell[.]app|am_crash|TestRunner|AndroidJUnitRunner|Instrumentation' \
         "\$full_logcat_file" || true
     else
       printf 'Full logcat artifact was not created: %s\n' "\$full_logcat_file"
@@ -1750,7 +1750,7 @@ instrumentation_output_has_failure_markers() {
 }
 
 logcat_has_app_or_test_failure_markers() {
-  grep -Eq 'Process: com[.]pocketshell[.]next|FATAL EXCEPTION.*com[.]pocketshell[.]next|FATAL SIGNAL.*com[.]pocketshell[.]next|AndroidRuntime.*com[.]pocketshell[.]next|(^|[[:space:]])FAILURES!!!($|[[:space:]])|INSTRUMENTATION_STATUS: stack=|INSTRUMENTATION_RESULT: shortMsg=Process crashed' "\$full_logcat_file"
+  grep -Eq 'Process: com[.]pocketshell[.]app|FATAL EXCEPTION.*com[.]pocketshell[.]app|FATAL SIGNAL.*com[.]pocketshell[.]app|AndroidRuntime.*com[.]pocketshell[.]app|(^|[[:space:]])FAILURES!!!($|[[:space:]])|INSTRUMENTATION_STATUS: stack=|INSTRUMENTATION_RESULT: shortMsg=Process crashed' "\$full_logcat_file"
 }
 
 logcat_has_adb_transport_drop_markers() {
@@ -1802,7 +1802,7 @@ cold_reboot_emulator_for_gl_recovery() {
   else
     printf 'No EGL/101010-2 logcat marker in the captured window; recovering on the compose-hierarchy signature alone.\n' >&2
   fi
-  for package in com.pocketshell.next.test com.pocketshell.next; do
+  for package in com.pocketshell.app.test com.pocketshell.app; do
     '$ADB' shell am force-stop "\$package" >/dev/null 2>&1 || true
   done
   '$ADB' reboot >/dev/null 2>&1 || true
@@ -1850,7 +1850,7 @@ max_instrumentation_runs=\$(( app_walkthrough_instrumentation_attempts + max_tra
 while [ "\$attempt" -le "\$max_instrumentation_runs" ]; do
   '$ADB' logcat -c || true
   set +e
-  output=\$('$ADB' shell am instrument -w -r com.pocketshell.next.test/com.pocketshell.next.HiltNextTestRunner 2>&1)
+  output=\$('$ADB' shell am instrument -w -r com.pocketshell.app.test/com.pocketshell.next.HiltNextTestRunner 2>&1)
   instrument_status=\$?
   set -e
   if [ "\$instrument_status" -ne 0 ]; then
@@ -1877,10 +1877,10 @@ while [ "\$attempt" -le "\$max_instrumentation_runs" ]; do
   fi
   if [ "\$attempt" -eq 1 ] &&
     { printf '%s\n' "\$output" | grep -q 'Process crashed'; } &&
-    grep -q 'Crash of app com[.]pocketshell[.]next running instrumentation' "\$full_logcat_file"; then
+    grep -q 'Crash of app com[.]pocketshell[.]app running instrumentation' "\$full_logcat_file"; then
     cp "\$full_logcat_file" "\$full_logcat_file.attempt1" || true
     printf 'Focused instrumentation crashed after external app force-stop; retrying selector once.\n' >&2
-    for package in com.pocketshell.next.test com.pocketshell.next; do
+    for package in com.pocketshell.app.test com.pocketshell.app; do
       '$ADB' shell am force-stop "\$package" >/dev/null 2>&1 || true
     done
     '$ADB' shell cmd package wait-for-handler --timeout 60000 >/dev/null 2>&1 || true
@@ -1897,7 +1897,7 @@ while [ "\$attempt" -le "\$max_instrumentation_runs" ]; do
     printf 'Focused instrumentation interrupted by adb transport drop on attempt %s; recovery %s/%s; retrying selector without treating it as an app/test retry.\n' "\$attempt" "\$transport_recovery_attempts" "\$max_transport_recovery_attempts" >&2
     '$ADB' reconnect >/dev/null 2>&1 || true
     timeout 60s '$ADB' wait-for-device >/dev/null 2>&1 || true
-    for package in com.pocketshell.next.test com.pocketshell.next; do
+    for package in com.pocketshell.app.test com.pocketshell.app; do
       '$ADB' shell am force-stop "\$package" >/dev/null 2>&1 || true
     done
     '$ADB' shell cmd package wait-for-handler --timeout 60000 >/dev/null 2>&1 || true
@@ -2167,7 +2167,7 @@ run_step "record-validated-apk-identity" \
   "$(cd "$(dirname "$TEST_APK_PATH")" && pwd)/$(basename "$TEST_APK_PATH")"
 
 # Issue #2481: this proof is REPOINTED at app2, not deleted. app2 runs under its
-# own applicationId (`com.pocketshell.next`) today, so no real device has a
+# own applicationId (`com.pocketshell.app`) today, so no real device has a
 # legacy `pocketshell.db` in its sandbox yet — but app2 reads the SAME schema
 # from :shared:core-storage and deliberately wires the whole migration array
 # (app2/src/main/java/com/pocketshell/next/di/AppModule.kt: "an install that
@@ -2233,7 +2233,7 @@ fi
 APP2_JOURNEY_SCREENSHOT_DIR="$RUN_DIR/journey-screenshots"
 mkdir -p "$APP2_JOURNEY_SCREENSHOT_DIR"
 run_step "pull-app2-journey-screenshots" bash -lc \
-  "'$ADB' pull /sdcard/Android/data/com.pocketshell.next/files '$APP2_JOURNEY_SCREENSHOT_DIR' >/dev/null 2>&1 || printf 'no journey screenshots were pulled (best effort)\\n'; find '$APP2_JOURNEY_SCREENSHOT_DIR' -type f -name '*.png' | sort" ||
+  "'$ADB' pull /sdcard/Android/data/com.pocketshell.app/files '$APP2_JOURNEY_SCREENSHOT_DIR' >/dev/null 2>&1 || printf 'no journey screenshots were pulled (best effort)\\n'; find '$APP2_JOURNEY_SCREENSHOT_DIR' -type f -name '*.png' | sort" ||
   printf 'WARN: journey screenshot collection failed; the suite result above is unaffected (issue #2481).\n' >&2
 
 # Issue #2064: this step used to re-run the app module's `assembleDebug` after

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,6 +48,6 @@ include(":shared:ui-kit")
 // settle-pump, consumed via `testImplementation` only — never ships in the APK.
 include(":shared:test-support")
 
-// The rewrite's application module (task M-1), applicationId
-// `com.pocketshell.next` so it installs side by side with the old client.
+// The rewrite's application module (task M-1). applicationId is
+// `com.pocketshell.app` so a 0.5.0 install upgrades the existing client.
 include(":app2")

--- a/tests/scripts/connected-test-serial-ownership-test.sh
+++ b/tests/scripts/connected-test-serial-ownership-test.sh
@@ -423,7 +423,7 @@ for arg in "$@"; do
     -PpocketshellAppIdSuffix=*) suffix="${arg#*=}" ;;
   esac
 done
-package="com.pocketshell.next${suffix:+.$suffix}"
+package="com.pocketshell.app${suffix:+.$suffix}"
 printf '%s\n' "$serial" > "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.serial"
 printf '%s\n' "$*" > "$FAKE_DEVICE_STATE/$FAKE_RUN_ID.gradle-args"
 
@@ -461,7 +461,7 @@ guard="$FAKE_DEVICE_STATE/mutating-$serial"
 if ! mkdir "$guard" 2>/dev/null; then
   printf '%s overlap %s\n' "$FAKE_RUN_ID" "$serial" >> "$FAKE_DEVICE_STATE/events"
   touch "$FAKE_DEVICE_STATE/overlap"
-  for active in "$FAKE_DEVICE_STATE"/active-com.pocketshell.next*; do
+  for active in "$FAKE_DEVICE_STATE"/active-com.pocketshell.app*; do
     [[ -e "$active" ]] || continue
     victim="${active##*/active-}"
     touch "$FAKE_DEVICE_STATE/killed-$victim"
@@ -656,7 +656,7 @@ assert_mixed_order_serialises() {
 
   [[ ! -e "$sandbox/device-state/overlap" ]] \
     || fail "pool/legacy mutation windows overlapped"
-  [[ ! -e "$sandbox/device-state/killed-com.pocketshell.next.i1737a" ]] \
+  [[ ! -e "$sandbox/device-state/killed-com.pocketshell.app.i1737a" ]] \
     || fail "first instrumentation package was killed"
   grep -q '^first instrumentation-survived emulator-5554 ' "$sandbox/device-state/events" \
     || fail "first instrumentation survival was not recorded"
@@ -939,7 +939,7 @@ holder_loss_at_gradle_boundary_fails_before_mutation() {
 assert_holder_loss_at_cleanup_boundary_fails_closed() {
   local sandbox="$1" run_id="$2" ignore_term="$3"
   make_sandbox "$sandbox"
-  printf 'com.pocketshell.next.i1737stale\n' \
+  printf 'com.pocketshell.app.i1737stale\n' \
     > "$sandbox/device-state/packages-emulator-5554"
 
   local cleanup_pid contender_pid cleanup_rc ignore_term_run_id=""

--- a/tests/scripts/walkthrough-visual-retry-test.sh
+++ b/tests/scripts/walkthrough-visual-retry-test.sh
@@ -76,11 +76,23 @@ fi
 pass_case "instrumentation crash result marker was treated as retryable"
 
 printf 'INSTRUMENTATION_STATUS: numtests=1\n' > "$classification_log"
-printf '05-30 10:00:00.000  123  456 E AndroidRuntime: Process: com.pocketshell.next\n' > "$classification_logcat"
+printf '05-30 10:00:00.000  123  456 E AndroidRuntime: Process: com.pocketshell.app\n' > "$classification_logcat"
 if visual_audit_should_retry_interrupted_instrumentation 255 "$classification_log" "$classification_logcat"; then
   fail "app crash marker was treated as retryable"
 fi
 pass_case "app crash marker was treated as retryable"
+
+printf '05-30 10:00:00.000  123  456 E AndroidRuntime: Process: com.pocketshell.app\n' > "$classification_logcat"
+if ! visual_audit_logcat_has_app_or_test_failure_markers "$classification_logcat"; then
+  fail "Process: com.pocketshell.app was not classified as an app crash marker"
+fi
+pass_case "Process: com.pocketshell.app is an app crash marker"
+
+printf '05-30 10:00:00.000  123  456 E AndroidRuntime: Process: com.pocketshell.next\n' > "$classification_logcat"
+if visual_audit_logcat_has_app_or_test_failure_markers "$classification_logcat"; then
+  fail "Process: com.pocketshell.next was still classified as the shipping install id"
+fi
+pass_case "Process: com.pocketshell.next is not the shipping install id"
 
 printf 'INSTRUMENTATION_CODE: -1\nOK (1 test)\n' > "$classification_log"
 printf '05-30 10:00:00.000  123  456 I adbd    : offline\n' > "$classification_logcat"
@@ -152,8 +164,8 @@ chmod +x "$fake_adb"
 RUN_DIR="$tmpdir/run"
 ADB="$fake_adb"
 DEVICE_OUTPUT_DIR="/sdcard/fake-output"
-TEST_PACKAGE="com.pocketshell.next.test"
-APP_PACKAGE="com.pocketshell.next"
+TEST_PACKAGE="com.pocketshell.app.test"
+APP_PACKAGE="com.pocketshell.app"
 INSTRUMENTATION_ATTEMPTS=2
 FAKE_ADB_STATE="$tmpdir/adb-state"
 export FAKE_ADB_STATE
@@ -175,5 +187,5 @@ pass_case "canonical instrumentation log did not contain final success"
 # Issue #2113: a harness that exits 0 having run nothing is the vacuous green
 # process.md catalogues. The count line is what makes the JVM assertion about
 # behaviour rather than about bash's exit status.
-(( CASES == 14 )) || fail "expected 14 cases to run, saw $CASES"
+(( CASES == 16 )) || fail "expected 16 cases to run, saw $CASES"
 printf 'PASS: walkthrough visual retry helper (%s cases)\n' "$CASES"


### PR DESCRIPTION
Closes #2519

Ship 0.5.0 as `com.pocketshell.app` (same debug.keystore as v0.4.47) so `adb install -r` upgrades the existing PocketShell instead of installing a second app.

Kotlin namespace stays `com.pocketshell.next`. Launch component is `com.pocketshell.app/com.pocketshell.next.MainActivity`.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2519#issuecomment-5551945479