### PR TITLE
feat: restore engine and backend pickers on New session

### DIFF
--- a/app2/src/main/java/com/pocketshell/next/tree/CreateSessionSheet.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/CreateSessionSheet.kt
@@ -3,11 +3,15 @@ package com.pocketshell.next.tree
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -25,10 +29,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.pocketshell.core.hostapi.Backend
+import com.pocketshell.core.hostapi.EngineInfo
+import com.pocketshell.core.hostapi.ProfileInfo
 import com.pocketshell.uikit.components.Banner
 import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.uikit.components.SectionHeader
+import com.pocketshell.uikit.components.SegmentedToggle
 import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
@@ -47,6 +57,18 @@ const val CREATE_SESSION_NAME_TAG: String = "create-session-name"
 const val CREATE_SESSION_SUBMIT_TAG: String = "create-session-submit"
 const val CREATE_SESSION_CANCEL_TAG: String = "create-session-cancel"
 const val CREATE_SESSION_ERROR_TAG: String = "create-session-error"
+const val CREATE_SESSION_TYPE_SHELL_TAG: String = "create-session-type-shell"
+const val CREATE_SESSION_TYPE_AGENT_TAG: String = "create-session-type-agent"
+const val CREATE_SESSION_ENGINE_TAG_PREFIX: String = "create-session-engine-"
+const val CREATE_SESSION_PROFILE_TAG: String = "create-session-profile"
+const val CREATE_SESSION_BACKEND_DEFAULT_TAG: String = "create-session-backend-default"
+const val CREATE_SESSION_BACKEND_TMUX_TAG: String = "create-session-backend-tmux"
+const val CREATE_SESSION_BACKEND_APLEXER_TAG: String = "create-session-backend-aplexer"
+const val CREATE_SESSION_NO_ENGINES_TAG: String = "create-session-no-engines"
+
+fun createSessionEngineTag(engineId: String): String = "$CREATE_SESSION_ENGINE_TAG_PREFIX$engineId"
+
+fun createSessionProfileTag(profileName: String): String = "$CREATE_SESSION_PROFILE_TAG-$profileName"
 
 internal const val CREATE_SESSION_TITLE = "New session"
 internal const val CREATE_SESSION_FOLDER_LABEL = "Folder"
@@ -56,6 +78,79 @@ internal const val CREATE_SESSION_CANCEL_LABEL = "Cancel"
 internal const val CREATE_SESSION_HINT =
     "The session starts detached in this folder. Leave the folder blank to use " +
         "the host's default."
