### PR TITLE
fix: wait after composer text before sending Enter

### DIFF
--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerText.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerText.kt
@@ -38,15 +38,22 @@ internal object ComposerText {
     }
 
     /**
-     * What actually leaves the app: the composed body plus the carriage return
-     * that submits it.
+     * The composed body as UTF-8, with no trailing Enter.
      *
-     * `\r`, not `\n`: this goes into a PTY, where a terminal line discipline
-     * turns carriage return into "the user pressed Enter". Sending `\n` types a
-     * literal newline into readline instead of submitting, which is the
-     * difference between a prompt running and a prompt sitting there.
+     * Send writes this first, waits [com.pocketshell.next.settings.AppSettings.agentSubmitEnterDelayMs],
+     * then writes [enterBytes] as a second PTY write. Concatenating body+CR
+     * here is the race agents treat as a newline instead of submit (#2526).
      */
-    fun wireBytes(body: String): ByteArray = (body + "\r").toByteArray(Charsets.UTF_8)
+    fun bodyBytes(body: String): ByteArray = body.toByteArray(Charsets.UTF_8)
+
+    /**
+     * Carriage return — a PTY line-discipline "the user pressed Enter".
+     *
+     * `\r`, not `\n`: sending `\n` types a literal newline into readline
+     * instead of submitting. A fresh array each call so a caller cannot
+     * mutate a shared buffer.
+     */
+    fun enterBytes(): ByteArray = byteArrayOf(0x0D)
 
     /**
      * The composer's storage key for one session, shared by the draft store and

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
@@ -8,6 +8,7 @@ import com.pocketshell.core.storage.entity.SentMessageEntity
 import com.pocketshell.core.transport.ConnectResult
 import com.pocketshell.core.transport.HostConnection
 import com.pocketshell.next.connect.ConnectionsRegistry
+import com.pocketshell.next.settings.SettingsRepository
 import com.pocketshell.next.voice.PendingTranscriptionDelivery
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -29,7 +30,10 @@ import kotlinx.coroutines.launch
  * Build the text, ask the session whether it is attached, and act on the
  * answer:
  *
- *  - attached → write `body + "\r"` through [SessionSink], clear the draft;
+ *  - attached → write the body through [SessionSink], wait the configured
+ *    agent-submit delay, then write `\r` as a second PTY write, clear the
+ *    draft. Concatenating body+Enter into one write is the race agents
+ *    treat as a newline (#2526);
  *  - anything else → KEEP the draft and show a "not delivered" chip.
  *
  * That is the whole delivery story. There is no queue, no retry loop, no
@@ -59,6 +63,7 @@ class ComposerViewModel @Inject constructor(
     private val stager: ComposerAttachmentStager,
     private val queuedDictations: PendingTranscriptionDelivery,
     speech: SpeechRecognitionProvider,
+    private val settings: SettingsRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ComposerUiState())
@@ -260,7 +265,7 @@ class ComposerViewModel @Inject constructor(
 
         val body = ComposerText.compose(current.draft.trim(), current.attachments.map { it.remotePath })
         val delivered = target.isLive
-        if (delivered) target.sendBytes(ComposerText.wireBytes(body))
+        if (delivered) deliver(target, body)
         record(body, delivered)
 
         if (delivered) {
@@ -419,6 +424,25 @@ class ComposerViewModel @Inject constructor(
         }
         homeDir = resolved
         return resolved
+    }
+
+    /**
+     * Body, then the configured delay, then Enter — two PTY writes.
+     *
+     * The delay is read HERE, at send time, off [SettingsRepository]'s live
+     * snapshot rather than captured in the constructor. ComposerViewModel is
+     * not a process-lifetime singleton, but a value read at Hilt construction
+     * is still stale the moment the user moves Settings → Terminal without
+     * leaving the session (same lesson as #2488). Zero is still two writes:
+     * concatenating body+CR is the race even when the wait is nothing.
+     */
+    private fun deliver(target: SessionSink, body: String) {
+        target.sendBytes(ComposerText.bodyBytes(body))
+        val delayMs = settings.settings.value.agentSubmitEnterDelayMs.toLong()
+        viewModelScope.launch {
+            delay(delayMs)
+            target.sendBytes(ComposerText.enterBytes())
+        }
     }
 
     private fun record(body: String, delivered: Boolean) {

--- a/app2/src/main/java/com/pocketshell/next/settings/AppSettings.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/AppSettings.kt
@@ -3,7 +3,7 @@ package com.pocketshell.next.settings
 /**
  * Every user-tunable preference app2 has (rewrite task P-6).
  *
- * ## Four fields, not sixteen
+ * ## Five fields, not sixteen
  *
  * The old client's `AppSettings` carried sixteen. Most of them configured
  * machinery the rewrite deleted, so porting them would have shipped a settings
@@ -15,13 +15,17 @@ package com.pocketshell.next.settings
  * | --- | --- |
  * | `tmuxOnAttachByDefault` | Plan P-6 drop list. app2 always attaches through the host CLI; there is no plain-SSH branch to prefer. |
  * | `outboundDeliveryAuthority` (+ enum) | Plan P-6 drop list. It selected between two outbound-queue implementations, both deleted. |
- * | `agentSubmitEnterDelayMs` | Plan P-6 drop list. Agent-TUI paste-race tuning; agent surfaces are cut. |
  * | `diagnosticsRecordingEnabled` | The connection-journal recorder subsystem is not ported (plan P-10, audit finding #5). |
  * | `terminalKeyboardMode` | app2's terminal pins char-based input (see `TerminalHostView`'s client) — a smart-text mode no longer exists to select. |
  * | `conversationFontSizeSp`, `showSystemNotes`, `defaultAgentSessionView` | The conversation view (U-10) is cut by the scope amendment. |
  * | `hostDetailViewMode` | The tree/flat toggle: app2 has one session-tree presentation (U-3). |
  * | `defaultHostId` | The open-on-launch destination. app2 always starts on the host list; "startup" is not in P-6's KEEP list. |
  * | `voiceSilenceThresholdSeconds`, `voiceTranscriptionProvider` | Both belonged to the buffered-WAV → OpenAI Whisper path. app2 dictates through the system recognizer only, which auto-stops itself and needs no API key. |
+ *
+ * `agentSubmitEnterDelayMs` was on that drop list (P-6: "agent surfaces are
+ * cut") and is back: the composer is still the send path into those agents,
+ * and concatenating body+Enter into one PTY write is the race issue #2526
+ * restores the delay to close. No capture-pane ACK gating (#869) — delay only.
  *
  * ## Values, not Compose state
  *
@@ -64,6 +68,18 @@ data class AppSettings(
      * is what lets it be changed without a rebuild.
      */
     val backgroundGraceMillis: Long = DEFAULT_BACKGROUND_GRACE_MILLIS,
+    /**
+     * Milliseconds to wait after writing the composer body before sending
+     * the submit Enter, as a second PTY write (issue #2526 / old #526).
+     *
+     * Agents (Claude/Codex/Grok) treat a body+CR concatenated into one write
+     * as a newline and swallow the submit. Default
+     * [DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS]; tunable between
+     * [MIN_AGENT_SUBMIT_ENTER_DELAY_MS] and [MAX_AGENT_SUBMIT_ENTER_DELAY_MS]
+     * via Settings → Terminal. Read per send, not once at graph construction
+     * (same lesson as #2488). Delay only — no capture-pane ACK gating (#869).
+     */
+    val agentSubmitEnterDelayMs: Int = DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS,
 ) {
     companion object {
 
@@ -122,6 +138,27 @@ data class AppSettings(
          * and the same number task U-8's `GraceCoordinator` defaults to.
          */
         const val DEFAULT_BACKGROUND_GRACE_MILLIS: Long = BACKGROUND_GRACE_90_SECONDS_MS
+
+        /**
+         * Issue #526 / #2526: bounds + default for the composer agent-submit
+         * Enter delay (ms). After typing the message text into the pane the
+         * composer waits this long, then sends Enter as a separate PTY write
+         * so a fast Enter does not race ahead of the agent TUI's paste
+         * ingestion (which leaves the message sitting unsent).
+         *
+         * - Default 150ms sits in the maintainer-suggested 100–300ms band:
+         *   long enough for Claude Code / Codex to finish ingesting a typical
+         *   composer message before the submit Enter, short enough that Send
+         *   still feels instant.
+         * - The floor is 0ms (back-to-back) for users whose agent never
+         *   races; the ceiling 1000ms covers a sluggish TUI without letting
+         *   a hand-edited prefs value make Send feel broken.
+         * - The slider grain is 50ms, matching v0.4.47.
+         */
+        const val MIN_AGENT_SUBMIT_ENTER_DELAY_MS: Int = 0
+        const val MAX_AGENT_SUBMIT_ENTER_DELAY_MS: Int = 1000
+        const val DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS: Int = 150
+        const val AGENT_SUBMIT_ENTER_DELAY_STEP_MS: Int = 50
 
         /**
          * The offered grace windows, ascending.

--- a/app2/src/main/java/com/pocketshell/next/settings/SettingsRepository.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/SettingsRepository.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
  *
  * ## SharedPreferences, like the rest of app2's small stores
  *
- * Four scalars with one write per user tap. Room would need a schema bump for
+ * Five scalars with one write per user tap. Room would need a schema bump for
  * state that is never queried relationally; DataStore would add a version
  * catalog entry for nothing. `ShowAllPortsStore` made the same call for the
  * same reason.
@@ -59,6 +59,11 @@ import kotlinx.coroutines.flow.asStateFlow
  * picker changed nothing for a user who moved it. It is now read per armed
  * background window straight off [settings], so a change takes effect on the
  * next background rather than the next process.
+ *
+ * [AppSettings.agentSubmitEnterDelayMs] is the same shape for Send (issue
+ * #2526): [com.pocketshell.next.composer.ComposerViewModel] reads it per send
+ * off this snapshot, not once at Hilt graph construction, so a slider change
+ * is the next Send rather than the next process.
  */
 @Singleton
 class SettingsRepository @Inject constructor(
@@ -114,6 +119,22 @@ class SettingsRepository @Inject constructor(
         _settings.value = _settings.value.copy(backgroundGraceMillis = supported)
     }
 
+    /**
+     * Composer agent-submit Enter delay (ms). Issue #2526 / old #526.
+     * Clamped to [AppSettings.MIN_AGENT_SUBMIT_ENTER_DELAY_MS] /
+     * [AppSettings.MAX_AGENT_SUBMIT_ENTER_DELAY_MS] and snapped to the
+     * slider grid so a hand-edited prefs file or slider rounding cannot
+     * push the delay outside the useful band. The send path reads this
+     * value per send to decide how long to wait after the body before
+     * the submit Enter.
+     */
+    fun setAgentSubmitEnterDelayMs(delayMs: Int) {
+        val snapped = snapAgentSubmitEnterDelay(delayMs)
+        if (_settings.value.agentSubmitEnterDelayMs == snapped) return
+        write { putInt(KEY_AGENT_SUBMIT_ENTER_DELAY_MS, snapped) }
+        _settings.value = _settings.value.copy(agentSubmitEnterDelayMs = snapped)
+    }
+
     private fun write(edit: SharedPreferences.Editor.() -> Unit) {
         runCatching { prefs.edit().apply(edit).apply() }
     }
@@ -143,6 +164,12 @@ class SettingsRepository @Inject constructor(
         backgroundGraceMillis = normaliseBackgroundGrace(
             prefs.safeLong(KEY_BACKGROUND_GRACE_MILLIS, AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS),
         ),
+        agentSubmitEnterDelayMs = snapAgentSubmitEnterDelay(
+            prefs.safeInt(
+                KEY_AGENT_SUBMIT_ENTER_DELAY_MS,
+                AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS,
+            ),
+        ),
     )
 
     private fun snapTerminalTextSize(sizePx: Int): Int = snap(
@@ -158,6 +185,28 @@ class SettingsRepository @Inject constructor(
         max = AppSettings.MAX_USAGE_WARN_PERCENT,
         step = AppSettings.USAGE_WARN_PERCENT_STEP,
     )
+
+    /**
+     * Snap [delayMs] to the nearest
+     * [AppSettings.AGENT_SUBMIT_ENTER_DELAY_STEP_MS] grid point within
+     * [AppSettings.MIN_AGENT_SUBMIT_ENTER_DELAY_MS] /
+     * [AppSettings.MAX_AGENT_SUBMIT_ENTER_DELAY_MS]. Issue #526 / #2526.
+     * Persistence and read both route through this helper so a legacy or
+     * hand-edited prefs value lands on a slider stop. Formula matches
+     * v0.4.47 `snapAgentSubmitEnterDelay` (zero-anchored; the floor is 0).
+     */
+    private fun snapAgentSubmitEnterDelay(delayMs: Int): Int {
+        val clamped = delayMs.coerceIn(
+            AppSettings.MIN_AGENT_SUBMIT_ENTER_DELAY_MS,
+            AppSettings.MAX_AGENT_SUBMIT_ENTER_DELAY_MS,
+        )
+        val step = AppSettings.AGENT_SUBMIT_ENTER_DELAY_STEP_MS
+        val snapped = ((clamped + step / 2) / step) * step
+        return snapped.coerceIn(
+            AppSettings.MIN_AGENT_SUBMIT_ENTER_DELAY_MS,
+            AppSettings.MAX_AGENT_SUBMIT_ENTER_DELAY_MS,
+        )
+    }
 
     private fun normaliseVoiceLanguage(code: String?): String {
         val trimmed = code?.trim()?.lowercase().orEmpty()
@@ -215,5 +264,6 @@ class SettingsRepository @Inject constructor(
         const val KEY_VOICE_LANGUAGE = "voice_language"
         const val KEY_USAGE_WARN_THRESHOLD = "usage_warn_threshold_percent"
         const val KEY_BACKGROUND_GRACE_MILLIS = "background_grace_millis"
+        const val KEY_AGENT_SUBMIT_ENTER_DELAY_MS = "agent_submit_enter_delay_ms"
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/settings/SettingsScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/SettingsScreen.kt
@@ -51,6 +51,8 @@ const val SETTINGS_TERMINAL_SIZE_SLIDER_TAG: String = "settings-terminal-size-sl
 const val SETTINGS_TERMINAL_SIZE_VALUE_TAG: String = "settings-terminal-size-value"
 const val SETTINGS_USAGE_WARN_SLIDER_TAG: String = "settings-usage-warn-slider"
 const val SETTINGS_USAGE_WARN_VALUE_TAG: String = "settings-usage-warn-value"
+const val SETTINGS_AGENT_SUBMIT_DELAY_SLIDER_TAG: String = "settings-agent-submit-delay-slider"
+const val SETTINGS_AGENT_SUBMIT_DELAY_VALUE_TAG: String = "settings-agent-submit-delay-value"
 const val SETTINGS_WORKSPACE_EMPTY_TAG: String = "settings-workspace-empty"
 const val SETTINGS_CRASH_REPORTS_TAG: String = "settings-crash-reports"
 const val SETTINGS_VERSION_TAG: String = "settings-version"
@@ -95,6 +97,7 @@ fun SettingsRoute(
         onVoiceLanguageChange = viewModel::setVoiceLanguage,
         onUsageWarnThresholdChange = viewModel::setUsageWarnThresholdPercent,
         onBackgroundGraceChange = viewModel::setBackgroundGraceMillis,
+        onAgentSubmitEnterDelayChange = viewModel::setAgentSubmitEnterDelayMs,
         onOpenWorkspaceRoots = onOpenWorkspaceRoots,
         onOpenCrashReports = onOpenCrashReports,
         modifier = modifier,
@@ -108,9 +111,10 @@ fun SettingsRoute(
  * Six sections, ordered most-used-first, all built from ui-kit primitives so
  * this screen adds no visual vocabulary of its own:
  *
- *  1. **Terminal** — glyph size, and the background grace window (which is a
+ *  1. **Terminal** — glyph size, the background grace window (a
  *     terminal-connection property, so it lives with the terminal rather than
- *     in a "Connection" section of one row).
+ *     in a "Connection" section of one row), and the agent-submit Enter delay
+ *     (issue #2526: body then Enter as two PTY writes).
  *  2. **Voice** — the dictation language hint.
  *  3. **Usage** — the "approaching limit" percent for the quota panel.
  *  4. **Workspace** — a host picker into that host's saved roots.
@@ -133,6 +137,7 @@ fun SettingsScreen(
     onVoiceLanguageChange: (String) -> Unit,
     onUsageWarnThresholdChange: (Int) -> Unit,
     onBackgroundGraceChange: (Long) -> Unit,
+    onAgentSubmitEnterDelayChange: (Int) -> Unit,
     onOpenWorkspaceRoots: (Long) -> Unit,
     onOpenCrashReports: () -> Unit,
     modifier: Modifier = Modifier,
@@ -190,6 +195,21 @@ fun SettingsScreen(
                             testTag = backgroundGraceOptionTag(option.millis),
                         )
                     }
+                    Spacer(modifier = Modifier.height(PocketShellSpacing.md))
+                    StepperSlider(
+                        title = "Agent submit delay",
+                        description = "Pause after typing a message before pressing Enter, so the " +
+                            "agent submits it instead of leaving it in the input. Raise this " +
+                            "if Send sometimes leaves text unsent.",
+                        value = settings.agentSubmitEnterDelayMs,
+                        valueLabel = "${settings.agentSubmitEnterDelayMs}ms",
+                        min = AppSettings.MIN_AGENT_SUBMIT_ENTER_DELAY_MS,
+                        max = AppSettings.MAX_AGENT_SUBMIT_ENTER_DELAY_MS,
+                        step = AppSettings.AGENT_SUBMIT_ENTER_DELAY_STEP_MS,
+                        onChange = onAgentSubmitEnterDelayChange,
+                        sliderTestTag = SETTINGS_AGENT_SUBMIT_DELAY_SLIDER_TAG,
+                        valueTestTag = SETTINGS_AGENT_SUBMIT_DELAY_VALUE_TAG,
+                    )
                 }
             }
 

--- a/app2/src/main/java/com/pocketshell/next/settings/SettingsViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/SettingsViewModel.kt
@@ -59,6 +59,8 @@ class SettingsViewModel @Inject constructor(
 
     fun setBackgroundGraceMillis(millis: Long) = repository.setBackgroundGraceMillis(millis)
 
+    fun setAgentSubmitEnterDelayMs(delayMs: Int) = repository.setAgentSubmitEnterDelayMs(delayMs)
+
     private companion object {
         const val STOP_TIMEOUT_MILLIS = 5_000L
 

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerTextTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerTextTest.kt
@@ -52,22 +52,28 @@ class ComposerTextTest {
     }
 
     /**
+     * Body bytes are the draft only — no concatenated CR. Send writes Enter
+     * as a second PTY write after the delay (#2526); putting `\r` here is
+     * the race agents treat as a newline.
+     */
+    @Test
+    fun `body bytes are the draft with no trailing carriage return`() {
+        assertEquals("hello", ComposerText.bodyBytes("hello").toString(Charsets.UTF_8))
+        assertEquals(
+            "привет".toByteArray(Charsets.UTF_8).toList(),
+            ComposerText.bodyBytes("привет").toList(),
+        )
+    }
+
+    /**
      * Carriage return, not newline. A PTY's line discipline turns `\r` into
      * "the user pressed Enter"; `\n` types a literal newline into readline and
      * the prompt just sits there — the difference between a command running and
      * a command not running.
      */
     @Test
-    fun `the wire bytes end in a carriage return`() {
-        assertEquals("hello\r", ComposerText.wireBytes("hello").toString(Charsets.UTF_8))
-    }
-
-    @Test
-    fun `the wire bytes are UTF-8`() {
-        assertEquals(
-            "привет\r".toByteArray(Charsets.UTF_8).toList(),
-            ComposerText.wireBytes("привет").toList(),
-        )
+    fun `enter bytes are a single carriage return`() {
+        assertEquals(byteArrayOf(0x0D).toList(), ComposerText.enterBytes().toList())
     }
 
     @Test

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
@@ -5,7 +5,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.pocketshell.next.settings.AppSettings
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.TestScope
@@ -72,8 +74,120 @@ class ComposerViewModelTest {
             advanceUntilIdle()
 
             // `\r`, not `\n`: this is a PTY, and carriage return is what a line
-            // discipline turns into "the user pressed Enter".
-            assertEquals(listOf("run the tests\r"), sink.sentText())
+            // discipline turns into "the user pressed Enter". Two writes, not
+            // one concatenated buffer — agents treat an immediate Enter as a
+            // newline (#2526).
+            assertEquals(listOf("run the tests", "\r"), sink.sentText())
+        }
+
+    /**
+     * Issue #2526: agents (Claude/Codex/Grok) treat a body+CR concatenated
+     * into one PTY write as a newline and swallow the submit. The old client
+     * (#526) wrote the text, waited, then sent Enter. This is that contract
+     * on a virtual clock: after send, the body is on the wire WITHOUT CR;
+     * advancing less than the delay does not send CR; advancing the delay
+     * sends exactly `\r`.
+     *
+     * Written first against the unfixed concatenated write so the RED is
+     * the reported defect, not a proxy.
+     */
+    @Test
+    fun `send writes the body, waits the delay, then writes CR as a second PTY write`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onDraftChange("hello")
+            advanceUntilIdle()
+
+            viewModel.send()
+            runCurrent()
+
+            assertEquals(
+                "body must leave without a concatenated CR",
+                listOf("hello"),
+                sink.sentText(),
+            )
+            assertEquals(
+                "the first write must not be the concatenated body+CR buffer",
+                "hello".toByteArray().toList(),
+                sink.sent.single().toList(),
+            )
+
+            val delayMs = AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS.toLong()
+            advanceTimeBy(delayMs - 1)
+            runCurrent()
+            assertEquals(
+                "CR must not leave before the delay elapses",
+                listOf("hello"),
+                sink.sentText(),
+            )
+
+            advanceTimeBy(1)
+            runCurrent()
+            assertEquals(listOf("hello", "\r"), sink.sentText())
+            assertEquals(byteArrayOf(0x0D).toList(), sink.sent.last().toList())
+        }
+
+    /**
+     * Issue #2526: a 0 ms delay is still two writes (body, then CR), never
+     * one combined `body + "\r"` buffer — concatenating is the race even
+     * when the wait is zero.
+     */
+    @Test
+    fun `zero delay still writes body and CR as two buffers, never one concatenated write`() =
+        runTest(dispatcher) {
+            stack.settings.setAgentSubmitEnterDelayMs(0)
+            val viewModel = bound()
+            viewModel.onDraftChange("hello")
+            advanceUntilIdle()
+
+            viewModel.send()
+            advanceUntilIdle()
+
+            assertEquals(2, sink.sent.size)
+            assertEquals("hello", sink.sent[0].toString(Charsets.UTF_8))
+            assertEquals(byteArrayOf(0x0D).toList(), sink.sent[1].toList())
+            assertTrue(
+                "zero delay must still be two writes, not one concatenated body+CR buffer",
+                sink.sent.none { it.toList() == "hello\r".toByteArray().toList() },
+            )
+        }
+
+    /**
+     * Same lesson as #2488: the delay is read per send off the live
+     * settings snapshot, not captured when the ViewModel (or the Hilt
+     * graph) was constructed. Changing the slider has to change the NEXT
+     * Send without a process restart.
+     */
+    @Test
+    fun `changing the agent submit delay is honoured on the next send`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            stack.settings.setAgentSubmitEnterDelayMs(200)
+            viewModel.onDraftChange("first")
+            advanceUntilIdle()
+
+            viewModel.send()
+            runCurrent()
+            assertEquals(listOf("first"), sink.sentText())
+            advanceTimeBy(199)
+            runCurrent()
+            assertEquals(listOf("first"), sink.sentText())
+            advanceTimeBy(1)
+            runCurrent()
+            assertEquals(listOf("first", "\r"), sink.sentText())
+
+            stack.settings.setAgentSubmitEnterDelayMs(50)
+            viewModel.onDraftChange("second")
+            advanceUntilIdle()
+            viewModel.send()
+            runCurrent()
+            assertEquals(listOf("first", "\r", "second"), sink.sentText())
+            advanceTimeBy(49)
+            runCurrent()
+            assertEquals(listOf("first", "\r", "second"), sink.sentText())
+            advanceTimeBy(1)
+            runCurrent()
+            assertEquals(listOf("first", "\r", "second", "\r"), sink.sentText())
         }
 
     @Test
@@ -129,7 +243,7 @@ class ComposerViewModelTest {
         viewModel.send()
         advanceUntilIdle()
 
-        assertEquals(listOf("first\r"), sink.sentText())
+        assertEquals(listOf("first", "\r"), sink.sentText())
         assertEquals("second", viewModel.state.value.draft)
     }
 
@@ -377,6 +491,7 @@ class ComposerViewModelTest {
             stager = stack.stager,
             queuedDictations = stack.queuedDictations,
             speech = stack.speech,
+            settings = stack.settings,
         )
 
         viewModel.bind(hostId, SESSION, sink)
@@ -499,7 +614,7 @@ class ComposerViewModelTest {
         viewModel.send()
         advanceUntilIdle()
 
-        assertEquals(listOf("try again later\r"), sink.sentText())
+        assertEquals(listOf("try again later", "\r"), sink.sentText())
         assertEquals(2, viewModel.state.value.history.size)
     }
 
@@ -549,7 +664,7 @@ class ComposerViewModelTest {
             advanceUntilIdle()
 
             assertEquals(
-                listOf("look at this\n\nAttached files:\n- ${staged.remotePath}\r"),
+                listOf("look at this\n\nAttached files:\n- ${staged.remotePath}", "\r"),
                 sink.sentText(),
             )
         }
@@ -565,7 +680,8 @@ class ComposerViewModelTest {
         advanceUntilIdle()
 
         val path = "~/.pocketshell/attachments/$SCOPE/"
-        assertTrue(sink.sentText().single().startsWith("Attached files:\n- $path"))
+        assertTrue(sink.sentText().first().startsWith("Attached files:\n- $path"))
+        assertEquals("\r", sink.sentText().last())
     }
 
     @Test
@@ -594,9 +710,10 @@ class ComposerViewModelTest {
         viewModel.send()
         advanceUntilIdle()
 
-        val body = sink.sentText().single()
+        val body = sink.sentText().first()
         assertTrue(body.contains("-b.txt"))
         assertFalse(body.contains("-a.txt"))
+        assertEquals("\r", sink.sentText().last())
     }
 
     /**
@@ -650,7 +767,8 @@ class ComposerViewModelTest {
         assertFalse(viewModel.state.value.busy)
         viewModel.send()
         advanceUntilIdle()
-        assertTrue(sink.sentText().single().contains("Attached files:"))
+        assertTrue(sink.sentText().first().contains("Attached files:"))
+        assertEquals("\r", sink.sentText().last())
     }
 
     // ------------------------------------------------------------- dictation

--- a/app2/src/test/java/com/pocketshell/next/composer/TestComposerStack.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/TestComposerStack.kt
@@ -13,6 +13,7 @@ import com.pocketshell.core.voice.WhisperClient
 import com.pocketshell.next.connect.ConnectionsRegistry
 import com.pocketshell.next.connect.FakeHostConnectionFactory
 import com.pocketshell.next.connect.RoomTrustStore
+import com.pocketshell.next.settings.SettingsRepository
 import com.pocketshell.next.voice.ConnectivityProbe
 import com.pocketshell.next.voice.PendingTranscriptionDelivery
 import com.pocketshell.next.voice.PendingTranscriptionStore
@@ -58,6 +59,8 @@ class TestComposerStack(homeDirectory: String = "/home/testuser") {
     )
 
     val drafts = ComposerDraftStore(context, Dispatchers.Unconfined)
+
+    val settings = SettingsRepository(context)
 
     val speech = FakeSpeechRecognitionProvider()
 
@@ -129,6 +132,7 @@ class TestComposerStack(homeDirectory: String = "/home/testuser") {
         stager = stager,
         queuedDictations = queuedDictations,
         speech = speech,
+        settings = settings,
     )
 
     fun close() {
@@ -136,6 +140,12 @@ class TestComposerStack(homeDirectory: String = "/home/testuser") {
         // SharedPreferences are process-global under Robolectric, so a draft
         // written by one test would otherwise be loaded by the next.
         context.getSharedPreferences("composer_drafts", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        // Same reason: a delay written by one test would otherwise be the
+        // next test's default.
+        context.getSharedPreferences("next_settings", Context.MODE_PRIVATE)
             .edit()
             .clear()
             .commit()

--- a/app2/src/test/java/com/pocketshell/next/settings/AppSettingsTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/settings/AppSettingsTest.kt
@@ -5,7 +5,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Pins the four fields' defaults and the fixed option lists — plain data, no
+ * Pins the five fields' defaults and the fixed option lists — plain data, no
  * Android dependency.
  */
 class AppSettingsTest {
@@ -18,6 +18,7 @@ class AppSettingsTest {
         assertEquals("auto", settings.voiceLanguage)
         assertEquals(80, settings.usageWarnThresholdPercent)
         assertEquals(90_000L, settings.backgroundGraceMillis)
+        assertEquals(150, settings.agentSubmitEnterDelayMs)
     }
 
     /**
@@ -66,5 +67,15 @@ class AppSettingsTest {
     fun `the terminal text size range brackets the default`() {
         assertTrue(AppSettings.MIN_TERMINAL_TEXT_SIZE_PX < AppSettings.DEFAULT_TERMINAL_TEXT_SIZE_PX)
         assertTrue(AppSettings.DEFAULT_TERMINAL_TEXT_SIZE_PX < AppSettings.MAX_TERMINAL_TEXT_SIZE_PX)
+    }
+
+    @Test
+    fun `agent submit delay defaults to 150ms and the range brackets it`() {
+        assertEquals(150, AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS)
+        assertEquals(0, AppSettings.MIN_AGENT_SUBMIT_ENTER_DELAY_MS)
+        assertEquals(1000, AppSettings.MAX_AGENT_SUBMIT_ENTER_DELAY_MS)
+        assertEquals(50, AppSettings.AGENT_SUBMIT_ENTER_DELAY_STEP_MS)
+        assertTrue(AppSettings.MIN_AGENT_SUBMIT_ENTER_DELAY_MS < AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS)
+        assertTrue(AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS < AppSettings.MAX_AGENT_SUBMIT_ENTER_DELAY_MS)
     }
 }

--- a/app2/src/test/java/com/pocketshell/next/settings/SettingsRepositoryTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/settings/SettingsRepositoryTest.kt
@@ -117,5 +117,50 @@ class SettingsRepositoryTest {
         assertEquals(60, snapshot.usageWarnThresholdPercent)
         assertEquals(AppSettings.VOICE_LANGUAGE_AUTO, snapshot.voiceLanguage)
         assertEquals(AppSettings.DEFAULT_BACKGROUND_GRACE_MILLIS, snapshot.backgroundGraceMillis)
+        assertEquals(AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS, snapshot.agentSubmitEnterDelayMs)
+    }
+
+    @Test
+    fun `agentSubmitEnterDelay defaults to 150ms`() {
+        val repo = repository()
+        assertEquals(
+            AppSettings.DEFAULT_AGENT_SUBMIT_ENTER_DELAY_MS,
+            repo.settings.value.agentSubmitEnterDelayMs,
+        )
+        assertEquals(150, repo.settings.value.agentSubmitEnterDelayMs)
+    }
+
+    @Test
+    fun `setAgentSubmitEnterDelayMs persists and round-trips`() {
+        repository().setAgentSubmitEnterDelayMs(300)
+        assertEquals(300, repository().settings.value.agentSubmitEnterDelayMs)
+    }
+
+    @Test
+    fun `setAgentSubmitEnterDelayMs clamps below minimum and above maximum`() {
+        val repo = repository()
+
+        repo.setAgentSubmitEnterDelayMs(-50)
+        assertEquals(
+            AppSettings.MIN_AGENT_SUBMIT_ENTER_DELAY_MS,
+            repo.settings.value.agentSubmitEnterDelayMs,
+        )
+
+        repo.setAgentSubmitEnterDelayMs(5000)
+        assertEquals(
+            AppSettings.MAX_AGENT_SUBMIT_ENTER_DELAY_MS,
+            repo.settings.value.agentSubmitEnterDelayMs,
+        )
+    }
+
+    @Test
+    fun `setAgentSubmitEnterDelayMs snaps to the 50ms slider grid`() {
+        val repo = repository()
+
+        repo.setAgentSubmitEnterDelayMs(170)
+        assertEquals(150, repo.settings.value.agentSubmitEnterDelayMs)
+
+        repo.setAgentSubmitEnterDelayMs(180)
+        assertEquals(200, repo.settings.value.agentSubmitEnterDelayMs)
     }
 }

--- a/app2/src/test/java/com/pocketshell/next/settings/SettingsScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/settings/SettingsScreenTest.kt
@@ -61,6 +61,23 @@ class SettingsScreenTest {
     }
 
     @Test
+    fun `the agent submit delay slider shows the current value`() {
+        setContent(settings = AppSettings(agentSubmitEnterDelayMs = 300))
+
+        composeRule.onNodeWithTag(SETTINGS_AGENT_SUBMIT_DELAY_SLIDER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SETTINGS_AGENT_SUBMIT_DELAY_VALUE_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("300ms").assertIsDisplayed()
+        composeRule.onNodeWithText("Agent submit delay").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the agent submit delay slider defaults to 150ms`() {
+        setContent()
+
+        composeRule.onNodeWithText("150ms").assertIsDisplayed()
+    }
+
+    @Test
     fun `an empty host list shows the add-a-host nudge instead of a blank section`() {
         setContent(hosts = emptyList())
 
@@ -125,6 +142,7 @@ class SettingsScreenTest {
         onVoiceLanguageChange: (String) -> Unit = {},
         onUsageWarnThresholdChange: (Int) -> Unit = {},
         onBackgroundGraceChange: (Long) -> Unit = {},
+        onAgentSubmitEnterDelayChange: (Int) -> Unit = {},
         onOpenWorkspaceRoots: (Long) -> Unit = {},
         onOpenCrashReports: () -> Unit = {},
     ) {
@@ -138,6 +156,7 @@ class SettingsScreenTest {
                 onVoiceLanguageChange = onVoiceLanguageChange,
                 onUsageWarnThresholdChange = onUsageWarnThresholdChange,
                 onBackgroundGraceChange = onBackgroundGraceChange,
+                onAgentSubmitEnterDelayChange = onAgentSubmitEnterDelayChange,
                 onOpenWorkspaceRoots = onOpenWorkspaceRoots,
                 onOpenCrashReports = onOpenCrashReports,
             )

--- a/app2/src/test/java/com/pocketshell/next/settings/SettingsViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/settings/SettingsViewModelTest.kt
@@ -73,11 +73,13 @@ class SettingsViewModelTest {
         vm.setVoiceLanguage("de")
         vm.setUsageWarnThresholdPercent(90)
         vm.setBackgroundGraceMillis(AppSettings.BACKGROUND_GRACE_30_SECONDS_MS)
+        vm.setAgentSubmitEnterDelayMs(300)
 
         val snapshot = repository.settings.value
         assertEquals("de", snapshot.voiceLanguage)
         assertEquals(90, snapshot.usageWarnThresholdPercent)
         assertEquals(AppSettings.BACKGROUND_GRACE_30_SECONDS_MS, snapshot.backgroundGraceMillis)
+        assertEquals(300, snapshot.agentSubmitEnterDelayMs)
     }
 
     @Test


### PR DESCRIPTION
Closes #2526

Composer Send writes the message, waits (default 150ms, Settings → Terminal), then sends Enter as a second PTY write so agents do not swallow it as a newline.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2526#issuecomment-5553009070