+internal const val CREATE_SESSION_TYPE_LABEL = "Session type"
+internal const val CREATE_SESSION_ENGINE_LABEL = "Agent engine"
+internal const val CREATE_SESSION_PROFILE_LABEL = "Profile"
+internal const val CREATE_SESSION_BACKEND_LABEL = "Backend"
+internal const val CREATE_SESSION_NO_ENGINES =
+    "No agent engines are available on this host."
+internal const val CREATE_SESSION_ENGINE_HINT =
+    "The engine will auto-start in the new pane."
+internal const val CREATE_SESSION_BACKEND_HINT =
+    "Default uses the host's [backends] config."
+internal const val CREATE_SESSION_LOADING_ENGINES = "Loading engines…"
+
+private val CREATE_SESSION_TYPE_LABELS = listOf("Shell", "Agent")
+private val CREATE_SESSION_BACKEND_LABELS = listOf("Default", "tmux", "aplexer")
+private val PICKER_SEGMENT_HEIGHT = 48.dp
+private const val CREATE_SESSION_HEIGHT_FRACTION = 0.85f
+private val CREATE_SESSION_MAX_HEIGHT = 560.dp
+
+/** Shell (plain pane) vs Agent (host starts an engine in the new session). */
+enum class CreateSessionKind { Shell, Agent }
+
+/**
+ * Backend override for `sessions create --backend`.
+ *
+ * [HostDefault] omits the flag so the host's `[backends]` config stays in
+ * charge — an explicit `tmux`/`aplexer` is what beats that config.
+ */
+enum class CreateSessionBackend {
+    HostDefault,
+    Tmux,
+    Aplexer,
+    ;
+
+    val flag: String?
+        get() = when (this) {
+            HostDefault -> null
+            Tmux -> Backend.WIRE_TMUX
+            Aplexer -> Backend.WIRE_APLEXER
+        }
+}
+
+/**
+ * What the sheet asks `sessions create` to do. Optional flags are `null`
+ * rather than blank so [com.pocketshell.core.hostapi.HostCliClient.createSession]
+ * omits them and the host's own defaults apply.
+ */
+data class CreateSessionRequest(
+    val name: String,
+    val cwd: String?,
+    val engine: String? = null,
+    val profile: String? = null,
+    val backend: String? = null,
+)
+
+/**
+ * The only rows the Agent engine picker may offer: enabled AND available AND
+ * the host's own `available_for_create` verdict. Disabled, missing-harness,
+ * and not-createable rows stay off the chips (issue #2439 / #2522). Aplexer's
+ * `shell` engine is never an agent, even if a host listed it as createable.
+ */
+fun availableEnginesForCreate(engines: List<EngineInfo>): List<EngineInfo> =
+    engines.filter { engine ->
+        engine.availableForCreate &&
+            engine.enabled &&
+            engine.available &&
+            engine.id != "shell"
+    }
+
+/** Profiles belonging to [engineId], in host order. */
+fun profilesForEngine(profiles: List<ProfileInfo>, engineId: String?): List<ProfileInfo> {
+    if (engineId == null) return emptyList()
+    return profiles.filter { it.engine == engineId }
+}
 
 /**
  * The session name derived from a folder path — the LAST path segment.
@@ -101,6 +196,9 @@ fun defaultSessionName(folder: String): String {
  * [name] tracks [folder] only until the user edits the name themselves; after
  * that the field is theirs and a later folder edit leaves it alone. Silently
  * overwriting a typed name would be the worse behaviour of the two.
+ *
+ * Kind defaults to [CreateSessionKind.Shell] so a one-tap create (journey J04)
+ * is still a plain shell session; Agent is an explicit pick.
  */
 @Stable
 class CreateSessionFormState(initialFolder: String = "") {
@@ -115,6 +213,18 @@ class CreateSessionFormState(initialFolder: String = "") {
     var nameEdited: Boolean by mutableStateOf(false)
         private set
 
+    var kind: CreateSessionKind by mutableStateOf(CreateSessionKind.Shell)
+        private set
+
+    var engineId: String? by mutableStateOf(null)
+        private set
+
+    var profileName: String? by mutableStateOf(null)
+        private set
+
+    var backend: CreateSessionBackend by mutableStateOf(CreateSessionBackend.HostDefault)
+        private set
+
     fun onFolderChange(value: String) {
         folder = value
         if (!nameEdited) name = defaultSessionName(value)
@@ -125,6 +235,23 @@ class CreateSessionFormState(initialFolder: String = "") {
         nameEdited = true
     }
 
+    fun onKindChange(value: CreateSessionKind) {
+        kind = value
+    }
+
+    fun onEngineChange(value: String?) {
+        engineId = value
+        profileName = null
+    }
+
+    fun onProfileChange(value: String?) {
+        profileName = value
+    }
+
+    fun onBackendChange(value: CreateSessionBackend) {
+        backend = value
+    }
+
     /** The host requires a name, so a blank one can never be submitted. */
     val canSubmit: Boolean get() = name.isNotBlank()
 
@@ -133,16 +260,46 @@ class CreateSessionFormState(initialFolder: String = "") {
 
     /** `--cwd`, or `null` so the host's own default working directory applies. */
     val submittedCwd: String? get() = folder.trim().ifBlank { null }
+
+    /**
+     * Agent create needs a createable engine. Shell never does. [available]
+     * is the already-filtered picker list so this does not re-derive the
+     * #2439 hide rule.
+     */
+    fun canSubmitWith(available: List<EngineInfo>): Boolean =
+        canSubmit && (kind == CreateSessionKind.Shell || available.isNotEmpty())
+
+    /** Flags the host CLI will see; omitted ones stay `null`. */
+    fun toRequest(
+        engines: List<EngineInfo>,
+        profiles: List<ProfileInfo>,
+    ): CreateSessionRequest {
+        val available = availableEnginesForCreate(engines)
+        val engine = if (kind == CreateSessionKind.Agent) {
+            available.firstOrNull { it.id == engineId } ?: available.firstOrNull()
+        } else {
+            null
+        }
+        val engineProfiles = profilesForEngine(profiles, engine?.id)
+        val profile = engine?.let {
+            val chosen = profileName ?: return@let null
+            engineProfiles.firstOrNull { profile -> profile.name == chosen }?.name
+        }
+        return CreateSessionRequest(
+            name = submittedName,
+            cwd = submittedCwd,
+            engine = engine?.id,
+            profile = profile,
+            backend = backend.flag,
+        )
+    }
 }
 
 /**
- * The create-session bottom sheet (rewrite task U-6, journey J04).
+ * The create-session bottom sheet (rewrite task U-6, journey J04, issue #2522).
  *
- * Folder + name only. There is deliberately no engine/profile picker: the
- * rewrite's scope amendment (docs/rewrite-implementation-plan.md, "Scope
- * amendment") cut agent launching from the client entirely, so this sheet
- * creates a plain shell session and `createSession`'s `engine`/`profile`
- * parameters are always `null` here.
+ * Folder + name, plus the v0.4.47 create interaction restored: Shell vs Agent,
+ * an engine/profile picker fed by the host registry, and tmux vs aplexer.
  *
  * Dismissing the sheet (scrim tap / back / drag-down) routes to [onCancel],
  * so backing out can never be mistaken for a create.
@@ -152,7 +309,7 @@ class CreateSessionFormState(initialFolder: String = "") {
 fun CreateSessionSheet(
     state: CreateSessionState,
     defaultFolder: String,
-    onSubmit: (name: String, cwd: String?) -> Unit,
+    onSubmit: (CreateSessionRequest) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
     // `skipPartiallyExpanded` is load-bearing, not a style choice: a modal sheet
@@ -190,7 +347,7 @@ fun CreateSessionSheet(
 fun CreateSessionSheetContent(
     state: CreateSessionState,
     defaultFolder: String,
-    onSubmit: (name: String, cwd: String?) -> Unit,
+    onSubmit: (CreateSessionRequest) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
     form: CreateSessionFormState = remember(defaultFolder) {
@@ -206,66 +363,166 @@ fun CreateSessionSheetContent(
         unfocusedLabelColor = PocketShellColors.TextSecondary,
         cursorColor = PocketShellColors.Accent,
     )
+    val available = availableEnginesForCreate(state.engines)
+    val selectedEngine = if (form.kind == CreateSessionKind.Agent) {
+        available.firstOrNull { it.id == form.engineId } ?: available.firstOrNull()
+    } else {
+        null
+    }
+    val engineProfiles = profilesForEngine(state.profiles, selectedEngine?.id)
+    val selectedProfileIndex = engineProfiles
+        .indexOfFirst { it.name == form.profileName }
+        .let { index -> if (index >= 0) index else engineProfiles.indexOfFirst { it.isDefault } }
+        .coerceAtLeast(0)
 
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .fillMaxHeight(CREATE_SESSION_HEIGHT_FRACTION)
+            .heightIn(max = CREATE_SESSION_MAX_HEIGHT)
             .testTag(CREATE_SESSION_SHEET_TAG)
-            .padding(horizontal = PocketShellSpacing.lg)
-            .padding(bottom = PocketShellSpacing.lg)
             .navigationBarsPadding()
             .imePadding(),
-        verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
     ) {
-        SheetHeader(
-            title = CREATE_SESSION_TITLE,
-            subtitle = CREATE_SESSION_HINT,
-            titleTestTag = CREATE_SESSION_TITLE_TAG,
-        )
-
-        // A failed create keeps the sheet open with the user's own text still
-        // in the fields: the fix for "that folder does not exist" is an edit,
-        // and a sheet that closed on failure would throw the edit away.
-        state.failure?.let { failure ->
-            Banner(
-                text = failure,
-                role = BannerRole.Error,
-                maxLines = 4,
-                modifier = Modifier.testTag(CREATE_SESSION_ERROR_TAG),
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = PocketShellSpacing.lg)
+                .padding(top = PocketShellSpacing.lg, bottom = PocketShellSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
+        ) {
+            SheetHeader(
+                title = CREATE_SESSION_TITLE,
+                subtitle = CREATE_SESSION_HINT,
+                titleTestTag = CREATE_SESSION_TITLE_TAG,
             )
+
+            // A failed create keeps the sheet open with the user's own text still
+            // in the fields: the fix for "that folder does not exist" is an edit,
+            // and a sheet that closed on failure would throw the edit away.
+            state.failure?.let { failure ->
+                Banner(
+                    text = failure,
+                    role = BannerRole.Error,
+                    maxLines = 4,
+                    modifier = Modifier.testTag(CREATE_SESSION_ERROR_TAG),
+                )
+            }
+
+            OutlinedTextField(
+                value = form.folder,
+                onValueChange = form::onFolderChange,
+                singleLine = true,
+                enabled = !state.submitting,
+                label = { Text(CREATE_SESSION_FOLDER_LABEL) },
+                placeholder = { Text("/home/you/git/project") },
+                colors = fieldColors,
+                textStyle = PocketShellType.bodyMono,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(CREATE_SESSION_FOLDER_TAG),
+            )
+
+            OutlinedTextField(
+                value = form.name,
+                onValueChange = form::onNameChange,
+                singleLine = true,
+                enabled = !state.submitting,
+                label = { Text(CREATE_SESSION_NAME_LABEL) },
+                colors = fieldColors,
+                textStyle = PocketShellType.bodyMono,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(CREATE_SESSION_NAME_TAG),
+            )
+
+            Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
+                SectionHeader(label = CREATE_SESSION_TYPE_LABEL)
+                SegmentedToggle(
+                    labels = CREATE_SESSION_TYPE_LABELS,
+                    selectedIndex = if (form.kind == CreateSessionKind.Shell) 0 else 1,
+                    onSelected = { index ->
+                        form.onKindChange(
+                            if (index == 0) CreateSessionKind.Shell else CreateSessionKind.Agent,
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = PICKER_SEGMENT_HEIGHT),
+                    fillSegments = true,
+                    segmentTag = { index ->
+                        if (index == 0) CREATE_SESSION_TYPE_SHELL_TAG else CREATE_SESSION_TYPE_AGENT_TAG
+                    },
+                )
+            }
+
+            if (form.kind == CreateSessionKind.Agent) {
+                AgentEnginePicker(
+                    available = available,
+                    selectedEngineId = selectedEngine?.id,
+                    loading = state.enginesLoading && available.isEmpty(),
+                    failure = state.enginesFailure,
+                    enabled = !state.submitting,
+                    onSelect = form::onEngineChange,
+                )
+                if (engineProfiles.size > 1) {
+                    Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
+                        SectionHeader(label = CREATE_SESSION_PROFILE_LABEL)
+                        SegmentedToggle(
+                            labels = engineProfiles.map { it.name },
+                            selectedIndex = selectedProfileIndex,
+                            onSelected = { index ->
+                                form.onProfileChange(engineProfiles[index].name)
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = PICKER_SEGMENT_HEIGHT)
+                                .testTag(CREATE_SESSION_PROFILE_TAG),
+                            fillSegments = true,
+                            segmentTag = { index ->
+                                createSessionProfileTag(engineProfiles[index].name)
+                            },
+                        )
+                    }
+                }
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
+                SectionHeader(label = CREATE_SESSION_BACKEND_LABEL)
+                SegmentedToggle(
+                    labels = CREATE_SESSION_BACKEND_LABELS,
+                    selectedIndex = form.backend.ordinal,
+                    onSelected = { index ->
+                        form.onBackendChange(CreateSessionBackend.entries[index])
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = PICKER_SEGMENT_HEIGHT),
+                    fillSegments = true,
+                    segmentTag = { index ->
+                        when (index) {
+                            0 -> CREATE_SESSION_BACKEND_DEFAULT_TAG
+                            1 -> CREATE_SESSION_BACKEND_TMUX_TAG
+                            else -> CREATE_SESSION_BACKEND_APLEXER_TAG
+                        }
+                    },
+                )
+                Text(
+                    text = CREATE_SESSION_BACKEND_HINT,
+                    color = PocketShellColors.TextMuted,
+                    style = PocketShellType.labelMono,
+                )
+            }
         }
 
-        OutlinedTextField(
-            value = form.folder,
-            onValueChange = form::onFolderChange,
-            singleLine = true,
-            enabled = !state.submitting,
-            label = { Text(CREATE_SESSION_FOLDER_LABEL) },
-            placeholder = { Text("/home/you/git/project") },
-            colors = fieldColors,
-            textStyle = PocketShellType.bodyMono,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag(CREATE_SESSION_FOLDER_TAG),
-        )
-
-        OutlinedTextField(
-            value = form.name,
-            onValueChange = form::onNameChange,
-            singleLine = true,
-            enabled = !state.submitting,
-            label = { Text(CREATE_SESSION_NAME_LABEL) },
-            colors = fieldColors,
-            textStyle = PocketShellType.bodyMono,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag(CREATE_SESSION_NAME_TAG),
-        )
-
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = PocketShellSpacing.lg)
+                .padding(bottom = PocketShellSpacing.lg),
             horizontalArrangement = Arrangement.spacedBy(
                 space = PocketShellSpacing.sm,
                 alignment = Alignment.End,
@@ -280,11 +537,59 @@ fun CreateSessionSheetContent(
             )
             PocketShellButton(
                 text = if (state.submitting) "Creating…" else CREATE_SESSION_SUBMIT_LABEL,
-                onClick = { onSubmit(form.submittedName, form.submittedCwd) },
+                onClick = { onSubmit(form.toRequest(state.engines, state.profiles)) },
                 variant = ButtonVariant.Primary,
-                enabled = form.canSubmit && !state.submitting,
+                enabled = form.canSubmitWith(available) && !state.submitting,
                 modifier = Modifier.testTag(CREATE_SESSION_SUBMIT_TAG),
             )
+        }
+    }
+}
+
+@Composable
+private fun AgentEnginePicker(
+    available: List<EngineInfo>,
+    selectedEngineId: String?,
+    loading: Boolean,
+    failure: String?,
+    enabled: Boolean,
+    onSelect: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
+        when {
+            loading -> Text(
+                text = CREATE_SESSION_LOADING_ENGINES,
+                color = PocketShellColors.TextMuted,
+                style = PocketShellType.labelMono,
+            )
+            available.isEmpty() -> Text(
+                text = failure ?: CREATE_SESSION_NO_ENGINES,
+                color = PocketShellColors.TextMuted,
+                style = PocketShellType.labelMono,
+                modifier = Modifier.testTag(CREATE_SESSION_NO_ENGINES_TAG),
+            )
+            else -> {
+                SectionHeader(label = CREATE_SESSION_ENGINE_LABEL)
+                SegmentedToggle(
+                    labels = available.map { it.label },
+                    selectedIndex = available
+                        .indexOfFirst { it.id == selectedEngineId }
+                        .coerceAtLeast(0),
+                    onSelected = { index ->
+                        if (enabled) onSelect(available[index].id)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = PICKER_SEGMENT_HEIGHT),
+                    fillSegments = true,
+                    segmentTag = { index -> createSessionEngineTag(available[index].id) },
+                )
+                Text(
+                    text = CREATE_SESSION_ENGINE_HINT,
+                    color = PocketShellColors.TextMuted,
+                    style = PocketShellType.labelMono,
+                )
+            }
         }
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/tree/SessionTreeScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/SessionTreeScreen.kt
@@ -154,7 +154,7 @@ fun SessionTreeScreen(
     onOpenPorts: () -> Unit = {},
     modifier: Modifier = Modifier,
     onCreateSession: () -> Unit = {},
-    onSubmitCreate: (name: String, cwd: String?) -> Unit = { _, _ -> },
+    onSubmitCreate: (CreateSessionRequest) -> Unit = {},
     onDismissCreate: () -> Unit = {},
     nowSec: Long = System.currentTimeMillis() / 1000,
 ) {

--- a/app2/src/main/java/com/pocketshell/next/tree/SessionTreeViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/SessionTreeViewModel.kt
@@ -4,7 +4,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pocketshell.core.hostapi.BackendError
+import com.pocketshell.core.hostapi.EngineInfo
 import com.pocketshell.core.hostapi.HostCliError
+import com.pocketshell.core.hostapi.ProfileInfo
 import com.pocketshell.core.transport.ConnectResult
 import com.pocketshell.core.transport.HostConnection
 import com.pocketshell.next.connect.ConnectionsRegistry
@@ -101,6 +103,14 @@ data class CreateSessionState(
     val notice: String? = null,
     /** The session name the screen should open next, once. */
     val openRequest: String? = null,
+    /** Host `engines list --json`, unfiltered; the sheet hides disabled/unavailable. */
+    val engines: List<EngineInfo> = emptyList(),
+    /** Host `profiles list --json`; the sheet filters these to the selected engine. */
+    val profiles: List<ProfileInfo> = emptyList(),
+    /** True while the first engines/profiles read for this sheet opening is in flight. */
+    val enginesLoading: Boolean = false,
+    /** Why engines could not be listed. Agent create is unavailable; Shell still works. */
+    val enginesFailure: String? = null,
 )
 
 /**
@@ -156,6 +166,7 @@ class SessionTreeViewModel @Inject constructor(
 
     private var inFlight: Job? = null
     private var createInFlight: Job? = null
+    private var pickerInFlight: Job? = null
 
     /**
      * Re-reads the host's session list. Safe to call from `ON_START` and from
@@ -176,7 +187,17 @@ class SessionTreeViewModel @Inject constructor(
 
     /** Raises the create sheet, with no stale failure or notice on it. */
     fun openCreateSheet() {
-        updateCreate { it.copy(visible = true, failure = null, notice = null) }
+        updateCreate {
+            it.copy(
+                visible = true,
+                failure = null,
+                notice = null,
+                enginesLoading = true,
+                enginesFailure = null,
+            )
+        }
+        pickerInFlight?.cancel()
+        pickerInFlight = viewModelScope.launch { loadPickerOptions() }
     }
 
     /**
@@ -186,22 +207,32 @@ class SessionTreeViewModel @Inject constructor(
      */
     fun dismissCreateSheet() {
         updateCreate { current ->
-            if (current.submitting) current else current.copy(visible = false, failure = null)
+            if (current.submitting) {
+                current
+            } else {
+                pickerInFlight?.cancel()
+                current.copy(visible = false, failure = null, enginesLoading = false)
+            }
         }
     }
 
     /**
-     * `pocketshell sessions create --json` for [name] in [cwd], then refresh
-     * the listing and ask the screen to open it.
+     * `pocketshell sessions create --json` for [request], then refresh the
+     * listing and ask the screen to open it.
      *
      * A session that already existed comes back `created == false`, which is a
      * SUCCESS: the sheet closes, the tree refreshes and the screen opens that
      * session, with a notice saying it was already there. A FAILURE leaves the
      * sheet open with its text intact so the user can fix the folder and retry.
+     *
+     * [CreateSessionRequest.engine] / [CreateSessionRequest.profile] /
+     * [CreateSessionRequest.backend] are forwarded when set and omitted when
+     * null, so a Shell create with the host-default backend is still
+     * `sessions create --json -- NAME`.
      */
-    fun createSession(name: String, cwd: String?) {
+    fun createSession(request: CreateSessionRequest) {
         if (createInFlight?.isActive == true) return
-        val trimmedName = name.trim()
+        val trimmedName = request.name.trim()
         if (trimmedName.isEmpty()) {
             // The host CLI takes NAME as a required positional argument, so a
             // blank name is answered here rather than sent for the host to
@@ -211,7 +242,13 @@ class SessionTreeViewModel @Inject constructor(
         }
         updateCreate { it.copy(submitting = true, failure = null, notice = null) }
         createInFlight = viewModelScope.launch {
-            runCreate(trimmedName, cwd?.trim()?.takeIf { it.isNotEmpty() })
+            runCreate(
+                name = trimmedName,
+                cwd = request.cwd?.trim()?.takeIf { it.isNotEmpty() },
+                engine = request.engine?.trim()?.takeIf { it.isNotEmpty() },
+                profile = request.profile?.trim()?.takeIf { it.isNotEmpty() },
+                backend = request.backend?.trim()?.takeIf { it.isNotEmpty() },
+            )
         }
     }
 
@@ -223,16 +260,54 @@ class SessionTreeViewModel @Inject constructor(
         updateCreate { it.copy(openRequest = null) }
     }
 
-    private suspend fun runCreate(name: String, cwd: String?) {
+    private suspend fun loadPickerOptions() {
+        val connection = when (val outcome = resolveConnection()) {
+            is ConnectionOutcome.Ready -> outcome.connection
+            is ConnectionOutcome.Unavailable -> {
+                updateCreate {
+                    it.copy(enginesLoading = false, enginesFailure = outcome.message)
+                }
+                return
+            }
+        }
+        val client = clients.create(connection)
+        val engines = client.listEngines()
+        val profiles = client.listProfiles()
+        updateCreate { current ->
+            if (!current.visible) {
+                current
+            } else {
+                current.copy(
+                    enginesLoading = false,
+                    engines = engines.getOrDefault(emptyList()),
+                    profiles = profiles.getOrDefault(emptyList()),
+                    enginesFailure = engines.exceptionOrNull()?.let { error ->
+                        userMessage(error, "Could not list engines on the host: ")
+                    },
+                )
+            }
+        }
+    }
+
+    private suspend fun runCreate(
+        name: String,
+        cwd: String?,
+        engine: String?,
+        profile: String?,
+        backend: String?,
+    ) {
         val connection = when (val outcome = resolveConnection()) {
             is ConnectionOutcome.Ready -> outcome.connection
             is ConnectionOutcome.Unavailable -> return failCreate(outcome.message)
         }
         clients.create(connection)
-            // engine/profile are deliberately always null: the rewrite's scope
-            // amendment cut agent launching from the client, so this is a plain
-            // shell session (docs/rewrite-implementation-plan.md).
-            .createSession(name = name, cwd = cwd, engine = null, profile = null)
+            .createSession(
+                name = name,
+                cwd = cwd,
+                engine = engine,
+                profile = profile,
+                backend = backend,
+            )
             .fold(
                 onSuccess = { created ->
                     updateCreate {

--- a/app2/src/test/java/com/pocketshell/next/tree/CreateSessionFormStateTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/CreateSessionFormStateTest.kt
@@ -1,5 +1,7 @@
 package com.pocketshell.next.tree
 
+import com.pocketshell.core.hostapi.EngineInfo
+import com.pocketshell.core.hostapi.ProfileInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -91,4 +93,107 @@ class CreateSessionFormStateTest {
         form.onFolderChange("  /home/a/git/pocketshell ")
         assertEquals("/home/a/git/pocketshell", form.submittedCwd)
     }
+
+    /**
+     * Issue #2439 / #2522: the Agent chips are enabled+available only.
+     * A dropped-row regression (hiding a working engine) or a shown-row
+     * regression (offering a disabled/missing one) both redden here.
+     */
+    @Test
+    fun `disabled and unavailable engines are hidden, enabled plus available is shown`() {
+        val rows = availableEnginesForCreate(
+            listOf(
+                testEngine("claude", enabled = true, available = true),
+                testEngine("codex", enabled = true, available = true),
+                testEngine("opencode", enabled = true, available = false, availableForCreate = false),
+                testEngine("disabled", enabled = false, available = true, availableForCreate = false),
+                testEngine("not-createable", enabled = true, available = true, availableForCreate = false),
+                testEngine("shell", enabled = true, available = true),
+            ),
+        )
+
+        assertEquals(listOf("claude", "codex"), rows.map { it.id })
+        assertFalse(rows.any { it.id == "opencode" })
+        assertFalse(rows.any { it.id == "disabled" })
+        assertFalse(rows.any { it.id == "not-createable" })
+        assertFalse(rows.any { it.id == "shell" })
+    }
+
+    @Test
+    fun `a shell create with the host default backend omits engine profile and backend`() {
+        val form = CreateSessionFormState("/home/a/git/pocketshell")
+
+        assertEquals(
+            CreateSessionRequest(name = "pocketshell", cwd = "/home/a/git/pocketshell"),
+            form.toRequest(listOf(testEngine("claude")), emptyList()),
+        )
+    }
+
+    @Test
+    fun `an agent create forwards the selected engine and an explicit backend`() {
+        val form = CreateSessionFormState("/home/a/git/pocketshell")
+        form.onKindChange(CreateSessionKind.Agent)
+        form.onEngineChange("codex")
+        form.onBackendChange(CreateSessionBackend.Aplexer)
+
+        val request = form.toRequest(
+            engines = listOf(testEngine("claude"), testEngine("codex"), testEngine("opencode", available = false)),
+            profiles = emptyList(),
+        )
+
+        assertEquals("codex", request.engine)
+        assertNull(request.profile)
+        assertEquals("aplexer", request.backend)
+        assertEquals("pocketshell", request.name)
+    }
+
+    @Test
+    fun `an agent create forwards a profile only after the user picks one`() {
+        val form = CreateSessionFormState("/srv")
+        form.onKindChange(CreateSessionKind.Agent)
+        form.onEngineChange("claude")
+        form.onProfileChange("Claude (Z.AI)")
+
+        val request = form.toRequest(
+            engines = listOf(testEngine("claude")),
+            profiles = listOf(
+                ProfileInfo("Claude", "claude", null, isDefault = true),
+                ProfileInfo("Claude (Z.AI)", "claude", "/home/a/.zlaude", isDefault = false),
+            ),
+        )
+
+        assertEquals("claude", request.engine)
+        assertEquals("Claude (Z.AI)", request.profile)
+    }
+
+    @Test
+    fun `switching to shell drops a previously chosen engine from the request`() {
+        val form = CreateSessionFormState("/srv")
+        form.onKindChange(CreateSessionKind.Agent)
+        form.onEngineChange("claude")
+        form.onKindChange(CreateSessionKind.Shell)
+
+        val request = form.toRequest(listOf(testEngine("claude")), emptyList())
+        assertNull(request.engine)
+        assertNull(request.profile)
+    }
 }
+
+internal fun testEngine(
+    id: String,
+    label: String = id.replaceFirstChar { it.uppercase() },
+    enabled: Boolean = true,
+    available: Boolean = true,
+    availableForCreate: Boolean = enabled && available,
+): EngineInfo = EngineInfo(
+    id = id,
+    label = label,
+    family = id,
+    harness = id,
+    providerMark = "",
+    usageProvider = null,
+    enabled = enabled,
+    available = available,
+    availableForCreate = availableForCreate,
+    unavailableReason = if (availableForCreate) null else "unavailable",
+)

--- a/app2/src/test/java/com/pocketshell/next/tree/CreateSessionSheetTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/CreateSessionSheetTest.kt
@@ -1,5 +1,8 @@
 package com.pocketshell.next.tree
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -7,7 +10,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.core.hostapi.ProfileInfo
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -16,14 +21,16 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * What the create-session sheet PAINTS and what its buttons carry (task U-6).
+ * What the create-session sheet PAINTS and what its buttons carry (task U-6,
+ * issue #2522).
  *
  * Journey J04 proves the sheet creates a real session on a real host; this
  * suite pins the rules a device journey would only catch by accident: that a
  * blank name cannot be submitted at all, that Create carries the form's own
- * values (name AND `--cwd`) rather than the prefill, that Cancel creates
- * nothing, and that a failed create leaves the sheet standing with the host's
- * words on it instead of closing and losing the user's text.
+ * values (name AND `--cwd`, plus `--engine`/`--backend` when selected), that
+ * Cancel creates nothing, that a failed create leaves the sheet standing with
+ * the host's words on it instead of closing and losing the user's text, and
+ * that a disabled/unavailable engine never becomes a chip.
  *
  * The sheet's BODY is composed directly ([CreateSessionSheetContent]) rather
  * than through [CreateSessionSheet]'s `ModalBottomSheet`: the container is
@@ -40,7 +47,7 @@ class CreateSessionSheetTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun `the sheet renders both fields, the hint and both actions`() {
+    fun `the sheet renders both fields, the hint, type backend and both actions`() {
         setContent(CreateSessionState(visible = true), defaultFolder = "/home/a/git/pocketshell")
 
         composeRule.onNodeWithTag(CREATE_SESSION_SHEET_TAG).assertIsDisplayed()
@@ -48,6 +55,11 @@ class CreateSessionSheetTest {
         composeRule.onNodeWithText(CREATE_SESSION_HINT).assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_FOLDER_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_NAME_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(CREATE_SESSION_TYPE_SHELL_TAG).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithTag(CREATE_SESSION_TYPE_AGENT_TAG).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithTag(CREATE_SESSION_BACKEND_DEFAULT_TAG).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithTag(CREATE_SESSION_BACKEND_TMUX_TAG).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithTag(CREATE_SESSION_BACKEND_APLEXER_TAG).performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_CANCEL_TAG).assertIsDisplayed()
 
@@ -56,18 +68,21 @@ class CreateSessionSheetTest {
         composeRule.onNodeWithText("/home/a/git/pocketshell").assertIsDisplayed()
         composeRule.onNodeWithText("pocketshell").assertIsDisplayed()
 
+        // Shell is the default: no engine chips until Agent is picked.
+        composeRule.onNodeWithTag(createSessionEngineTag("claude")).assertDoesNotExist()
+
         // Nothing has failed, so no error banner.
         composeRule.onNodeWithTag(CREATE_SESSION_ERROR_TAG).assertDoesNotExist()
     }
 
     @Test
     fun `a blank name cannot be submitted`() {
-        val submitted = mutableListOf<Pair<String, String?>>()
+        val submitted = mutableListOf<CreateSessionRequest>()
         // No folder to derive from, so the name field starts empty.
         setContent(
             CreateSessionState(visible = true),
             defaultFolder = "",
-            onSubmit = { name, cwd -> submitted += name to cwd },
+            onSubmit = { submitted += it },
         )
 
         composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).assertIsNotEnabled()
@@ -78,48 +93,51 @@ class CreateSessionSheetTest {
 
     @Test
     fun `Create carries the forms own name and folder`() {
-        val submitted = mutableListOf<Pair<String, String?>>()
+        val submitted = mutableListOf<CreateSessionRequest>()
         val form = CreateSessionFormState("/home/a/git/pocketshell")
         form.onFolderChange("/srv/reviews")
         form.onNameChange("review-2")
         setContent(
             CreateSessionState(visible = true),
             defaultFolder = "/home/a/git/pocketshell",
-            onSubmit = { name, cwd -> submitted += name to cwd },
+            onSubmit = { submitted += it },
             form = form,
         )
 
         composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).assertIsEnabled().performClick()
 
-        assertEquals(listOf("review-2" to "/srv/reviews"), submitted)
+        assertEquals(
+            listOf(CreateSessionRequest(name = "review-2", cwd = "/srv/reviews")),
+            submitted,
+        )
     }
 
     /** A blank folder means "no `--cwd`", not an empty one. */
     @Test
     fun `Create sends a null cwd when the folder field is empty`() {
-        val submitted = mutableListOf<Pair<String, String?>>()
+        val submitted = mutableListOf<CreateSessionRequest>()
         val form = CreateSessionFormState("")
         form.onNameChange("demo")
         setContent(
             CreateSessionState(visible = true),
             defaultFolder = "",
-            onSubmit = { name, cwd -> submitted += name to cwd },
+            onSubmit = { submitted += it },
             form = form,
         )
 
         composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).performClick()
 
-        assertEquals(listOf<Pair<String, String?>>("demo" to null), submitted)
+        assertEquals(listOf(CreateSessionRequest(name = "demo", cwd = null)), submitted)
     }
 
     @Test
     fun `Cancel dismisses without creating anything`() {
         var cancelled = 0
-        val submitted = mutableListOf<Pair<String, String?>>()
+        val submitted = mutableListOf<CreateSessionRequest>()
         setContent(
             CreateSessionState(visible = true),
             defaultFolder = "/home/a/git/pocketshell",
-            onSubmit = { name, cwd -> submitted += name to cwd },
+            onSubmit = { submitted += it },
             onCancel = { cancelled += 1 },
         )
 
@@ -151,11 +169,11 @@ class CreateSessionSheetTest {
 
     @Test
     fun `a create in flight freezes the sheets actions`() {
-        val submitted = mutableListOf<Pair<String, String?>>()
+        val submitted = mutableListOf<CreateSessionRequest>()
         setContent(
             CreateSessionState(visible = true, submitting = true),
             defaultFolder = "/home/a/git/pocketshell",
-            onSubmit = { name, cwd -> submitted += name to cwd },
+            onSubmit = { submitted += it },
         )
 
         composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).assertIsNotEnabled()
@@ -165,30 +183,125 @@ class CreateSessionSheetTest {
         assertNull(submitted.firstOrNull())
     }
 
+    @Test
+    fun `Agent shows enabled available engines and hides the rest`() {
+        setContent(
+            CreateSessionState(
+                visible = true,
+                engines = listOf(
+                    testEngine("claude"),
+                    testEngine("codex"),
+                    testEngine("opencode", enabled = true, available = false, availableForCreate = false),
+                    testEngine("disabled", enabled = false, available = true, availableForCreate = false),
+                ),
+            ),
+            defaultFolder = "/home/a/git/pocketshell",
+        )
+
+        composeRule.onNodeWithTag(CREATE_SESSION_TYPE_AGENT_TAG).performScrollTo().performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(createSessionEngineTag("claude")).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithTag(createSessionEngineTag("codex")).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithTag(createSessionEngineTag("opencode")).assertDoesNotExist()
+        composeRule.onNodeWithTag(createSessionEngineTag("disabled")).assertDoesNotExist()
+        composeRule.onNodeWithText("Claude").assertIsDisplayed()
+        composeRule.onNodeWithText("Codex").assertIsDisplayed()
+    }
+
+    @Test
+    fun `Create on Agent carries engine profile and backend`() {
+        val submitted = mutableListOf<CreateSessionRequest>()
+        val form = CreateSessionFormState("/srv/reviews")
+        form.onKindChange(CreateSessionKind.Agent)
+        form.onEngineChange("claude")
+        form.onProfileChange("Claude (Z.AI)")
+        form.onBackendChange(CreateSessionBackend.Tmux)
+        setContent(
+            CreateSessionState(
+                visible = true,
+                engines = listOf(testEngine("claude"), testEngine("codex")),
+                profiles = listOf(
+                    ProfileInfo("Claude", "claude", null, isDefault = true),
+                    ProfileInfo("Claude (Z.AI)", "claude", "/home/a/.zlaude", isDefault = false),
+                ),
+            ),
+            defaultFolder = "/srv/reviews",
+            onSubmit = { submitted += it },
+            form = form,
+        )
+
+        composeRule.onNodeWithTag(createSessionEngineTag("claude")).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithTag(CREATE_SESSION_PROFILE_TAG).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).assertIsEnabled().performClick()
+
+        assertEquals(
+            listOf(
+                CreateSessionRequest(
+                    name = "reviews",
+                    cwd = "/srv/reviews",
+                    engine = "claude",
+                    profile = "Claude (Z.AI)",
+                    backend = "tmux",
+                ),
+            ),
+            submitted,
+        )
+    }
+
+    @Test
+    fun `Create on Shell omits engine even after a backend pick`() {
+        val submitted = mutableListOf<CreateSessionRequest>()
+        val form = CreateSessionFormState("/srv/demo")
+        form.onNameChange("demo")
+        form.onKindChange(CreateSessionKind.Agent)
+        form.onEngineChange("claude")
+        form.onKindChange(CreateSessionKind.Shell)
+        form.onBackendChange(CreateSessionBackend.HostDefault)
+        setContent(
+            CreateSessionState(
+                visible = true,
+                engines = listOf(testEngine("claude")),
+            ),
+            defaultFolder = "/srv/demo",
+            onSubmit = { submitted += it },
+            form = form,
+        )
+
+        composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).performClick()
+
+        assertEquals(
+            listOf(CreateSessionRequest(name = "demo", cwd = "/srv/demo")),
+            submitted,
+        )
+    }
+
     private fun setContent(
         state: CreateSessionState,
         defaultFolder: String,
-        onSubmit: (String, String?) -> Unit = { _, _ -> },
+        onSubmit: (CreateSessionRequest) -> Unit = {},
         onCancel: () -> Unit = {},
         form: CreateSessionFormState? = null,
     ) {
         composeRule.setContent {
             PocketShellTheme {
-                if (form == null) {
-                    CreateSessionSheetContent(
-                        state = state,
-                        defaultFolder = defaultFolder,
-                        onSubmit = onSubmit,
-                        onCancel = onCancel,
-                    )
-                } else {
-                    CreateSessionSheetContent(
-                        state = state,
-                        defaultFolder = defaultFolder,
-                        onSubmit = onSubmit,
-                        onCancel = onCancel,
-                        form = form,
-                    )
+                Box(Modifier.fillMaxSize()) {
+                    if (form == null) {
+                        CreateSessionSheetContent(
+                            state = state,
+                            defaultFolder = defaultFolder,
+                            onSubmit = onSubmit,
+                            onCancel = onCancel,
+                        )
+                    } else {
+                        CreateSessionSheetContent(
+                            state = state,
+                            defaultFolder = defaultFolder,
+                            onSubmit = onSubmit,
+                            onCancel = onCancel,
+                            form = form,
+                        )
+                    }
                 }
             }
         }

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeRouteTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeRouteTest.kt
@@ -88,7 +88,9 @@ class SessionTreeRouteTest {
         composeRule.waitForIdle()
         assertEquals("nothing opens before a create", emptyList<String>(), opened)
 
-        composeRule.runOnIdle { viewModel.createSession(name = "reviews", cwd = "/srv/reviews") }
+        composeRule.runOnIdle {
+            viewModel.createSession(CreateSessionRequest(name = "reviews", cwd = "/srv/reviews"))
+        }
         composeRule.waitUntil(timeoutMillis = 5_000) { opened.isNotEmpty() }
         composeRule.waitForIdle()
 

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeViewModelTest.kt
@@ -371,7 +371,9 @@ class SessionTreeViewModelTest {
             viewModel.openCreateSheet()
             assertTrue(viewModel.state.value.create.visible)
 
-            viewModel.createSession(name = "demo", cwd = "/home/testuser/git/pocketshell")
+            viewModel.createSession(
+                CreateSessionRequest(name = "demo", cwd = "/home/testuser/git/pocketshell"),
+            )
             advanceUntilIdle()
 
             val create = viewModel.state.value.create
@@ -382,7 +384,8 @@ class SessionTreeViewModelTest {
             assertEquals("demo", create.openRequest)
 
             // The command is the host CLI's own, with --cwd quoted and the name
-            // after `--`, and engine/profile ABSENT (the picker is cut).
+            // after `--`. A Shell create with the host-default backend omits
+            // --engine / --profile / --backend.
             val createCommand = connection().executedCommands.single { "create" in it }
             assertEquals(
                 "pocketshell sessions create --json --cwd '/home/testuser/git/pocketshell' -- 'demo'",
@@ -410,7 +413,7 @@ class SessionTreeViewModelTest {
         val viewModel = viewModel(hostId)
 
         viewModel.openCreateSheet()
-        viewModel.createSession(name = "claude-main", cwd = null)
+        viewModel.createSession(CreateSessionRequest(name = "claude-main", cwd = null))
         advanceUntilIdle()
 
         val create = viewModel.state.value.create
@@ -449,7 +452,7 @@ class SessionTreeViewModelTest {
         viewModel.refresh()
         advanceUntilIdle()
         viewModel.openCreateSheet()
-        viewModel.createSession(name = "demo", cwd = "/nope")
+        viewModel.createSession(CreateSessionRequest(name = "demo", cwd = "/nope"))
         advanceUntilIdle()
 
         val create = viewModel.state.value.create
@@ -472,7 +475,7 @@ class SessionTreeViewModelTest {
         viewModel.refresh()
         advanceUntilIdle()
         viewModel.openCreateSheet()
-        viewModel.createSession(name = "   ", cwd = "/home/testuser")
+        viewModel.createSession(CreateSessionRequest(name = "   ", cwd = "/home/testuser"))
         advanceUntilIdle()
 
         assertEquals(BLANK_NAME_MESSAGE, viewModel.state.value.create.failure)
@@ -491,7 +494,7 @@ class SessionTreeViewModelTest {
         answerListAndCreate(HEALTHY_LISTING, createdJson("demo", created = true))
         val viewModel = viewModel(hostId)
 
-        viewModel.createSession(name = "demo", cwd = "   ")
+        viewModel.createSession(CreateSessionRequest(name = "demo", cwd = "   "))
         advanceUntilIdle()
 
         assertEquals(
@@ -506,7 +509,7 @@ class SessionTreeViewModelTest {
         answerListAndCreate(HEALTHY_LISTING, createdJson("demo", created = true))
         val viewModel = viewModel(hostId)
 
-        viewModel.createSession(name = "demo", cwd = null)
+        viewModel.createSession(CreateSessionRequest(name = "demo", cwd = null))
         advanceUntilIdle()
         assertEquals("demo", viewModel.state.value.create.openRequest)
 
@@ -525,11 +528,11 @@ class SessionTreeViewModelTest {
         val viewModel = viewModel(hostId)
 
         viewModel.openCreateSheet()
-        viewModel.createSession(name = "demo", cwd = null)
+        viewModel.createSession(CreateSessionRequest(name = "demo", cwd = null))
         // Not advanced: the create is queued but has not answered yet.
         assertTrue(viewModel.state.value.create.submitting)
 
-        viewModel.createSession(name = "demo-2", cwd = null)
+        viewModel.createSession(CreateSessionRequest(name = "demo-2", cwd = null))
         viewModel.dismissCreateSheet()
         assertTrue("a submitting sheet must stay on screen", viewModel.state.value.create.visible)
         advanceUntilIdle()
@@ -550,7 +553,7 @@ class SessionTreeViewModelTest {
             val viewModel = viewModel(hostId)
 
             viewModel.openCreateSheet()
-            viewModel.createSession(name = "", cwd = null)
+            viewModel.createSession(CreateSessionRequest(name = "", cwd = null))
             assertEquals(BLANK_NAME_MESSAGE, viewModel.state.value.create.failure)
 
             viewModel.dismissCreateSheet()
@@ -560,9 +563,70 @@ class SessionTreeViewModelTest {
             assertFalse(create.visible)
             assertNull(create.failure)
             assertNull(create.openRequest)
-            // Nothing was ever sent — a blank name is answered locally, so the
-            // host was not even dialled.
-            assertEquals(0, stack.factory.dialCount)
+            // A blank name is answered locally: `sessions create` is never sent.
+            assertTrue(
+                "a blank name must never reach sessions create",
+                stack.factory.connections.flatMap { it.executedCommands }
+                    .none { "create" in it },
+            )
+        }
+
+    @Test
+    fun `an agent create forwards engine profile and backend on the argv`() = runTest(dispatcher) {
+        val hostId = stack.seedHost()
+        answerListAndCreate(HEALTHY_LISTING, createdJson("demo", created = true))
+        val viewModel = viewModel(hostId)
+
+        viewModel.createSession(
+            CreateSessionRequest(
+                name = "demo",
+                cwd = "/home/testuser/git/pocketshell",
+                engine = "claude",
+                profile = "Claude (Z.AI)",
+                backend = "aplexer",
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            "pocketshell sessions create --json " +
+                "--cwd '/home/testuser/git/pocketshell' " +
+                "--engine 'claude' " +
+                "--profile 'Claude (Z.AI)' " +
+                "--backend 'aplexer' " +
+                "-- 'demo'",
+            connection().executedCommands.single { "create" in it },
+        )
+        assertEquals("demo", viewModel.state.value.create.openRequest)
+    }
+
+    @Test
+    fun `opening the sheet loads engines including ones the picker will hide`() =
+        runTest(dispatcher) {
+            val hostId = stack.seedHost()
+            answerListAndCreate(HEALTHY_LISTING, createdJson("demo", created = true))
+            val viewModel = viewModel(hostId)
+
+            viewModel.openCreateSheet()
+            advanceUntilIdle()
+
+            val create = viewModel.state.value.create
+            assertEquals(
+                listOf("claude", "codex", "opencode", "disabled"),
+                create.engines.map { it.id },
+            )
+            assertFalse(create.enginesLoading)
+            assertNull(create.enginesFailure)
+            assertEquals(
+                listOf("pocketshell engines list --json", "pocketshell profiles list --json"),
+                connection().executedCommands.filter { "engines" in it || "profiles" in it },
+            )
+            // The hide rule is the sheet's: the VM keeps the host's full list
+            // so a dropped-row regression is a picker bug, not a missing fetch.
+            assertEquals(
+                listOf("claude", "codex"),
+                availableEnginesForCreate(create.engines).map { it.id },
+            )
         }
 
     /**
@@ -653,6 +717,14 @@ class SessionTreeViewModelTest {
                 "pocketshell sessions create",
                 ExecResult(exitCode = 0, stdout = createJson, stderr = "", timedOut = false),
             )
+            connection.onExecPrefix(
+                "pocketshell engines list",
+                ExecResult(exitCode = 0, stdout = ENGINES_LISTING, stderr = "", timedOut = false),
+            )
+            connection.onExecPrefix(
+                "pocketshell profiles list",
+                ExecResult(exitCode = 0, stdout = PROFILES_LISTING, stderr = "", timedOut = false),
+            )
         }
     }
 
@@ -710,6 +782,29 @@ class SessionTreeViewModelTest {
               ],
               "errors": []
             }
+        """.trimIndent()
+
+        val ENGINES_LISTING = """
+            {"engines":[
+              {"id":"claude","label":"Claude","available_for_create":true,
+               "enabled":true,"available":true},
+              {"id":"codex","label":"Codex","available_for_create":true,
+               "enabled":true,"available":true},
+              {"id":"opencode","label":"OpenCode","available_for_create":false,
+               "enabled":true,"available":false,
+               "unavailable_reason":"`opencode` is not installed on this host (not on PATH)."},
+              {"id":"disabled","label":"Disabled","available_for_create":false,
+               "enabled":false,"available":true,
+               "unavailable_reason":"disabled in the host registry"}
+            ]}
+        """.trimIndent()
+
+        val PROFILES_LISTING = """
+            {"profiles":[
+              {"name":"Claude","engine":"claude","config_dir":null,"default":true},
+              {"name":"Claude (Z.AI)","engine":"claude","config_dir":"/home/a/.zlaude","default":false},
+              {"name":"Codex","engine":"codex","default":true}
+            ]}
         """.trimIndent()
 
         val PARTIAL_LISTING = """

--- a/shared/core-hostapi/src/main/java/com/pocketshell/core/hostapi/HostCliClient.kt
+++ b/shared/core-hostapi/src/main/java/com/pocketshell/core/hostapi/HostCliClient.kt
@@ -96,19 +96,23 @@ class HostCliClient(
      * [engine] additionally asks the HOST to start that agent in the new
      * session (server-side `send-keys`), so the phone never types a launch
      * line; [profile] selects a named host profile for it (see
-     * [listProfiles]).
+     * [listProfiles]). [backend] is `tmux` or `aplexer` and becomes
+     * `--backend`; omitting it leaves the host's `[backends]` config in
+     * charge (explicit flag beats that config).
      */
     suspend fun createSession(
         name: String,
         cwd: String? = null,
         engine: String? = null,
         profile: String? = null,
+        backend: String? = null,
     ): Result<CreatedSession> {
         val command = buildString {
             append(binary).append(" sessions create --json")
             if (cwd != null) append(" --cwd ").append(shellSingleQuote(cwd))
             if (engine != null) append(" --engine ").append(shellSingleQuote(engine))
             if (profile != null) append(" --profile ").append(shellSingleQuote(profile))
+            if (backend != null) append(" --backend ").append(shellSingleQuote(backend))
             append(" -- ").append(shellSingleQuote(name))
         }
         val outcome = capture(command, CREATE_TIMEOUT_MS).getOrElse { return Result.failure(it) }

--- a/shared/core-hostapi/src/test/java/com/pocketshell/core/hostapi/HostCliCommandStringTest.kt
+++ b/shared/core-hostapi/src/test/java/com/pocketshell/core/hostapi/HostCliCommandStringTest.kt
@@ -151,6 +151,38 @@ class HostCliCommandStringTest {
     }
 
     @Test
+    fun `createSession forwards backend when set`() {
+        val exec = RecordingExec.ok(fixture("create-tmux-real.json"))
+
+        runSuspending {
+            HostCliClient(exec).createSession(name = "work", backend = "aplexer")
+        }
+
+        assertEquals(
+            "pocketshell sessions create --json --backend 'aplexer' -- 'work'",
+            exec.command,
+        )
+    }
+
+    @Test
+    fun `createSession forwards engine and backend together`() {
+        val exec = RecordingExec.ok(fixture("create-tmux-real.json"))
+
+        runSuspending {
+            HostCliClient(exec).createSession(
+                name = "work",
+                engine = "claude",
+                backend = "tmux",
+            )
+        }
+
+        assertEquals(
+            "pocketshell sessions create --json --engine 'claude' --backend 'tmux' -- 'work'",
+            exec.command,
+        )
+    }
+
+    @Test
     fun `a custom binary is used by the run verbs too`() {
         val exec = RecordingExec.ok(fixture("sessions-list-real.json"))
 

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -788,6 +788,25 @@ class DesignRenders {
     }
 
     /**
+     * Issue #2522: New session sheet in the Shell state (the J04 default).
+     * The real sheet lives in `:app2`; this fixture is the same ui-kit
+     * primitives it composes. See [CreateSessionSheetShellRender].
+     */
+    @Test
+    fun createSessionSheetShell() = render("create-session-sheet-shell") {
+        CreateSessionSheetShellRender()
+    }
+
+    /**
+     * Issue #2522: New session sheet in the Agent state — engines, profile,
+     * and tmux vs aplexer. See [CreateSessionSheetAgentRender].
+     */
+    @Test
+    fun createSessionSheetAgent() = render("create-session-sheet-agent") {
+        CreateSessionSheetAgentRender()
+    }
+
+    /**
      * Issue #678: the `+ window` shell-vs-agent picker. It reuses the exact
      * same [com.pocketshell.app.projects.SessionTypePickerSheet] as the new
      * SESSION flow — the only visible difference is the heading ("New window"

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/SessionMenuRenderFixtures.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/SessionMenuRenderFixtures.kt
@@ -255,6 +255,159 @@ internal fun NewWindowTypePickerRender() {
     }
 }
 
+/**
+ * Issue #2522: 0.5.0 New session sheet, Shell state. The real
+ * `CreateSessionSheet` lives in `:app2`, which this ui-kit harness cannot
+ * import, so this fixture reconstructs it from the same primitives
+ * (`SheetHeader`, `SectionHeader`, cyan-fill `SegmentedToggle`, action row).
+ */
+@Composable
+internal fun CreateSessionSheetShellRender() {
+    CreateSessionSheetRender(
+        kindIndex = 0,
+        showAgent = false,
+    )
+}
+
+/**
+ * Issue #2522: the same sheet with Agent selected — host engines, a profile
+ * picker, and the tmux vs aplexer backend override.
+ */
+@Composable
+internal fun CreateSessionSheetAgentRender() {
+    CreateSessionSheetRender(
+        kindIndex = 1,
+        showAgent = true,
+    )
+}
+
+@Composable
+private fun CreateSessionSheetRender(
+    kindIndex: Int,
+    showAgent: Boolean,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "New session",
+            color = PocketShellColors.Text,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text = "The session starts detached in this folder. Leave the folder blank to use the host's default.",
+            color = PocketShellColors.TextSecondary,
+            fontSize = 13.sp,
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            SectionHeader(label = "Folder")
+            CreateSessionFieldRender("/home/alexey/git/pocketshell")
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            SectionHeader(label = "Session name")
+            CreateSessionFieldRender("pocketshell")
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            SectionHeader(label = "Session type")
+            SegmentedToggle(
+                labels = listOf("Shell", "Agent"),
+                selectedIndex = kindIndex,
+                onSelected = {},
+                modifier = Modifier.fillMaxWidth().height(48.dp),
+                fillSegments = true,
+            )
+        }
+
+        if (showAgent) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                SectionHeader(label = "Agent engine")
+                SegmentedToggle(
+                    labels = listOf("Claude", "Codex", "Grok"),
+                    selectedIndex = 0,
+                    onSelected = {},
+                    modifier = Modifier.fillMaxWidth().height(48.dp),
+                    fillSegments = true,
+                )
+                Text(
+                    text = "The engine will auto-start in the new pane.",
+                    color = PocketShellColors.TextMuted,
+                    fontSize = 11.sp,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                SectionHeader(label = "Profile")
+                SegmentedToggle(
+                    labels = listOf("Claude", "Claude (Z.AI)"),
+                    selectedIndex = 0,
+                    onSelected = {},
+                    modifier = Modifier.fillMaxWidth().height(48.dp),
+                    fillSegments = true,
+                )
+            }
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            SectionHeader(label = "Backend")
+            SegmentedToggle(
+                labels = listOf("Default", "tmux", "aplexer"),
+                selectedIndex = 0,
+                onSelected = {},
+                modifier = Modifier.fillMaxWidth().height(48.dp),
+                fillSegments = true,
+            )
+            Text(
+                text = "Default uses the host's [backends] config.",
+                color = PocketShellColors.TextMuted,
+                fontSize = 11.sp,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(1.dp, PocketShellColors.BorderSoft)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            PocketShellButton(text = "Cancel", onClick = {}, variant = ButtonVariant.Text)
+            Spacer(modifier = Modifier.width(8.dp))
+            PocketShellButton(text = "Create", onClick = {}, variant = ButtonVariant.Primary)
+        }
+    }
+}
+
+@Composable
+private fun CreateSessionFieldRender(value: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .background(PocketShellColors.SurfaceElev, RoundedCornerShape(10.dp))
+            .border(1.dp, PocketShellColors.BorderSoft, RoundedCornerShape(10.dp))
+            .padding(horizontal = 12.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(
+            text = value,
+            color = PocketShellColors.Text,
+            fontSize = 13.sp,
+            fontFamily = FontFamily.Monospace,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
 @Composable
 internal fun HostDetailOverflowMenuRender() {
     Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {


### PR DESCRIPTION
Closes #2522

New session sheet: Shell vs Agent, engine/profile from the host, tmux vs aplexer (`--backend`). Host CLI already had the flags; the app now sends them.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2522#issuecomment-5552874341