### PR TITLE
feat: compact session bar with floating composer and hotkeys

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/composer/J07ComposerSendJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/composer/J07ComposerSendJourney.kt
@@ -29,6 +29,7 @@ import com.pocketshell.next.terminal.SESSION_ERROR_BANNER_TAG
 import com.pocketshell.next.terminal.SESSION_SCREEN_TAG
 import com.pocketshell.next.tree.SESSION_TREE_TAG
 import com.pocketshell.next.tree.sessionRowTag
+import com.pocketshell.uikit.components.SESSION_COMPOSER_LAUNCHER_TAG
 import com.termux.view.TerminalView
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -155,6 +156,7 @@ class J07ComposerSendJourney {
         openSession()
         awaitTranscript("the fixture's banner line") { it.contains(BANNER) }
 
+        openComposer()
         compose.onNodeWithTag(COMPOSER_TAG).assertIsDisplayed()
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).performTextInput("echo $MARKER")
         compose.awaitIdle("after composing the draft")
@@ -210,6 +212,7 @@ class J07ComposerSendJourney {
         AgentsFixture.exec("tmux -S $SOCKET kill-server 2>/dev/null || true")
         awaitTag(SESSION_ERROR_BANNER_TAG, "the session-ended banner")
 
+        openComposer()
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).performTextInput(UNDELIVERED_TEXT)
         compose.awaitIdle("after composing the undelivered draft")
         // Prove the editor took the text and Send is live BEFORE asserting on
@@ -243,6 +246,7 @@ class J07ComposerSendJourney {
         openSession()
         awaitTranscript("the fixture's banner line") { it.contains(BANNER) }
 
+        openComposer()
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).performTextInput(HISTORY_TEXT)
         compose.awaitIdle("after composing the history draft")
         compose.onNodeWithTag(COMPOSER_SEND_TAG).performClick()
@@ -320,6 +324,12 @@ class J07ComposerSendJourney {
         awaitTag(sessionRowTag(SESSION))
         compose.onNodeWithTag(sessionRowTag(SESSION)).performClick()
         awaitTag(SESSION_SCREEN_TAG)
+    }
+
+    private fun openComposer() {
+        awaitTag(SESSION_COMPOSER_LAUNCHER_TAG, "the Prompt Composer launcher")
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).performClick()
+        awaitTag(COMPOSER_TAG, "the Prompt Composer sheet")
     }
 
     /**

--- a/app2/src/androidTest/java/com/pocketshell/next/composer/J08VoiceDictationJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/composer/J08VoiceDictationJourney.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.next.composer
 
+import android.Manifest
 import android.content.Context
 import android.os.SystemClock
 import androidx.compose.ui.test.assertCountEquals
@@ -26,6 +27,8 @@ import com.pocketshell.next.hosts.hostRowTag
 import com.pocketshell.next.terminal.SESSION_SCREEN_TAG
 import com.pocketshell.next.tree.SESSION_TREE_TAG
 import com.pocketshell.next.tree.sessionRowTag
+import com.pocketshell.uikit.components.SESSION_COMPOSER_LAUNCHER_TAG
+import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.next.voice.ConnectivityProbe
 import com.pocketshell.next.voice.PendingTranscriptionItem
 import com.pocketshell.next.voice.PendingTranscriptionStore
@@ -146,6 +149,8 @@ class J08VoiceDictationJourney {
     @Test
     fun micTapDictatesIntoTheComposerDraft() {
         openSession()
+        grantRecordAudio()
+        openComposer()
 
         compose.onNodeWithTag(COMPOSER_DRAFT_TAG).assertIsDisplayed()
         compose.onNodeWithTag(COMPOSER_MIC_TAG).performClick()
@@ -187,6 +192,7 @@ class J08VoiceDictationJourney {
         }
 
         openSession()
+        openComposer()
 
         awaitTag(COMPOSER_NOTICE_TAG, "the offline-dictation-delivered notice")
         JourneyScreenshots.capture("03-offline-delivered", JOURNEY)
@@ -207,6 +213,20 @@ class J08VoiceDictationJourney {
         awaitTag(sessionRowTag(SESSION))
         compose.onNodeWithTag(sessionRowTag(SESSION)).performClick()
         awaitTag(SESSION_SCREEN_TAG)
+    }
+
+    private fun openComposer() {
+        awaitTag(SESSION_COMPOSER_LAUNCHER_TAG, "the Prompt Composer launcher")
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).performClick()
+        awaitTag(COMPOSER_TAG, "the Prompt Composer sheet")
+    }
+
+    private fun grantRecordAudio() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.uiAutomation.grantRuntimePermission(
+            instrumentation.targetContext.packageName,
+            Manifest.permission.RECORD_AUDIO,
+        )
     }
 
     private fun awaitTag(tag: String, what: String = tag) {

--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/J03AttachAndTypeJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/J03AttachAndTypeJourney.kt
@@ -26,9 +26,16 @@ import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.appGraph
 import com.pocketshell.next.connect.awaitIdle
 import com.pocketshell.next.connect.idleWedgeNote
+import com.pocketshell.next.composer.COMPOSER_SEND_TAG
+import com.pocketshell.next.composer.COMPOSER_TAG
 import com.pocketshell.next.hosts.hostRowTag
 import com.pocketshell.next.tree.SESSION_TREE_TAG
 import com.pocketshell.next.tree.sessionRowTag
+import com.pocketshell.uikit.components.SESSION_COMPOSER_LAUNCHER_TAG
+import com.pocketshell.uikit.components.SESSION_HOTKEYS_LAUNCHER_TAG
+import com.pocketshell.uikit.components.SESSION_LAUNCHER_BAR_TAG
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_CLOSE_TAG
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
 import com.termux.view.TerminalView
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -364,7 +371,26 @@ class J03AttachAndTypeJourney {
     }
 
     /**
-     * Task U-5: Ctrl on the key bar plus `c` on the keyboard is a real SIGINT.
+     * #2521: the circled always-visible 4-key bar + full composer is gone.
+     * Closed session chrome is the compact Prompt Composer + ⌨ launcher.
+     */
+    @Test
+    fun closedChromeIsCompactLauncherOnly() {
+        openSession()
+        awaitTranscript("the fixture's banner line") { it.contains(BANNER) }
+
+        compose.onNodeWithTag(SESSION_LAUNCHER_BAR_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).assertIsDisplayed()
+        compose.onNodeWithText("Ctrl").assertDoesNotExist()
+        compose.onNodeWithText("Esc").assertDoesNotExist()
+        compose.onNodeWithTag(COMPOSER_TAG).assertDoesNotExist()
+        compose.onNodeWithTag(COMPOSER_SEND_TAG).assertDoesNotExist()
+        JourneyScreenshots.capture("06-compact-launcher", JOURNEY)
+    }
+
+    /**
+     * Task U-5 / #2521: `^C` on the hotkeys panel is a real SIGINT.
      *
      * The oracle is the HOST's process table, not the screen. A terminal shows
      * `^C` for any number of reasons — a locally echoed control glyph, a shell
@@ -386,20 +412,20 @@ class J03AttachAndTypeJourney {
         awaitHostSleep(running = true)
         JourneyScreenshots.capture("07-sleeping", JOURNEY)
 
-        // The whole point of the key bar: the modifier comes from the bar, the
-        // letter from the keyboard, because a phone keyboard has every letter
-        // and no Ctrl.
-        compose.onNodeWithText(KEY_LABEL_CTRL).assertIsDisplayed()
-        compose.onNodeWithText(KEY_LABEL_CTRL).performClick()
-        compose.awaitIdle("after the Ctrl key-bar tap")
-        typeCharacter('c')
+        openHotkeys()
+        // Two ordinary taps are the documented accessible fallback for a
+        // stubborn agent; they also survive a first tap being eaten as a
+        // sheet-drag. Each tap is one 0x03.
+        compose.onNodeWithText("^C").performClick()
+        compose.onNodeWithText("^C").performClick()
+        compose.awaitIdle("after the hotkeys-panel ^C taps")
+        compose.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_TAG).assertIsDisplayed()
 
         awaitHostSleep(running = false)
         JourneyScreenshots.capture("08-interrupted", JOURNEY)
 
-        // ...and the session is still usable afterwards. Twice, for the reason
-        // the headline test explains: once as the shell echoes the typed line,
-        // once as the command's own output.
+        compose.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_CLOSE_TAG).performClick()
+        compose.awaitIdle("after closing the hotkeys panel")
         typeLine("echo $CTRL_MARKER")
         awaitTranscript("the post-interrupt marker twice") {
             it.split(CTRL_MARKER).size >= 3
@@ -411,36 +437,37 @@ class J03AttachAndTypeJourney {
     }
 
     /**
-     * Task U-5: Esc and Enter on the key bar reach the remote as real bytes.
+     * Task U-5 / #2521: Enter on the hotkeys panel reaches the remote as CR.
      *
-     * Enter is the load-bearing one — a bar that sent `\n` instead of `\r`
+     * Enter is the load-bearing one — a panel that sent `\n` instead of `\r`
      * submits nothing to a line editor — and it is asserted the only way that
      * distinguishes them: by typing a command WITHOUT a newline and letting the
-     * bar's Enter run it.
+     * panel's Enter run it. The panel stays open after the tap.
      */
     @Test
     fun theKeyBarsEnterSubmitsATypedCommand() {
         openSession()
         awaitTranscript("the fixture's banner line") { it.contains(BANNER) }
 
-        // Typed WITHOUT the Enter key event `typeLine` appends.
         typeCharacters("echo $ENTER_MARKER")
         val beforeEnter = awaitTranscript("the un-submitted command echoed back") {
             it.contains(ENTER_MARKER)
         }
         assertEquals(
-            "the command must NOT have run yet, or the key bar's Enter proves nothing:\n" +
+            "the command must NOT have run yet, or the panel's Enter proves nothing:\n" +
                 beforeEnter,
             2,
             squashed(beforeEnter).split(ENTER_MARKER).size,
         )
 
+        openHotkeys()
         compose.onNodeWithText(KEY_LABEL_ENTER).performClick()
+        compose.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_TAG).assertIsDisplayed()
 
         awaitTranscript("the marker echoed and run") { it.split(ENTER_MARKER).size >= 3 }
-        JourneyScreenshots.capture("09-key-bar-enter", JOURNEY)
+        JourneyScreenshots.capture("09-hotkeys-enter", JOURNEY)
         assertTrue(
-            "the host must show the command the key bar's Enter submitted",
+            "the host must show the command the hotkeys panel's Enter submitted",
             squashed(capturePane()).contains(ENTER_MARKER),
         )
     }
@@ -460,6 +487,12 @@ class J03AttachAndTypeJourney {
         awaitTag(sessionRowTag(SESSION))
         compose.onNodeWithTag(sessionRowTag(SESSION)).performClick()
         awaitTag(SESSION_SCREEN_TAG)
+    }
+
+    private fun openHotkeys() {
+        awaitTag(SESSION_HOTKEYS_LAUNCHER_TAG)
+        compose.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).performClick()
+        awaitTag(TERMINAL_HOTKEYS_PANEL_TAG)
     }
 
     /**
@@ -1070,6 +1103,7 @@ class J03AttachAndTypeJourney {
             "theRemoteTerminalSizeTracksTheKeyboardAndRotation" to 9_303L,
             "ctrlFromTheKeyBarInterruptsARunningCommand" to 9_304L,
             "theKeyBarsEnterSubmitsATypedCommand" to 9_305L,
+            "closedChromeIsCompactLauncherOnly" to 9_306L,
         )
     }
 }

--- a/app2/src/main/AndroidManifest.xml
+++ b/app2/src/main/AndroidManifest.xml
@@ -47,9 +47,9 @@
         Task P-2: the composer's mic. Both dictation arms need it — Android's
         `SpeechRecognizer` opens the microphone in the recognition service's
         process on the caller's behalf, and the Whisper arm records a WAV
-        locally. Declared here AND requested at runtime by `ComposerBar`; a
-        manifest-only declaration would make every mic tap fail silently on
-        Android 6+.
+        locally. Declared here AND requested at runtime by `PromptComposerSheet`
+        via `RequestPermission`; a manifest-only declaration would make every
+        mic tap fail silently (or crash) on Android 6+.
     -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerBar.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerBar.kt
@@ -49,6 +49,7 @@ import com.pocketshell.uikit.theme.PocketShellSpacing
 const val COMPOSER_TAG: String = "composer"
 const val COMPOSER_DRAFT_TAG: String = "composer-draft"
 const val COMPOSER_SEND_TAG: String = "composer-send"
+const val COMPOSER_INSERT_TAG: String = "composer-insert"
 const val COMPOSER_ATTACH_TAG: String = "composer-attach"
 const val COMPOSER_MIC_TAG: String = "composer-mic"
 const val COMPOSER_DISCARD_RECORDING_TAG: String = "composer-discard-recording"
@@ -66,28 +67,18 @@ fun composerSlashRowTag(command: String): String = "composer-slash-row:$command"
 /** The text a send that never left the device puts on screen. */
 const val COMPOSER_UNDELIVERED_TEXT: String = "Not delivered — session offline. Your draft was kept."
 
+/** Shown when RECORD_AUDIO is denied; dictation is not started. */
+const val COMPOSER_RECORD_AUDIO_DENIED_TEXT: String =
+    "Microphone permission denied. You can still type."
+
 internal const val COMPOSER_PLACEHOLDER: String = "Compose a message…"
 
 /**
- * The composer, inline in the session screen's bottom chrome (rewrite task
- * P-1).
+ * The Prompt Composer body (rewrite task P-1, restored as a sheet in #2521).
  *
- * ## Why inline rather than the old modal bottom sheet
- *
- * The old composer was a `ModalBottomSheet`, and two of its ported support
- * files (`ComposerSheetChrome`, `PromptComposerImeAnchorPolicy`) existed only
- * to fight Material's sheet anchors: a policy that measured the sheet Surface
- * against the IME boundary and re-anchored it, plus a hand-rolled drag handle
- * that clawed back the ~45dp of dead top inset Material charged a floating
- * sheet. Both are chrome-shaped bug fixes for a container this composer does
- * not use.
- *
- * An inline bar sits above the keyboard by construction — the screen carries
- * `imePadding()` and the terminal above it resizes — so the whole class of
- * anchor/dead-band defect the maintainer reported against the sheet cannot
- * occur, and 289 lines of correction machinery do not need to be maintained to
- * prevent it. This is the rewrite's premise applied to the composer: delete the
- * shim by removing the thing it was shimming.
+ * Hosted inside [PromptComposerSheet], not inline in the session column. The
+ * session column's compact launcher opens the sheet; this composable is the
+ * draft, mic, Insert, and Send once it is open.
  *
  * ## Stateless
  *
@@ -103,6 +94,7 @@ fun ComposerBar(
     state: ComposerUiState,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
+    onInsert: () -> Unit,
     onAttach: () -> Unit,
     onMicTap: () -> Unit,
     onCancelRecording: () -> Unit,
@@ -194,6 +186,7 @@ fun ComposerBar(
         ControlsRow(
             state = state,
             onSend = onSend,
+            onInsert = onInsert,
             onAttach = onAttach,
             onMicTap = onMicTap,
             onCancelRecording = onCancelRecording,
@@ -297,6 +290,7 @@ private fun DraftField(value: TextFieldValue, onValueChange: (TextFieldValue) ->
 private fun ControlsRow(
     state: ComposerUiState,
     onSend: () -> Unit,
+    onInsert: () -> Unit,
     onAttach: () -> Unit,
     onMicTap: () -> Unit,
     onCancelRecording: () -> Unit,
@@ -304,7 +298,8 @@ private fun ControlsRow(
     onTogglePreview: () -> Unit,
     onDiscard: () -> Unit,
 ) {
-    Row(
+    Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
+        Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs),
@@ -366,17 +361,6 @@ private fun ControlsRow(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        if (state.recording != RecordingState.Recording) {
-            PocketShellButton(
-                text = "Send",
-                onClick = onSend,
-                enabled = state.canSend && !state.busy,
-                compact = true,
-                modifier = Modifier.testTag(COMPOSER_SEND_TAG),
-            )
-            Spacer(modifier = Modifier.width(PocketShellSpacing.xs))
-        }
-
         MicButton(
             state = when {
                 state.recording == RecordingState.Recording -> MicButtonState.Recording
@@ -384,10 +368,34 @@ private fun ControlsRow(
                 else -> MicButtonState.Disabled
             },
             onClick = onMicTap,
-            // No size override: `MicButton` pins its own 56dp disc after the
-            // caller's modifier, so anything set here would be a silent no-op.
             modifier = Modifier.testTag(COMPOSER_MIC_TAG),
         )
+    }
+
+    if (state.recording != RecordingState.Recording) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs),
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+            PocketShellButton(
+                text = "Insert",
+                onClick = onInsert,
+                enabled = state.canSend && !state.busy,
+                variant = ButtonVariant.Secondary,
+                compact = true,
+                modifier = Modifier.testTag(COMPOSER_INSERT_TAG),
+            )
+            PocketShellButton(
+                text = "Send",
+                onClick = onSend,
+                enabled = state.canSend && !state.busy,
+                compact = true,
+                modifier = Modifier.testTag(COMPOSER_SEND_TAG),
+            )
+        }
+    }
     }
 }
 

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerSheetChrome.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerSheetChrome.kt
@@ -1,0 +1,168 @@
+package com.pocketshell.next.composer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.layout.findRootCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.theme.PocketShellColors
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.supervisorScope
+
+/**
+ * The composer's Material chrome, in one place (ported from v0.4.47 #1622
+ * for overlay geometry only).
+ *
+ * Horizontal-only content insets so a floating sheet is not charged the
+ * status-bar inset as dead padding above the grabber. Compact drag handle
+ * instead of Material's 48 dp default. [composerImeAnchorPolicy] re-anchors
+ * a settled partial sheet when the IME would cover the draft.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ComposerModalBottomSheet(
+    onDismissRequest: () -> Unit,
+    sheetState: SheetState,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = PocketShellColors.Surface,
+        contentColor = PocketShellColors.Text,
+        modifier = modifier.composerImeAnchorPolicy(sheetState),
+        dragHandle = { ComposerDragHandle() },
+        contentWindowInsets = {
+            WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
+        },
+        content = content,
+    )
+}
+
+@Composable
+internal fun ComposerDragHandle(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .padding(vertical = ComposerDragHandleVerticalPadding)
+            .size(width = ComposerDragHandleBarWidth, height = ComposerDragHandleBarHeight)
+            .background(
+                color = PocketShellColors.TextSecondary,
+                shape = RoundedCornerShape(percent = 50),
+            )
+            .testTag(COMPOSER_DRAG_HANDLE_TAG),
+    )
+}
+
+internal val ComposerDragHandleBlockHeight: Dp
+    get() = ComposerDragHandleVerticalPadding * 2 + ComposerDragHandleBarHeight
+
+internal val ComposerDragHandleVerticalPadding = 9.dp
+internal val ComposerDragHandleBarWidth = 32.dp
+internal val ComposerDragHandleBarHeight = 4.dp
+
+internal const val COMPOSER_DRAG_HANDLE_TAG = "prompt-composer-drag-handle"
+
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun Modifier.composerImeAnchorPolicy(
+    sheetState: SheetState,
+): Modifier = composed {
+    val density = LocalDensity.current
+    val imeInsets = WindowInsets.ime
+    var geometry by remember(sheetState) {
+        mutableStateOf<ComposerModalSurfaceGeometry?>(null)
+    }
+    var autoExpandedFromPartial by remember(sheetState) { mutableStateOf(false) }
+    var preservePreImeExpanded by remember(sheetState) { mutableStateOf(false) }
+
+    LaunchedEffect(sheetState, density) {
+        snapshotFlow {
+            val imeBottomPx = imeInsets.getBottom(density)
+            val surfaceTopPx = runCatching { sheetState.requireOffset() }.getOrNull()
+            ComposerImeAnchorSnapshot(
+                imeVisible = imeBottomPx > 0,
+                overlapsKeyboard = composerModalSurfaceOverlapsIme(
+                    geometry = geometry,
+                    surfaceTopPx = surfaceTopPx,
+                    imeBottomPx = imeBottomPx,
+                ),
+                currentValue = sheetState.currentValue,
+                targetValue = sheetState.targetValue,
+                hasPartiallyExpandedState = sheetState.hasPartiallyExpandedState,
+                autoExpandedFromPartial = autoExpandedFromPartial,
+            )
+        }.collect { snapshot ->
+            preservePreImeExpanded = updateComposerPreImeExpanded(
+                previous = preservePreImeExpanded,
+                snapshot = snapshot,
+            )
+            when (decideComposerImeAnchorAction(snapshot)) {
+                ComposerImeAnchorAction.None -> Unit
+                ComposerImeAnchorAction.ExpandFromPartial -> {
+                    try {
+                        supervisorScope { sheetState.expand() }
+                        autoExpandedFromPartial = composerImeOwnsExpansionAfter(
+                            ComposerImeExpansionOutcome.Completed,
+                            preservePreImeExpanded = preservePreImeExpanded,
+                        )
+                    } catch (cancelled: CancellationException) {
+                        val effectDisposed = !currentCoroutineContext().isActive
+                        autoExpandedFromPartial = composerImeOwnsExpansionAfter(
+                            if (effectDisposed) {
+                                ComposerImeExpansionOutcome.EffectDisposed
+                            } else {
+                                ComposerImeExpansionOutcome.InterruptedByUser
+                            },
+                            preservePreImeExpanded = preservePreImeExpanded,
+                        )
+                        if (effectDisposed) throw cancelled
+                    }
+                }
+                ComposerImeAnchorAction.RestorePartial -> {
+                    autoExpandedFromPartial = false
+                    try {
+                        supervisorScope { sheetState.partialExpand() }
+                    } catch (cancelled: CancellationException) {
+                        if (!currentCoroutineContext().isActive) throw cancelled
+                    }
+                }
+                ComposerImeAnchorAction.ReleaseOwnership -> {
+                    autoExpandedFromPartial = false
+                }
+            }
+        }
+    }
+
+    onGloballyPositioned { coordinates ->
+        geometry = ComposerModalSurfaceGeometry(
+            rootBottomPx = coordinates.findRootCoordinates().size.height,
+            surfaceHeightPx = coordinates.size.height,
+        )
+    }
+}

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerText.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerText.kt
@@ -56,6 +56,14 @@ internal object ComposerText {
     fun enterBytes(): ByteArray = byteArrayOf(0x0D)
 
     /**
+     * Insert writes the body with no trailing Enter.
+     *
+     * The old Prompt Composer contract: Insert types into the PTY; Send
+     * submits. A `\r` here would make Insert indistinguishable from Send.
+     */
+    fun insertBytes(body: String): ByteArray = body.toByteArray(Charsets.UTF_8)
+
+    /**
      * The composer's storage key for one session, shared by the draft store and
      * the sent-message log so both answer "which session is this" identically.
      */

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
@@ -252,20 +252,36 @@ class ComposerViewModel @Inject constructor(
     // ---------------------------------------------------------------- sending
 
     /**
-     * Sends the composed message.
+     * Sends the composed message: body, then the agent-submit delay, then Enter.
      *
      * Ignored while an upload is in flight: an attachment that is halfway to
      * the host has no remote path yet, so sending now would send a message
      * referencing a file that is not there.
      */
-    fun send() {
+    fun send() = deliver(submit = true)
+
+    /**
+     * Writes the composed message to the PTY without submitting.
+     *
+     * Same live/undelivered contract as [send]; the only difference is the
+     * trailing carriage return.
+     */
+    fun insert() = deliver(submit = false)
+
+    private fun deliver(submit: Boolean) {
         val current = _state.value
         if (!current.canSend || current.busy) return
         val target = sink ?: return
 
         val body = ComposerText.compose(current.draft.trim(), current.attachments.map { it.remotePath })
         val delivered = target.isLive
-        if (delivered) deliver(target, body)
+        if (delivered) {
+            if (submit) {
+                deliver(target, body)
+            } else {
+                target.sendBytes(ComposerText.insertBytes(body))
+            }
+        }
         record(body, delivered)
 
         if (delivered) {
@@ -348,6 +364,11 @@ class ComposerViewModel @Inject constructor(
     /** Mic tap: start dictating, or stop and transcribe. */
     fun onMicTap() {
         if (dictation.isRecording) dictation.stop() else dictation.start()
+    }
+
+    /** RECORD_AUDIO was denied. The recognizer is not started. */
+    fun surfacePermissionDenied() {
+        notify(ComposerNotice.Problem(COMPOSER_RECORD_AUDIO_DENIED_TEXT))
     }
 
     /** Discard the recording and restore the draft as it was before the mic opened. */

--- a/app2/src/main/java/com/pocketshell/next/composer/PromptComposerImeAnchorPolicy.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/PromptComposerImeAnchorPolicy.kt
@@ -1,0 +1,117 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.pocketshell.next.composer
+
+import androidx.compose.material3.SheetValue
+
+/**
+ * The one-shot anchor transitions owned by the composer's IME policy.
+ *
+ * Ported from v0.4.47 for overlay geometry only (#2521): Material owns the
+ * actual anchors and animations. This policy decides when the composer must
+ * leave a settled partial anchor because the measured modal Surface crosses
+ * its owning root's keyboard boundary, and whether an earlier policy-owned
+ * expansion may be restored after the IME hides.
+ */
+internal enum class ComposerImeAnchorAction {
+    None,
+    ExpandFromPartial,
+    RestorePartial,
+    ReleaseOwnership,
+}
+
+/**
+ * How a policy-requested expansion stopped.
+ *
+ * Ownership begins only after [Completed]. Material cancels `expand()` when a
+ * user gesture wins its mutation mutex; either cancellation outcome must leave
+ * the resulting anchor user-owned so hiding the IME cannot collapse it.
+ */
+internal enum class ComposerImeExpansionOutcome {
+    Completed,
+    InterruptedByUser,
+    EffectDisposed,
+}
+
+internal fun composerImeOwnsExpansionAfter(
+    outcome: ComposerImeExpansionOutcome,
+    preservePreImeExpanded: Boolean,
+): Boolean = outcome == ComposerImeExpansionOutcome.Completed &&
+    !preservePreImeExpanded
+
+internal data class ComposerImeAnchorSnapshot(
+    val imeVisible: Boolean,
+    val overlapsKeyboard: Boolean,
+    val currentValue: SheetValue,
+    val targetValue: SheetValue,
+    val hasPartiallyExpandedState: Boolean,
+    val autoExpandedFromPartial: Boolean,
+)
+
+internal data class ComposerModalSurfaceGeometry(
+    val rootBottomPx: Int,
+    val surfaceHeightPx: Int,
+)
+
+internal fun updateComposerPreImeExpanded(
+    previous: Boolean,
+    snapshot: ComposerImeAnchorSnapshot,
+): Boolean {
+    if (snapshot.imeVisible || snapshot.autoExpandedFromPartial) {
+        return previous
+    }
+    if (snapshot.currentValue != snapshot.targetValue) {
+        return previous
+    }
+    return when (snapshot.currentValue) {
+        SheetValue.Expanded -> snapshot.hasPartiallyExpandedState
+        SheetValue.PartiallyExpanded -> false
+        SheetValue.Hidden -> previous
+    }
+}
+
+internal fun composerModalSurfaceOverlapsIme(
+    geometry: ComposerModalSurfaceGeometry?,
+    surfaceTopPx: Float?,
+    imeBottomPx: Int,
+): Boolean = geometry != null &&
+    surfaceTopPx != null &&
+    imeBottomPx > 0 &&
+    surfaceTopPx + geometry.surfaceHeightPx >
+    geometry.rootBottomPx - imeBottomPx
+
+internal fun decideComposerImeAnchorAction(
+    snapshot: ComposerImeAnchorSnapshot,
+): ComposerImeAnchorAction {
+    if (!snapshot.imeVisible) {
+        if (!snapshot.autoExpandedFromPartial) {
+            return ComposerImeAnchorAction.None
+        }
+        if (
+            snapshot.hasPartiallyExpandedState &&
+            snapshot.targetValue == SheetValue.Expanded &&
+            snapshot.currentValue != SheetValue.Expanded
+        ) {
+            return ComposerImeAnchorAction.None
+        }
+        return if (
+            snapshot.hasPartiallyExpandedState &&
+            snapshot.currentValue == SheetValue.Expanded &&
+            snapshot.targetValue == SheetValue.Expanded
+        ) {
+            ComposerImeAnchorAction.RestorePartial
+        } else {
+            ComposerImeAnchorAction.ReleaseOwnership
+        }
+    }
+
+    if (
+        snapshot.overlapsKeyboard &&
+        snapshot.currentValue == SheetValue.PartiallyExpanded &&
+        snapshot.targetValue == SheetValue.PartiallyExpanded
+    ) {
+        return ComposerImeAnchorAction.ExpandFromPartial
+    }
+
+    return ComposerImeAnchorAction.None
+}

--- a/app2/src/main/java/com/pocketshell/next/composer/PromptComposerSheet.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/PromptComposerSheet.kt
@@ -1,0 +1,174 @@
+package com.pocketshell.next.composer
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.core.content.ContextCompat
+import com.pocketshell.uikit.components.SheetHeader
+
+const val COMPOSER_TITLE_TAG: String = "composer-title"
+const val COMPOSER_CLOSE_TAG: String = "composer-close"
+const val COMPOSER_SHEET_TITLE: String = "Prompt Composer"
+
+/** What a mic tap does, given the current permission and recording state. */
+enum class MicTapAction {
+    /** Already recording, or RECORD_AUDIO is granted: start or stop dictation. */
+    StartOrStop,
+
+    /** First tap on a fresh install: ask for RECORD_AUDIO before the recognizer. */
+    RequestPermission,
+}
+
+/**
+ * The RECORD_AUDIO gate (#2521).
+ *
+ * The rewrite's `ComposerBar` called `SpeechRecognizer` with no runtime
+ * prompt, which is the dictation crash on a fresh install. A tap while
+ * already recording always stops (the permission is already held). A tap
+ * that would START recording requests the permission first when it is not
+ * granted; denied does not start the recognizer.
+ */
+fun decideMicTap(hasRecordAudioPermission: Boolean, recording: Boolean): MicTapAction =
+    if (recording || hasRecordAudioPermission) {
+        MicTapAction.StartOrStop
+    } else {
+        MicTapAction.RequestPermission
+    }
+
+/**
+ * Prompt Composer as a floating [androidx.compose.material3.ModalBottomSheet]
+ * over the terminal (D11, #2521).
+ *
+ * Restore of the v0.4.47 chrome — title, close, draft, mic, Insert / Send —
+ * on the rewrite send path (no outbound queue). Opening this sheet must not
+ * sit in the session column: the terminal underneath keeps its cell count.
+ *
+ * [hasRecordAudioPermission] is a test seam. Production leaves it null and
+ * reads `ContextCompat.checkSelfPermission`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PromptComposerSheet(
+    state: ComposerUiState,
+    onDismiss: () -> Unit,
+    onDraftChange: (String) -> Unit,
+    onSend: () -> Unit,
+    onInsert: () -> Unit,
+    onAttach: () -> Unit,
+    onMicTap: () -> Unit,
+    onCancelRecording: () -> Unit,
+    onToggleHistory: () -> Unit,
+    onTogglePreview: () -> Unit,
+    onRemoveAttachment: (String) -> Unit,
+    onDismissNotice: () -> Unit,
+    onDiscard: () -> Unit,
+    onPermissionDenied: () -> Unit,
+    modifier: Modifier = Modifier,
+    hasRecordAudioPermission: (() -> Boolean)? = null,
+) {
+    val context = LocalContext.current
+    val permissionGranted: () -> Boolean = hasRecordAudioPermission ?: {
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.RECORD_AUDIO,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) onMicTap() else onPermissionDenied()
+    }
+
+    val dismiss = {
+        onCancelRecording()
+        onDismiss()
+    }
+
+    ComposerModalBottomSheet(
+        onDismissRequest = dismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        modifier = modifier,
+    ) {
+        PromptComposerContent(
+            state = state,
+            onClose = dismiss,
+            onDraftChange = onDraftChange,
+            onSend = onSend,
+            onInsert = onInsert,
+            onAttach = onAttach,
+            onMicTap = {
+                when (
+                    decideMicTap(
+                        hasRecordAudioPermission = permissionGranted(),
+                        recording = state.recording == RecordingState.Recording,
+                    )
+                ) {
+                    MicTapAction.StartOrStop -> onMicTap()
+                    MicTapAction.RequestPermission ->
+                        permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                }
+            },
+            onCancelRecording = onCancelRecording,
+            onToggleHistory = onToggleHistory,
+            onTogglePreview = onTogglePreview,
+            onRemoveAttachment = onRemoveAttachment,
+            onDismissNotice = onDismissNotice,
+            onDiscard = onDiscard,
+        )
+    }
+}
+
+/**
+ * Sheet body without the modal window, so host-JVM tests can drive Insert /
+ * Send / mic without Robolectric dropping clicks on a `ModalBottomSheet`.
+ */
+@Composable
+fun PromptComposerContent(
+    state: ComposerUiState,
+    onClose: () -> Unit,
+    onDraftChange: (String) -> Unit,
+    onSend: () -> Unit,
+    onInsert: () -> Unit,
+    onAttach: () -> Unit,
+    onMicTap: () -> Unit,
+    onCancelRecording: () -> Unit,
+    onToggleHistory: () -> Unit,
+    onTogglePreview: () -> Unit,
+    onRemoveAttachment: (String) -> Unit,
+    onDismissNotice: () -> Unit,
+    onDiscard: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.navigationBarsPadding()) {
+        SheetHeader(
+            title = COMPOSER_SHEET_TITLE,
+            titleTestTag = COMPOSER_TITLE_TAG,
+            onClose = onClose,
+            closeContentDescription = "Close Prompt Composer",
+            closeTestTag = COMPOSER_CLOSE_TAG,
+        )
+        ComposerBar(
+            state = state,
+            onDraftChange = onDraftChange,
+            onSend = onSend,
+            onInsert = onInsert,
+            onAttach = onAttach,
+            onMicTap = onMicTap,
+            onCancelRecording = onCancelRecording,
+            onToggleHistory = onToggleHistory,
+            onTogglePreview = onTogglePreview,
+            onRemoveAttachment = onRemoveAttachment,
+            onDismissNotice = onDismissNotice,
+            onDiscard = onDiscard,
+        )
+    }
+}

--- a/app2/src/main/java/com/pocketshell/next/terminal/HotkeyCatalog.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/HotkeyCatalog.kt
@@ -1,0 +1,68 @@
+package com.pocketshell.next.terminal
+
+import com.pocketshell.uikit.components.HotkeySection
+import com.pocketshell.uikit.model.KeyBinding
+import com.pocketshell.uikit.model.KeyKind
+
+/** Visible label for the dedicated Ctrl-picker action (#1662). */
+const val HOTKEY_CTRL_FLOW_LABEL: String = "Ctrl+…"
+
+/**
+ * Issue #1662 main page: a one-screenful catalog of common controls.
+ *
+ * Ported from v0.4.47 `TmuxHotkeyMainSections`. The old CTRL COMBOS, visible
+ * doubled tiles, sticky modifier, literal-letter grid, and expander are
+ * deliberately gone. Arbitrary control chords live on [HOTKEY_CTRL_SECTIONS].
+ */
+val HOTKEY_MAIN_SECTIONS: List<HotkeySection> = listOf(
+    HotkeySection(
+        title = "ARROWS",
+        keys = listOf(
+            KeyBinding(label = KEY_LABEL_ARROW_LEFT, kind = KeyKind.Arrow),
+            KeyBinding(label = KEY_LABEL_ARROW_UP, kind = KeyKind.Arrow),
+            KeyBinding(label = KEY_LABEL_ARROW_DOWN, kind = KeyKind.Arrow),
+            KeyBinding(label = KEY_LABEL_ARROW_RIGHT, kind = KeyKind.Arrow),
+        ),
+        columns = 4,
+    ),
+    HotkeySection(
+        title = "KEYS",
+        keys = listOf(
+            KeyBinding(label = KEY_LABEL_ESC, kind = KeyKind.Regular),
+            KeyBinding(label = KEY_LABEL_TAB, kind = KeyKind.Regular),
+            KeyBinding(label = KEY_LABEL_SHIFT_TAB, kind = KeyKind.Regular),
+            KeyBinding(label = KEY_LABEL_ENTER, kind = KeyKind.Regular),
+        ),
+        columns = 4,
+    ),
+    HotkeySection(
+        title = "CTRL",
+        keys = listOf(
+            KeyBinding(label = "^B", kind = KeyKind.Regular),
+            KeyBinding(label = "^C", kind = KeyKind.Regular),
+            KeyBinding(label = "^D", kind = KeyKind.Regular),
+            KeyBinding(label = "^Q", kind = KeyKind.Regular),
+            KeyBinding(label = "^X", kind = KeyKind.Regular),
+        ),
+        columns = 5,
+    ),
+)
+
+private val CTRL_ROWS: List<String> = listOf("QWERT", "YUIOP", "ASDFG", "HJKL", "ZXCVB", "NM\\")
+
+private fun controlBindings(keys: String): List<KeyBinding> =
+    keys.map { key -> KeyBinding("^$key", KeyKind.Regular) }
+
+/**
+ * Issue #1662 Ctrl page: every control chord the old sheet exposed, arranged
+ * by QWERTY muscle memory in five columns. Labels include the caret so the
+ * same `^<char>` parser handles both pages.
+ */
+val HOTKEY_CTRL_SECTIONS: List<HotkeySection> = listOf(
+    HotkeySection(
+        title = "CTRL + KEY",
+        keys = CTRL_ROWS.flatMap(::controlBindings),
+        columns = 5,
+        rows = CTRL_ROWS.map(::controlBindings),
+    ),
+)

--- a/app2/src/main/java/com/pocketshell/next/terminal/KeyBytes.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/KeyBytes.kt
@@ -1,35 +1,16 @@
 package com.pocketshell.next.terminal
 
 /**
- * What each key bar slot puts on the wire (rewrite task U-5).
+ * What each hotkeys-panel slot puts on the wire (rewrite task U-5, restored
+ * catalog in #2521).
  *
- * ## Why this file exists at all
- *
- * The ui-kit's `KeyBar` is pure render plus a sticky-modifier state machine —
- * its own KDoc says "the semantic mapping (which keystroke this corresponds to
- * on the wire) is left to the caller". app2 talks to a plain PTY, so the
- * mapping is the raw control bytes a VT terminal has used since the 1970s, not
- * tmux `send-keys` named keys (the pre-rewrite client's mapping, which existed
- * because it drove a `-CC` control channel rather than a terminal).
+ * app2 talks to a plain PTY, so the mapping is the raw control bytes a VT
+ * terminal has used since the 1970s, not tmux `send-keys` named keys. The
+ * #1662 panel catalog (arrows, Esc/Tab/⇧Tab/Enter, `^B ^C ^D ^Q ^X`, and
+ * the Ctrl-page letters) all route through [keyBarBytes].
  *
  * Everything here is a pure function of its arguments: no Android types, no
- * Compose, no session state. The tap/arm/clear state machine belongs to
- * `KeyBar`; the "which byte" question belongs here; the "who do I send it to"
- * question belongs to [SessionViewModel].
- *
- * ## The trimmed key set
- *
- * Four slots — Ctrl, Esc, Tab, Enter — per the maintainer's 2026-09-03 scope
- * cut ("I need Ctrl+C, Ctrl+D, Escape, Enter, this kind of thing; most of the
- * shortcuts I don't really use"). D18's original eight-slot Esc/Tab/Ctrl/Alt/
- * arrows bar is explicitly NOT built, so there are deliberately no arrow-key or
- * Alt encodings below: an unexposed table is dead code, and dead code in an
- * encoder is the kind that silently rots until someone trusts it.
- *
- * Ctrl is the only modifier. It arms the NEXT character — which normally comes
- * from the on-screen keyboard, not from this bar, since a phone keyboard
- * already has every letter and the bar only needs to supply what a phone
- * keyboard lacks.
+ * Compose, no session state.
  */
 
 /** The label the key bar renders for the sticky Ctrl modifier. */
@@ -43,6 +24,27 @@ const val KEY_LABEL_TAB: String = "Tab"
 
 /** The label for Return. */
 const val KEY_LABEL_ENTER: String = "Enter"
+
+/** Back-tab / Shift+Tab. Emits CSI `Z`. */
+const val KEY_LABEL_SHIFT_TAB: String = "⇧Tab"
+
+/** Left arrow. */
+const val KEY_LABEL_ARROW_LEFT: String = "←"
+
+/** Up arrow. */
+const val KEY_LABEL_ARROW_UP: String = "↑"
+
+/** Down arrow. */
+const val KEY_LABEL_ARROW_DOWN: String = "↓"
+
+/** Right arrow. */
+const val KEY_LABEL_ARROW_RIGHT: String = "→"
+
+/** Long-press `^C`: two interrupt bytes. */
+const val KEY_LABEL_INTERRUPT_X2: String = "^C×2"
+
+/** Long-press `^D`: two EOF bytes. */
+const val KEY_LABEL_EOF_X2: String = "^D×2"
 
 /** `ESC` — 0x1B. */
 private const val BYTE_ESC: Byte = 0x1B
@@ -68,20 +70,40 @@ private const val BYTE_CR: Byte = 0x0D
  * modifier by itself never reaches the remote — it decorates the next key.
  *
  * [ctrlArmed] is accepted for every label rather than only the character case
- * because the screen cannot know in advance which labels care. It happens that
- * none of the three named keys change under Ctrl (Ctrl+[ IS Esc, Ctrl+I IS
- * Tab, Ctrl+M IS Enter — the same bytes), so an armed Ctrl plus Esc/Tab/Enter
- * is correctly a no-op rather than a special case.
+ * because the screen cannot know in advance which labels care. Named keys
+ * (Esc/Tab/Enter, arrows, ⇧Tab, `^X`) do not change under a leftover armed
+ * Ctrl: Ctrl+[ IS Esc, Ctrl+I IS Tab, Ctrl+M IS Enter.
  *
- * @param label the tapped slot's label, as rendered by the bar.
- * @param ctrlArmed whether the Ctrl slot is armed (one-shot or locked).
+ * @param label the tapped slot's label, as rendered by the bar or panel.
+ * @param ctrlArmed whether a sticky Ctrl is armed (one-shot or locked).
  */
 fun keyBarBytes(label: String, ctrlArmed: Boolean = false): ByteArray? = when (label) {
     KEY_LABEL_CTRL -> null
     KEY_LABEL_ESC -> byteArrayOf(BYTE_ESC)
     KEY_LABEL_TAB -> byteArrayOf(BYTE_TAB)
-    KEY_LABEL_ENTER -> byteArrayOf(BYTE_CR)
-    else -> characterKeyBytes(label, ctrlArmed)
+    KEY_LABEL_ENTER, "⏎" -> byteArrayOf(BYTE_CR)
+    KEY_LABEL_SHIFT_TAB -> csi('Z')
+    KEY_LABEL_ARROW_LEFT, "‹", "Left" -> csi('D')
+    KEY_LABEL_ARROW_UP, "⌃", "Up" -> csi('A')
+    KEY_LABEL_ARROW_DOWN, "⌄", "Down" -> csi('B')
+    KEY_LABEL_ARROW_RIGHT, "›", "Right" -> csi('C')
+    KEY_LABEL_INTERRUPT_X2 -> byteArrayOf(0x03, 0x03)
+    KEY_LABEL_EOF_X2 -> byteArrayOf(0x04, 0x04)
+    else -> caretControlBytes(label) ?: characterKeyBytes(label, ctrlArmed)
+}
+
+/** CSI sequence: `ESC [ <final>`. */
+private fun csi(finalByte: Char): ByteArray =
+    byteArrayOf(BYTE_ESC, '['.code.toByte(), finalByte.code.toByte())
+
+/**
+ * `^X` / `^C` / `^\` labels from the #1662 catalog.
+ *
+ * Length-2 and a leading caret, so `^C×2` does not fall through here.
+ */
+private fun caretControlBytes(label: String): ByteArray? {
+    if (label.length != 2 || label[0] != '^') return null
+    return controlBytes(label[1].code)
 }
 
 /**

--- a/app2/src/main/java/com/pocketshell/next/terminal/SessionScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/SessionScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -23,10 +24,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
-import com.pocketshell.next.composer.ComposerBar
 import com.pocketshell.next.composer.ComposerUiState
 import com.pocketshell.next.composer.ComposerViewModel
 import com.pocketshell.next.composer.MessageHistorySheet
+import com.pocketshell.next.composer.PromptComposerSheet
 import com.pocketshell.next.composer.SentMessage
 import com.pocketshell.next.composer.SessionSink
 import com.pocketshell.next.usage.UsageGlancePill
@@ -36,12 +37,10 @@ import com.pocketshell.uikit.components.Banner
 import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.EmptyState
-import com.pocketshell.uikit.components.KeyBar
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
+import com.pocketshell.uikit.components.SessionLauncherBar
 import com.pocketshell.uikit.model.KeyBinding
-import com.pocketshell.uikit.model.KeyKind
-import com.pocketshell.uikit.model.KeyModifierState
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.termux.terminal.TerminalSession
@@ -54,31 +53,10 @@ const val SESSION_ERROR_BANNER_TAG: String = "session-error-banner"
 const val SESSION_RECONNECT_BANNER_TAG: String = "session-reconnect-banner"
 const val SESSION_RETRY_TAG: String = "session-retry"
 const val SESSION_BACK_TAG: String = "session-back"
-const val SESSION_KEY_BAR_TAG: String = "session-key-bar"
-
-/**
- * The key bar's slots (rewrite task U-5).
- *
- * Four, not D18's eight. The maintainer cut the scope on 2026-09-03 — "I need
- * Ctrl+C, Ctrl+D, Escape, Enter, this kind of thing; most of the shortcuts I
- * don't really use" — so the arrows and Alt are gone and the bar carries only
- * what a phone keyboard cannot produce at all. Tab is in despite not being
- * named because shell completion is near-universal and no soft keyboard sends
- * it into a terminal.
- *
- * Ctrl is the one modifier, and it is deliberately first: it is the slot the
- * user reaches for before typing a letter, and a thumb travels left to right.
- */
-val TERMINAL_KEY_BAR_KEYS: List<KeyBinding> = listOf(
-    KeyBinding(label = KEY_LABEL_CTRL, kind = KeyKind.Modifier),
-    KeyBinding(label = KEY_LABEL_ESC, kind = KeyKind.Regular),
-    KeyBinding(label = KEY_LABEL_TAB, kind = KeyKind.Regular),
-    KeyBinding(label = KEY_LABEL_ENTER, kind = KeyKind.Regular),
-)
 
 /**
  * Route-level entry point for `session/{hostId}/{sessionName}` (rewrite tasks
- * U-4, U-5, U-7 and P-1).
+ * U-4, U-5, U-7, P-1, and #2521).
  *
  * Two ViewModels, one screen. [SessionViewModel] owns the transport and the
  * terminal; [ComposerViewModel] owns the draft, its attachments and its
@@ -91,9 +69,9 @@ val TERMINAL_KEY_BAR_KEYS: List<KeyBinding> = listOf(
  * whenever the screen last recomposed, which is precisely when a send would
  * vanish into a dead pane and the draft would be cleared for it.
  *
- * The key bar's raw control bytes (Ctrl+C, Esc, Tab, Enter) go STRAIGHT to
- * [SessionViewModel.sendBytes] — they are not composed messages and have no
- * business in the composer's draft/history/attachment machinery.
+ * Hotkeys-panel bytes go STRAIGHT to [SessionViewModel.sendBytes] — they are
+ * not composed messages and have no business in the composer's
+ * draft/history/attachment machinery.
  */
 @Composable
 fun SessionRoute(
@@ -111,9 +89,6 @@ fun SessionRoute(
     val usagePillState by usageGlanceViewModel.state.collectAsState()
 
     LaunchedEffect(hostId, sessionName) { viewModel.open(hostId, sessionName) }
-    // The pill does its own foreground-only fetch (task P-5): no scheduler, no
-    // cache shared with the usage panel — a session open is itself a "view",
-    // same as opening the panel is.
     LifecycleEventEffect(Lifecycle.Event.ON_START) { usageGlanceViewModel.refresh() }
 
     val sink = remember(viewModel) {
@@ -126,17 +101,8 @@ fun SessionRoute(
         composerViewModel.bind(hostId, sessionName, sink)
     }
 
-    // Task P-2: the composer becoming visible again is the trigger for
-    // delivering anything dictated while the device was offline (the subway
-    // case) — see `ComposerViewModel.onForegroundResume`'s KDoc. `ON_START`
-    // rather than `ON_RESUME`: it also fires on the very first composition,
-    // which is exactly when a queued dictation from the last session should
-    // surface.
     LifecycleEventEffect(Lifecycle.Event.ON_START) { composerViewModel.onForegroundResume() }
 
-    // `OpenMultipleDocuments` rather than a media picker: the maintainer
-    // attaches logs, patches and screenshots, and the storage-access framework
-    // is the one picker that reaches all three without a storage permission.
     val picker = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenMultipleDocuments(),
     ) { uris: List<Uri> -> composerViewModel.attach(uris) }
@@ -150,9 +116,10 @@ fun SessionRoute(
         onOpenUsage = onOpenUsage,
         onResized = viewModel::onResized,
         onRetry = viewModel::retryNow,
-        onKeyBarSend = viewModel::sendBytes,
+        onHotkeySend = viewModel::sendBytes,
         onDraftChange = composerViewModel::onDraftChange,
         onSend = composerViewModel::send,
+        onInsert = composerViewModel::insert,
         onAttach = { picker.launch(arrayOf("*/*")) },
         onMicTap = composerViewModel::onMicTap,
         onCancelRecording = composerViewModel::cancelRecording,
@@ -162,74 +129,31 @@ fun SessionRoute(
         onDismissNotice = composerViewModel::dismissNotice,
         onDiscardDraft = composerViewModel::discard,
         onUseHistoryEntry = composerViewModel::useHistoryEntry,
+        onPermissionDenied = composerViewModel::surfacePermissionDenied,
         modifier = modifier,
     )
 }
 
 /**
- * One attached session: a title bar, a full-bleed terminal, the key bar, and
- * the composer.
+ * One attached session: a title bar, a full-bleed terminal, and a compact
+ * launcher bar. Prompt Composer and the hotkeys panel open as floating
+ * overlays (#2521) and do not sit in this column.
  *
- * ## Chrome, and what is still absent
+ * ## The keyboard shrinks the terminal, the overlays do not
  *
- * A name, a way back, the terminal, four keys, and one composer. No
- * conversation tab, no hotkey panel, no scroll affordances — every one of
- * those is a cut task, and each is a place the pre-rewrite screen accumulated
- * state that had to agree with the terminal's. The one thing the chrome does
- * say is WHICH session, because the tree can show several with similar names.
+ * [imePadding] on the column is what makes `stty size` on the remote track
+ * the system keyboard: the column shrinks, so the terminal slot shrinks, so
+ * the vendored view reports a new cell count through [onResized]. The
+ * composer and hotkeys sheets are [androidx.compose.material3.ModalBottomSheet]s
+ * — they float over the viewport and must not change that cell count, so
+ * imePadding is skipped while either overlay is open.
  *
- * ## The keyboard shrinks the terminal, it does not cover it
- *
- * [imePadding] on the whole column is what makes `stty size` on the remote
- * track the keyboard: the column shrinks, so the terminal slot shrinks, so the
- * vendored view relayouts and reports its new cell count through [onResized]
- * — the single path to `pty.resize`. The composer is the bottom-most child, so
- * it rides up with the IME too. That is why the composer is inline rather than
- * a modal sheet: a sheet floats in its own window and has to be re-anchored
- * against the IME by hand, which is 289 lines of machinery the old client
- * carried and this screen does not need. The same mechanism covers rotation,
- * which reaches the view as an ordinary layout-size change.
- *
- * ## The key bar is up before the terminal is
- *
- * It renders for `Connecting` and `Reconnecting` as well as `Live` so the
- * terminal slot has the SAME height throughout — the pre-attach size estimate
- * below would otherwise measure a slot two rows taller than the one the
- * terminal eventually gets, and the remote would be resized twice on every
- * attach. It is hidden on `Failed`, where there is nothing to send to.
- *
- * ## Reconnecting keeps the terminal — and the composer stays mounted through
- * a failure, on purpose
- *
- * [SessionUiState.Reconnecting] renders the SAME terminal surface as
- * [SessionUiState.Live], with a banner above it — the emulator is simply not
- * being fed, and tmux repaints it on reattach. The composer never unmounts,
- * not even on [SessionUiState.Failed]: that is the state in which a draft is
- * most valuable, and hiding the composer would delete the one thing the send
- * contract promises to keep.
- *
- * ## A failure offers Retry
- *
- * The ladder gives up eventually (task U-7), and the user gets the manual
- * retry the give-up message names, next to the way back.
- *
- * @param onResized the terminal's size in character cells. Called by the
- *   vendored view once it exists, and — before it does — by the pre-attach
- *   estimate, so the PTY opens at the phone's real geometry instead of 80x24.
- * @param onRetry manual retry after the reconnect ladder gives up (task U-7).
- * @param onKeyBarSend raw bytes for the remote: key bar taps, and Ctrl+key
- *   combinations the key bar armed and the keyboard completed. Bypasses the
- *   composer entirely — these are not composed messages.
- * @param usagePillState the top bar's usage glance pill (task P-5), or null
- *   before its first foreground fetch has landed — the pill is simply absent
- *   until then, never a placeholder.
- * @param onOpenUsage navigates to the usage panel; the pill's tap target.
- * @param cellMetrics the rendered face's cell metrics, used only for the
- *   pre-attach estimate. A seam with the production default, like
- *   [com.pocketshell.next.AppNavHost]'s screens: Robolectric's `Paint` reports
- *   a 1 px glyph with no ascent, so a host-JVM test needs real numbers to see
- *   this path run.
+ * @param onResized the terminal's size in character cells.
+ * @param onHotkeySend raw bytes for the remote from the hotkeys panel.
+ * @param initiallyShowComposer test seam: start with the composer sheet open.
+ * @param initiallyShowHotkeys test seam: start with the hotkeys panel open.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SessionScreen(
     state: SessionUiState,
@@ -240,9 +164,10 @@ fun SessionScreen(
     usagePillState: UsageGlancePillState? = null,
     onOpenUsage: () -> Unit = {},
     onRetry: () -> Unit,
-    onKeyBarSend: (ByteArray) -> Unit,
+    onHotkeySend: (ByteArray) -> Unit,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
+    onInsert: () -> Unit,
     onAttach: () -> Unit,
     onMicTap: () -> Unit,
     onCancelRecording: () -> Unit,
@@ -252,19 +177,20 @@ fun SessionScreen(
     onDismissNotice: () -> Unit,
     onDiscardDraft: () -> Unit,
     onUseHistoryEntry: (SentMessage) -> Unit,
+    onPermissionDenied: () -> Unit = {},
     modifier: Modifier = Modifier,
     cellMetrics: TerminalCellMetrics = rememberTerminalCellMetrics(),
+    initiallyShowComposer: Boolean = false,
+    initiallyShowHotkeys: Boolean = false,
 ) {
-    // The bar's sticky state is mirrored here rather than left inside `KeyBar`
-    // because two things need it: the bar itself (for the armed highlight) and
-    // the terminal view (to encode the next typed letter). `KeyBar` prefers a
-    // caller-supplied map over its own, so this is the single source.
-    var ctrl by remember { mutableStateOf(KeyModifierState.Off) }
+    var composerOpen by remember { mutableStateOf(initiallyShowComposer) }
+    var hotkeysOpen by remember { mutableStateOf(initiallyShowHotkeys) }
+    val overlayOpen = composerOpen || hotkeysOpen
 
     Column(
         modifier = modifier
             .fillMaxSize()
-            .imePadding()
+            .then(if (overlayOpen) Modifier else Modifier.imePadding())
             .testTag(SESSION_SCREEN_TAG),
     ) {
         ScreenHeader(
@@ -280,9 +206,6 @@ fun SessionScreen(
                     modifier = Modifier.testTag(SESSION_BACK_TAG),
                 )
             },
-            // The usage glance pill (task P-5) rides the top bar next to the
-            // session title, always visible once a reading exists — hidden
-            // (not a placeholder) until the first foreground fetch lands.
             trailing = usagePillState?.let { pillState ->
                 { UsageGlancePill(state = pillState, onClick = onOpenUsage) }
             },
@@ -292,15 +215,8 @@ fun SessionScreen(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
-                // The terminal renders its own background per cell, but the
-                // view can be laid out taller than the grid it has drawn so
-                // far; without this the gap flashes the theme surface.
                 .background(PocketShellColors.Background)
                 .onSizeChanged { size ->
-                    // Only until the terminal exists. From then on the view
-                    // owns the number — it has the renderer, so it has the
-                    // authoritative metrics — and a second reporter would fight
-                    // it on every layout pass.
                     if (state !is SessionUiState.Live) {
                         terminalCells(size.width, size.height, cellMetrics)?.let { cells ->
                             onResized(cells.cols, cells.rows)
@@ -320,15 +236,6 @@ fun SessionScreen(
                 is SessionUiState.Live -> TerminalHostView(
                     session = state.terminal,
                     onResized = onResized,
-                    ctrlArmed = ctrl != KeyModifierState.Off,
-                    onControlBytes = { bytes ->
-                        onKeyBarSend(bytes)
-                        // The key that consumed the modifier came from the
-                        // keyboard, not from the bar, so the bar's own
-                        // auto-clear never fires. A LOCKED Ctrl survives, which
-                        // is the point of locking it.
-                        if (ctrl == KeyModifierState.OneShot) ctrl = KeyModifierState.Off
-                    },
                     modifier = Modifier.fillMaxSize(),
                 )
 
@@ -351,7 +258,6 @@ fun SessionScreen(
                             .padding(bottom = PocketShellSpacing.sm)
                             .testTag(SESSION_RECONNECT_BANNER_TAG),
                     )
-                    // The last frame stays exactly where it was, under the banner.
                     Terminal(
                         session = state.terminal,
                         onResized = onResized,
@@ -388,18 +294,29 @@ fun SessionScreen(
             }
         }
 
-        if (state !is SessionUiState.Failed) {
-            TerminalKeyBar(
-                ctrl = ctrl,
-                onCtrlChange = { ctrl = it },
-                onSend = onKeyBarSend,
-            )
-        }
+        SessionLauncherBar(
+            onOpenComposer = {
+                hotkeysOpen = false
+                composerOpen = true
+            },
+            onOpenHotkeys = if (state is SessionUiState.Failed) {
+                null
+            } else {
+                {
+                    composerOpen = false
+                    hotkeysOpen = true
+                }
+            },
+        )
+    }
 
-        ComposerBar(
+    if (composerOpen) {
+        PromptComposerSheet(
             state = composerState,
+            onDismiss = { composerOpen = false },
             onDraftChange = onDraftChange,
             onSend = onSend,
+            onInsert = onInsert,
             onAttach = onAttach,
             onMicTap = onMicTap,
             onCancelRecording = onCancelRecording,
@@ -408,6 +325,17 @@ fun SessionScreen(
             onRemoveAttachment = onRemoveAttachment,
             onDismissNotice = onDismissNotice,
             onDiscard = onDiscardDraft,
+            onPermissionDenied = onPermissionDenied,
+        )
+    }
+
+    if (hotkeysOpen) {
+        TerminalHotkeysSheet(
+            onKey = { binding: KeyBinding ->
+                keyBarBytes(binding.label)?.let(onHotkeySend)
+            },
+            onDismiss = { hotkeysOpen = false },
+            enabled = state is SessionUiState.Live,
         )
     }
 
@@ -429,9 +357,6 @@ private fun Terminal(
     Box(
         modifier = modifier
             .fillMaxSize()
-            // The terminal renders its own background per cell, but the view can
-            // be laid out taller than the grid it has drawn so far; without this
-            // the gap flashes the theme surface.
             .background(PocketShellColors.Background),
     ) {
         TerminalHostView(
@@ -442,46 +367,9 @@ private fun Terminal(
     }
 }
 
-/**
- * The ui-kit [KeyBar], wired to the wire.
- *
- * The component owns the tap gestures and the sticky one-shot/lock state
- * machine; this owns the semantics — which bytes a slot stands for, and where
- * they go. Modifier taps never reach [onSend]: `KeyBar` reports them through
- * `onModifierStateChange` only, which is what makes "arm Ctrl, then type a
- * letter on the keyboard" possible at all.
- */
-@Composable
-private fun TerminalKeyBar(
-    ctrl: KeyModifierState,
-    onCtrlChange: (KeyModifierState) -> Unit,
-    onSend: (ByteArray) -> Unit,
-) {
-    KeyBar(
-        keys = TERMINAL_KEY_BAR_KEYS,
-        onKey = { binding ->
-            keyBarBytes(binding.label, ctrlArmed = ctrl != KeyModifierState.Off)?.let(onSend)
-        },
-        modifierStates = mapOf(KEY_LABEL_CTRL to ctrl),
-        onModifierStateChange = { binding, next ->
-            if (binding.label == KEY_LABEL_CTRL) onCtrlChange(next)
-        },
-        modifier = Modifier.testTag(SESSION_KEY_BAR_TAG),
-    )
-}
-
-/**
- * The reconnect banner's text.
- *
- * Both numbers are load bearing: the attempt says the app is still working
- * rather than stuck, and the countdown says how long the wait is instead of
- * making the user guess whether anything will happen. The attempt is rendered
- * 1-based — [ReconnectController] counts from 0, users do not.
- */
 private fun reconnectingMessage(state: SessionUiState.Reconnecting): String {
     val attempt = state.attempt + 1
     if (state.retryInMs <= 0) return "Reconnecting… attempt $attempt · retrying now"
-    // Rounded UP, so a countdown never displays "0s" while it is still waiting.
     val seconds = (state.retryInMs + 999) / 1000
     return "Reconnecting… attempt $attempt · retrying in ${seconds}s"
 }

--- a/app2/src/main/java/com/pocketshell/next/terminal/TerminalHotkeysSheet.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/TerminalHotkeysSheet.kt
@@ -1,0 +1,116 @@
+package com.pocketshell.next.terminal
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.pocketshell.uikit.components.HotkeyLongPressAction
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
+import com.pocketshell.uikit.components.TerminalHotkeysPanel
+import com.pocketshell.uikit.components.TerminalHotkeysPage
+import com.pocketshell.uikit.model.KeyBinding
+import com.pocketshell.uikit.model.KeyKind
+import com.pocketshell.uikit.theme.PocketShellColors
+
+/**
+ * The dedicated terminal-hotkeys panel in its own [ModalBottomSheet] (#2521,
+ * ported from v0.4.47 `TerminalHotkeysSheet`).
+ *
+ * Opened from the compact `⌨` launcher. Stays open after a key tap so the
+ * user can fire several keys in a row; `×` / scrim / system back dismiss it.
+ * The body is the ui-kit [TerminalHotkeysPanel]; this sheet owns Main/Ctrl
+ * page state. Per-key bytes go through [keyBarBytes] via [onKey].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TerminalHotkeysSheet(
+    onKey: (KeyBinding) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+) {
+    var page by remember { mutableStateOf(TerminalHotkeysPage.Main) }
+
+    BackHandler(enabled = page == TerminalHotkeysPage.Ctrl) {
+        page = TerminalHotkeysPage.Main
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = PocketShellColors.Surface,
+        contentColor = PocketShellColors.Text,
+        modifier = modifier,
+        contentWindowInsets = {
+            WindowInsets.safeDrawing.only(
+                WindowInsetsSides.Top + WindowInsetsSides.Horizontal,
+            )
+        },
+    ) {
+        Crossfade(
+            targetState = page,
+            animationSpec = tween(durationMillis = 150),
+            label = "terminal-hotkeys-page",
+        ) { currentPage ->
+            TerminalHotkeysPanel(
+                sections = if (currentPage == TerminalHotkeysPage.Main) {
+                    HOTKEY_MAIN_SECTIONS
+                } else {
+                    HOTKEY_CTRL_SECTIONS
+                },
+                page = currentPage,
+                onKey = onKey,
+                onLongKey = { binding ->
+                    when (binding.label) {
+                        "^C" -> onKey(KeyBinding(KEY_LABEL_INTERRUPT_X2, KeyKind.Regular))
+                        "^D" -> onKey(KeyBinding(KEY_LABEL_EOF_X2, KeyKind.Regular))
+                    }
+                },
+                onOpenCtrlPage = {
+                    if (enabled) page = TerminalHotkeysPage.Ctrl
+                },
+                onBackToMain = {
+                    if (enabled) page = TerminalHotkeysPage.Main
+                },
+                onClose = onDismiss,
+                enabled = enabled,
+                ctrlFlowLabel = HOTKEY_CTRL_FLOW_LABEL,
+                longPressActions = if (currentPage == TerminalHotkeysPage.Main) {
+                    MainLongPressActions
+                } else {
+                    emptyMap()
+                },
+                modifier = Modifier
+                    .navigationBarsPadding()
+                    .testTag(TERMINAL_HOTKEYS_PANEL_TAG),
+            )
+        }
+    }
+}
+
+private val MainLongPressActions: Map<String, HotkeyLongPressAction> = mapOf(
+    "^C" to HotkeyLongPressAction(
+        cue = "hold ×2",
+        accessibilityLabel = "Send Ctrl-C twice",
+    ),
+    "^D" to HotkeyLongPressAction(
+        cue = "hold ×2",
+        accessibilityLabel = "Send Ctrl-D twice",
+    ),
+)

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerBarTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerBarTest.kt
@@ -37,6 +37,7 @@ class ComposerBarTest {
 
         composeRule.onNodeWithTag(COMPOSER_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(COMPOSER_SEND_TAG).assertIsNotEnabled()
+        composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).assertIsNotEnabled()
     }
 
     /**
@@ -62,6 +63,24 @@ class ComposerBarTest {
         setContent(ComposerUiState(draft = "something"))
 
         composeRule.onNodeWithTag(COMPOSER_SEND_TAG).assertIsEnabled()
+        composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).assertIsEnabled()
+    }
+
+    @Test
+    fun `insert and send are separate taps`() {
+        var inserts = 0
+        var sends = 0
+        setContent(
+            ComposerUiState(draft = "something"),
+            onInsert = { inserts += 1 },
+            onSend = { sends += 1 },
+        )
+
+        composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).performClick()
+        composeRule.onNodeWithTag(COMPOSER_SEND_TAG).performClick()
+
+        assertEquals(1, inserts)
+        assertEquals(1, sends)
     }
 
     /** An attachment on its own is a complete message. */
@@ -137,6 +156,7 @@ class ComposerBarTest {
         composeRule.onNodeWithTag(COMPOSER_ATTACH_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(COMPOSER_HISTORY_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(COMPOSER_SEND_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).assertDoesNotExist()
     }
 
     @Test
@@ -195,6 +215,7 @@ class ComposerBarTest {
         state: ComposerUiState,
         onDraftChange: (String) -> Unit = {},
         onSend: () -> Unit = {},
+        onInsert: () -> Unit = {},
         onRemoveAttachment: (String) -> Unit = {},
         onToggleHistory: () -> Unit = {},
     ) {
@@ -204,6 +225,7 @@ class ComposerBarTest {
                     state = state,
                     onDraftChange = onDraftChange,
                     onSend = onSend,
+                    onInsert = onInsert,
                     onAttach = {},
                     onMicTap = {},
                     onCancelRecording = {},

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerTextTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerTextTest.kt
@@ -77,6 +77,11 @@ class ComposerTextTest {
     }
 
     @Test
+    fun `insert bytes are the body with no carriage return`() {
+        assertEquals("hello", ComposerText.insertBytes("hello").toString(Charsets.UTF_8))
+    }
+
+    @Test
     fun `the session key pairs the host id with the session name`() {
         assertEquals("7/my project", ComposerText.sessionKey(7, "my project"))
     }

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
@@ -191,6 +191,36 @@ class ComposerViewModelTest {
         }
 
     @Test
+    fun `insert on a live session puts the text on the wire without a carriage return`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onDraftChange("run the tests")
+            advanceUntilIdle()
+
+            viewModel.insert()
+            advanceUntilIdle()
+
+            assertEquals(listOf("run the tests"), sink.sentText())
+            assertEquals("", viewModel.state.value.draft)
+        }
+
+    @Test
+    fun `insert with the session offline keeps the draft and shows the chip`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onDraftChange("this should survive")
+            advanceUntilIdle()
+            sink.isLive = false
+
+            viewModel.insert()
+            advanceUntilIdle()
+
+            assertTrue("nothing may reach a dead session", sink.sent.isEmpty())
+            assertEquals("this should survive", viewModel.state.value.draft)
+            assertEquals(ComposerNotice.Undelivered, viewModel.state.value.notice)
+        }
+
+    @Test
     fun `a delivered send clears the draft and the persisted copy`() = runTest(dispatcher) {
         val viewModel = bound()
         viewModel.onDraftChange("ship it")
@@ -818,6 +848,21 @@ class ComposerViewModelTest {
         assertEquals(RecordingState.Idle, viewModel.state.value.recording)
         assertTrue(viewModel.state.value.notice is ComposerNotice.Problem)
     }
+
+    @Test
+    fun `a denied record-audio permission surfaces a notice and does not start dictation`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+
+            viewModel.surfacePermissionDenied()
+            advanceUntilIdle()
+
+            assertEquals(RecordingState.Idle, viewModel.state.value.recording)
+            assertEquals(
+                ComposerNotice.Problem(COMPOSER_RECORD_AUDIO_DENIED_TEXT),
+                viewModel.state.value.notice,
+            )
+        }
 
     // ------------------------------------------------ offline-queued dictation
 

--- a/app2/src/test/java/com/pocketshell/next/composer/PromptComposerImeAnchorPolicyTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/PromptComposerImeAnchorPolicyTest.kt
@@ -1,0 +1,61 @@
+package com.pocketshell.next.composer
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Overlay-geometry IME policy ported from v0.4.47 (#2521). */
+@OptIn(ExperimentalMaterial3Api::class)
+class PromptComposerImeAnchorPolicyTest {
+
+    @Test
+    fun `a settled partial sheet that overlaps the keyboard expands`() {
+        val action = decideComposerImeAnchorAction(
+            ComposerImeAnchorSnapshot(
+                imeVisible = true,
+                overlapsKeyboard = true,
+                currentValue = SheetValue.PartiallyExpanded,
+                targetValue = SheetValue.PartiallyExpanded,
+                hasPartiallyExpandedState = true,
+                autoExpandedFromPartial = false,
+            ),
+        )
+        assertEquals(ComposerImeAnchorAction.ExpandFromPartial, action)
+    }
+
+    @Test
+    fun `hiding the ime restores a policy-owned expansion`() {
+        val action = decideComposerImeAnchorAction(
+            ComposerImeAnchorSnapshot(
+                imeVisible = false,
+                overlapsKeyboard = false,
+                currentValue = SheetValue.Expanded,
+                targetValue = SheetValue.Expanded,
+                hasPartiallyExpandedState = true,
+                autoExpandedFromPartial = true,
+            ),
+        )
+        assertEquals(ComposerImeAnchorAction.RestorePartial, action)
+    }
+
+    @Test
+    fun `a surface ending exactly at the keyboard is not overlapping`() {
+        assertFalse(
+            composerModalSurfaceOverlapsIme(
+                geometry = ComposerModalSurfaceGeometry(rootBottomPx = 2000, surfaceHeightPx = 400),
+                surfaceTopPx = 1600f,
+                imeBottomPx = 0,
+            ),
+        )
+        assertTrue(
+            composerModalSurfaceOverlapsIme(
+                geometry = ComposerModalSurfaceGeometry(rootBottomPx = 2000, surfaceHeightPx = 400),
+                surfaceTopPx = 1700f,
+                imeBottomPx = 400,
+            ),
+        )
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/composer/PromptComposerPermissionTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/PromptComposerPermissionTest.kt
@@ -1,0 +1,118 @@
+package com.pocketshell.next.composer
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The RECORD_AUDIO gate (#2521) and the Insert vs Send chrome on the
+ * Prompt Composer sheet.
+ */
+@RunWith(AndroidJUnit4::class)
+class PromptComposerPermissionTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `a mic tap without permission requests it and does not start dictation`() {
+        var micTaps = 0
+        var requested = 0
+        setContent(
+            hasPermission = false,
+            onMicTap = { micTaps += 1 },
+            onPermissionDenied = { requested += 1 },
+        )
+
+        composeRule.onNodeWithTag(COMPOSER_MIC_TAG).performClick()
+        composeRule.waitForIdle()
+
+        assertEquals("the recognizer must not start before RECORD_AUDIO is granted", 0, micTaps)
+        assertEquals(1, requested)
+    }
+
+    @Test
+    fun `a mic tap with permission starts dictation`() {
+        var micTaps = 0
+        setContent(hasPermission = true, onMicTap = { micTaps += 1 })
+
+        composeRule.onNodeWithTag(COMPOSER_MIC_TAG).performClick()
+        composeRule.waitForIdle()
+
+        assertEquals(1, micTaps)
+    }
+
+    @Test
+    fun `the sheet is titled Prompt Composer and offers Insert and Send`() {
+        var inserts = 0
+        var sends = 0
+        setContent(
+            state = ComposerUiState(draft = "hello", micAvailable = true),
+            onInsert = { inserts += 1 },
+            onSend = { sends += 1 },
+        )
+
+        composeRule.onNodeWithTag(COMPOSER_TITLE_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).performClick()
+        composeRule.onNodeWithTag(COMPOSER_SEND_TAG).performClick()
+
+        assertEquals(1, inserts)
+        assertEquals(1, sends)
+    }
+
+    @Test
+    fun `decideMicTap requests permission only when starting without it`() {
+        assertEquals(MicTapAction.RequestPermission, decideMicTap(hasRecordAudioPermission = false, recording = false))
+        assertEquals(MicTapAction.StartOrStop, decideMicTap(hasRecordAudioPermission = true, recording = false))
+        assertEquals(MicTapAction.StartOrStop, decideMicTap(hasRecordAudioPermission = false, recording = true))
+        assertEquals(MicTapAction.StartOrStop, decideMicTap(hasRecordAudioPermission = true, recording = true))
+    }
+
+    private fun setContent(
+        state: ComposerUiState = ComposerUiState(micAvailable = true),
+        hasPermission: Boolean = true,
+        onMicTap: () -> Unit = {},
+        onInsert: () -> Unit = {},
+        onSend: () -> Unit = {},
+        onPermissionDenied: () -> Unit = {},
+    ) {
+        composeRule.setContent {
+            PocketShellTheme {
+                PromptComposerContent(
+                    state = state,
+                    onClose = {},
+                    onDraftChange = {},
+                    onSend = onSend,
+                    onInsert = onInsert,
+                    onAttach = {},
+                    onMicTap = {
+                        when (
+                            decideMicTap(
+                                hasRecordAudioPermission = hasPermission,
+                                recording = state.recording == RecordingState.Recording,
+                            )
+                        ) {
+                            MicTapAction.StartOrStop -> onMicTap()
+                            MicTapAction.RequestPermission -> onPermissionDenied()
+                        }
+                    },
+                    onCancelRecording = {},
+                    onToggleHistory = {},
+                    onTogglePreview = {},
+                    onRemoveAttachment = {},
+                    onDismissNotice = {},
+                    onDiscard = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(COMPOSER_TITLE_TAG).assertIsDisplayed()
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/render/ComposerRenders.kt
+++ b/app2/src/test/java/com/pocketshell/next/render/ComposerRenders.kt
@@ -134,6 +134,7 @@ class ComposerRenders {
         state = state,
         onDraftChange = {},
         onSend = {},
+        onInsert = {},
         onAttach = {},
         onMicTap = {},
         onCancelRecording = {},

--- a/app2/src/test/java/com/pocketshell/next/render/SessionScreenRenders.kt
+++ b/app2/src/test/java/com/pocketshell/next/render/SessionScreenRenders.kt
@@ -41,7 +41,7 @@ import org.robolectric.annotation.GraphicsMode
 @Config(qualifiers = "w412dp-h915dp-night-xxhdpi")
 class SessionScreenRenders {
 
-    /** Attaching, with the key bar and composer already docked so the layout cannot jump. */
+    /** Attaching, with the compact launcher already docked so the layout cannot jump. */
     @Test
     fun sessionAttaching() = render("u5-session-attaching") {
         SessionScreen(
@@ -51,9 +51,10 @@ class SessionScreenRenders {
             onBack = {},
             onResized = { _, _ -> },
             onRetry = {},
-            onKeyBarSend = {},
+            onHotkeySend = {},
             onDraftChange = {},
             onSend = {},
+            onInsert = {},
             onAttach = {},
             onMicTap = {},
             onCancelRecording = {},
@@ -66,7 +67,7 @@ class SessionScreenRenders {
         )
     }
 
-    /** Attached: the four-slot bar and the composer under a full-bleed terminal. */
+    /** Attached: compact Prompt Composer + ⌨ launcher under a full-bleed terminal. */
     @Test
     fun sessionLiveWithKeyBar() = render("u5-session-key-bar") {
         SessionScreen(
@@ -76,9 +77,10 @@ class SessionScreenRenders {
             onBack = {},
             onResized = { _, _ -> },
             onRetry = {},
-            onKeyBarSend = {},
+            onHotkeySend = {},
             onDraftChange = {},
             onSend = {},
+            onInsert = {},
             onAttach = {},
             onMicTap = {},
             onCancelRecording = {},
@@ -103,9 +105,10 @@ class SessionScreenRenders {
             onBack = {},
             onResized = { _, _ -> },
             onRetry = {},
-            onKeyBarSend = {},
+            onHotkeySend = {},
             onDraftChange = {},
             onSend = {},
+            onInsert = {},
             onAttach = {},
             onMicTap = {},
             onCancelRecording = {},

--- a/app2/src/test/java/com/pocketshell/next/terminal/HotkeyCatalogTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/HotkeyCatalogTest.kt
@@ -1,0 +1,57 @@
+package com.pocketshell.next.terminal
+
+import com.pocketshell.uikit.model.KeyKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Issue #1662 production catalog contract, restored in #2521. */
+class HotkeyCatalogTest {
+
+    @Test
+    fun `main page is exactly the agreed common controls`() {
+        assertEquals(listOf("ARROWS", "KEYS", "CTRL"), HOTKEY_MAIN_SECTIONS.map { it.title })
+        assertEquals(
+            listOf(
+                "←", "↑", "↓", "→",
+                "Esc", "Tab", "⇧Tab", "Enter",
+                "^B", "^C", "^D", "^Q", "^X",
+            ),
+            HOTKEY_MAIN_SECTIONS.flatMap { section -> section.keys.map { it.label } },
+        )
+        assertTrue(HOTKEY_MAIN_SECTIONS.first().keys.all { it.kind == KeyKind.Arrow })
+    }
+
+    @Test
+    fun `ctrl page preserves qwerty rows and every previously reachable control letter`() {
+        val section = HOTKEY_CTRL_SECTIONS.single()
+        assertEquals(
+            listOf("QWERT", "YUIOP", "ASDFG", "HJKL", "ZXCVB", "NM\\"),
+            section.rows.map { row -> row.joinToString("") { it.label.removePrefix("^") } },
+        )
+        assertEquals(
+            (('A'..'Z').map { "^$it" } + "^\\").toSet(),
+            section.keys.map { it.label }.toSet(),
+        )
+    }
+
+    @Test
+    fun `duplicated old catalog and literal letters are gone`() {
+        val visible = (HOTKEY_MAIN_SECTIONS + HOTKEY_CTRL_SECTIONS)
+            .flatMap { it.keys }
+            .map { it.label }
+
+        listOf(
+            KEY_LABEL_INTERRUPT_X2,
+            KEY_LABEL_EOF_X2,
+            "Ctrl",
+            "a",
+            "z",
+        ).forEach { obsolete ->
+            assertFalse("$obsolete must not remain a visible tile", visible.contains(obsolete))
+        }
+        assertEquals(2, visible.count { it == "^C" })
+        assertEquals(2, visible.count { it == "^D" })
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/terminal/KeyBytesTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/KeyBytesTest.kt
@@ -184,4 +184,45 @@ class KeyBytesTest {
             assertEquals(1, controlBytes(codePoint)?.size)
         }
     }
+
+    // --- #1662 hotkeys-panel catalog ---------------------------------------
+
+    @Test
+    fun `arrows send CSI cursor sequences`() {
+        assertArrayEquals(byteArrayOf(0x1B, '['.code.toByte(), 'D'.code.toByte()), keyBarBytes("←"))
+        assertArrayEquals(byteArrayOf(0x1B, '['.code.toByte(), 'A'.code.toByte()), keyBarBytes("↑"))
+        assertArrayEquals(byteArrayOf(0x1B, '['.code.toByte(), 'B'.code.toByte()), keyBarBytes("↓"))
+        assertArrayEquals(byteArrayOf(0x1B, '['.code.toByte(), 'C'.code.toByte()), keyBarBytes("→"))
+    }
+
+    @Test
+    fun `shift-tab sends CSI Z`() {
+        assertArrayEquals(
+            byteArrayOf(0x1B, '['.code.toByte(), 'Z'.code.toByte()),
+            keyBarBytes(KEY_LABEL_SHIFT_TAB),
+        )
+    }
+
+    @Test
+    fun `caret-X is the cancel byte`() {
+        assertArrayEquals(byteArrayOf(0x18), keyBarBytes("^X"))
+    }
+
+    @Test
+    fun `long-press interrupt and eof send two bytes`() {
+        assertArrayEquals(byteArrayOf(0x03, 0x03), keyBarBytes(KEY_LABEL_INTERRUPT_X2))
+        assertArrayEquals(byteArrayOf(0x04, 0x04), keyBarBytes(KEY_LABEL_EOF_X2))
+    }
+
+    @Test
+    fun `caret labels on the ctrl page map the whole alphabet`() {
+        ('A'..'Z').forEachIndexed { index, letter ->
+            assertArrayEquals(
+                "Ctrl+$letter",
+                byteArrayOf((index + 1).toByte()),
+                keyBarBytes("^$letter"),
+            )
+        }
+        assertArrayEquals(byteArrayOf(0x1C), keyBarBytes("^\\"))
+    }
 }

--- a/app2/src/test/java/com/pocketshell/next/terminal/SessionKeyBarTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/SessionKeyBarTest.kt
@@ -2,14 +2,23 @@ package com.pocketshell.next.terminal
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
-import com.pocketshell.next.composer.ComposerUiState
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.next.composer.ComposerUiState
+import com.pocketshell.uikit.components.SESSION_COMPOSER_LAUNCHER_TAG
+import com.pocketshell.uikit.components.SESSION_HOTKEYS_LAUNCHER_TAG
+import com.pocketshell.uikit.components.SESSION_LAUNCHER_BAR_TAG
+import com.pocketshell.uikit.components.TERMINAL_HOTKEYS_PANEL_TAG
+import com.pocketshell.uikit.components.TerminalHotkeysPanel
+import com.pocketshell.uikit.components.TerminalHotkeysPage
+import com.pocketshell.uikit.model.KeyBinding
 import com.pocketshell.uikit.theme.PocketShellTheme
 import com.termux.view.TerminalView
 import org.junit.Assert.assertArrayEquals
@@ -20,25 +29,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * The key bar wired into the session screen (rewrite task U-5), on the host JVM.
- *
- * ## What this proves that the byte tables cannot
+ * The hotkeys panel wired into the session screen (#2521).
  *
  * `KeyBytesTest` pins what each key MEANS. This pins that the real ui-kit
- * `KeyBar` — its own sticky one-shot/lock state machine, unmodified — is wired
- * to those bytes and to the send path, including the interaction the whole
- * design turns on: **Ctrl is armed on the bar and the letter arrives from the
- * keyboard**, because a phone keyboard has every letter and no Ctrl.
+ * `TerminalHotkeysPanel` is opened from the compact launcher, that a tap
+ * reaches [keyBarBytes], and that the panel stays open afterwards.
  *
- * That letter is driven through the REAL vendored input path
- * (`TerminalView.inputCodePoint`, the method the IME and a hardware keyboard
- * both funnel into), not by calling the screen's callback directly — a test
- * that skipped it would still pass with `readControlKey()` left returning
- * `false`, which is precisely the bug that would make Ctrl+C do nothing on a
- * phone.
- *
- * J03 proves the same round trip end to end against a real host: `sleep 100`,
- * Ctrl, `c`, prompt back.
+ * J03 proves the same round trip end to end against a real host: `sleep`,
+ * `^C` from the panel, prompt back.
  */
 @RunWith(AndroidJUnit4::class)
 class SessionKeyBarTest {
@@ -48,184 +46,116 @@ class SessionKeyBarTest {
 
     private var rootView: View? = null
 
-    // --- presence ------------------------------------------------------------
-
-    /**
-     * The bar is up before the terminal is.
-     *
-     * Not cosmetic: the terminal slot must be the same height while attaching
-     * and once attached, or the pre-attach size estimate measures a taller slot
-     * than the terminal eventually gets and the remote is resized twice on
-     * every single attach.
-     */
     @Test
-    fun `the key bar is present while still attaching`() {
+    fun `the compact launcher is present while still attaching`() {
         setContent(SessionUiState.Connecting)
 
-        composeRule.onNodeWithTag(SESSION_KEY_BAR_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_LAUNCHER_BAR_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).assertIsDisplayed()
     }
 
     @Test
-    fun `the key bar is present once the session is live`() {
+    fun `the compact launcher is present once the session is live`() {
         setContent(SessionUiState.Live(createRemoteTerminalSession()))
 
-        composeRule.onNodeWithTag(SESSION_KEY_BAR_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_LAUNCHER_BAR_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).assertIsDisplayed()
     }
 
-    /** The four slots the maintainer asked for, and nothing else. */
     @Test
-    fun `the bar carries exactly ctrl esc tab and enter`() {
+    fun `closed chrome has no always-visible key bar`() {
         setContent(SessionUiState.Live(createRemoteTerminalSession()))
 
-        listOf(KEY_LABEL_CTRL, KEY_LABEL_ESC, KEY_LABEL_TAB, KEY_LABEL_ENTER).forEach { label ->
-            composeRule.onNodeWithText(label).assertIsDisplayed()
-        }
-        assertEquals(4, TERMINAL_KEY_BAR_KEYS.size)
-        // D18's arrows/Alt are explicitly out of scope (maintainer, 2026-09-03).
-        listOf("Alt", "←", "→", "↑", "↓").forEach { absent ->
-            composeRule.onNodeWithText(absent).assertDoesNotExist()
+        listOf("Ctrl", "Esc", "Tab", "Enter").forEach { label ->
+            composeRule.onNodeWithText(label).assertDoesNotExist()
         }
     }
 
-    /** Nothing to send to: a failed session hides the bar rather than lying. */
     @Test
-    fun `a failed session has no key bar`() {
+    fun `a failed session has no hotkeys launcher`() {
         setContent(SessionUiState.Failed("Session \"$SESSION\" ended (exit 3)."))
 
-        composeRule.onNodeWithTag(SESSION_KEY_BAR_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).assertDoesNotExist()
     }
 
-    // --- taps ----------------------------------------------------------------
+    @Test
+    fun `tapping the hotkeys chip opens the panel`() {
+        setContent(SessionUiState.Live(createRemoteTerminalSession()))
+
+        composeRule.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("^C").assertIsDisplayed()
+        composeRule.onNodeWithText(KEY_LABEL_ENTER).assertIsDisplayed()
+        composeRule.onNodeWithText(KEY_LABEL_SHIFT_TAB).assertIsDisplayed()
+    }
 
     @Test
-    fun `tapping escape sends the escape byte`() {
-        val sent = mutableListOf<ByteArray>()
-        setContent(SessionUiState.Live(createRemoteTerminalSession()), onSend = { sent += it })
-
-        composeRule.onNodeWithText(KEY_LABEL_ESC).performClick()
-
+    fun `tapping escape on the panel sends the escape byte and stays open`() {
+        val sent = tapHotkey(KEY_LABEL_ESC)
         assertEquals(1, sent.size)
         assertArrayEquals(byteArrayOf(0x1B), sent.single())
+        composeRule.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_TAG).assertIsDisplayed()
     }
 
     @Test
-    fun `tapping tab sends the tab byte`() {
-        val sent = mutableListOf<ByteArray>()
-        setContent(SessionUiState.Live(createRemoteTerminalSession()), onSend = { sent += it })
-
-        composeRule.onNodeWithText(KEY_LABEL_TAB).performClick()
-
-        assertArrayEquals(byteArrayOf(0x09), sent.single())
-    }
-
-    @Test
-    fun `tapping enter sends carriage return`() {
-        val sent = mutableListOf<ByteArray>()
-        setContent(SessionUiState.Live(createRemoteTerminalSession()), onSend = { sent += it })
-
-        composeRule.onNodeWithText(KEY_LABEL_ENTER).performClick()
-
+    fun `tapping enter on the panel sends carriage return`() {
+        val sent = tapHotkey(KEY_LABEL_ENTER)
         assertArrayEquals(byteArrayOf(0x0D), sent.single())
+        composeRule.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_TAG).assertIsDisplayed()
     }
 
-    /**
-     * A modifier is not a key. Tapping Ctrl must put NOTHING on the wire — if
-     * it did, every Ctrl+C would send a stray byte to the shell first.
-     */
     @Test
-    fun `tapping ctrl sends nothing`() {
-        val sent = mutableListOf<ByteArray>()
-        setContent(SessionUiState.Live(createRemoteTerminalSession()), onSend = { sent += it })
-
-        composeRule.onNodeWithText(KEY_LABEL_CTRL).performClick()
-
-        assertTrue("a modifier tap must not reach the remote, got $sent", sent.isEmpty())
-    }
-
-    // --- the Ctrl round trip -------------------------------------------------
-
-    /**
-     * The headline interaction: arm Ctrl on the bar, type `c` on the keyboard,
-     * get 0x03 — and Ctrl disarms itself afterwards.
-     *
-     * Every step runs through production code: the real `KeyBar` decides that
-     * the tap arms a one-shot, the real `TerminalView.inputCodePoint` asks the
-     * screen's client whether Ctrl is down, and the real client encodes the
-     * combination. The disarm is asserted by sending a SECOND `c` and getting
-     * a plain letter back — a one-shot that silently latched would make the
-     * next thing the user typed disappear into control codes.
-     */
-    @Test
-    fun `arming ctrl on the bar makes the next typed letter a control byte`() {
-        val sent = mutableListOf<ByteArray>()
-        setContent(SessionUiState.Live(createRemoteTerminalSession()), onSend = { sent += it })
-
-        composeRule.onNodeWithText(KEY_LABEL_CTRL).performClick()
-        composeRule.waitForIdle()
-
-        typeCodePoint('c')
-
-        assertEquals("exactly one send for one keystroke", 1, sent.size)
+    fun `tapping caret-C on the panel sends the interrupt byte`() {
+        val sent = tapHotkey("^C")
         assertArrayEquals(byteArrayOf(0x03), sent.single())
-
-        // The one-shot cleared: the vendored path handles the plain letter
-        // itself, so the screen's send callback is not called again.
-        typeCodePoint('c')
-        assertEquals("Ctrl must not have latched, got $sent", 1, sent.size)
+        composeRule.onNodeWithTag(TERMINAL_HOTKEYS_PANEL_TAG).assertIsDisplayed()
     }
 
-    /**
-     * Double-tapping Ctrl locks it, and a locked modifier survives the key it
-     * modified — that is what the lock is for (`^C^C` to a stubborn agent
-     * without re-arming between them).
-     */
     @Test
-    fun `double-tapping ctrl locks it across several keystrokes`() {
-        val sent = mutableListOf<ByteArray>()
-        setContent(SessionUiState.Live(createRemoteTerminalSession()), onSend = { sent += it })
+    fun `opening the composer overlay does not change the terminal slot size`() {
+        val sizes = mutableListOf<Pair<Int, Int>>()
+        setContent(
+            SessionUiState.Connecting,
+            onResized = { c, r -> sizes += c to r },
+            cellMetrics = NARROW_CELLS,
+        )
+        composeRule.waitForIdle()
+        assertTrue("no size was reported while attaching", sizes.isNotEmpty())
+        val closedSize = sizes.last()
 
-        // Two taps inside the bar's 350 ms double-tap window promote the
-        // one-shot to a lock.
-        composeRule.onNodeWithText(KEY_LABEL_CTRL).performClick()
-        composeRule.onNodeWithText(KEY_LABEL_CTRL).performClick()
+        composeRule.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).performClick()
         composeRule.waitForIdle()
 
-        typeCodePoint('c')
-        typeCodePoint('d')
-
-        assertEquals(2, sent.size)
-        assertArrayEquals(byteArrayOf(0x03), sent[0])
-        assertArrayEquals(byteArrayOf(0x04), sent[1])
+        assertEquals(
+            "opening the composer sheet must not steal terminal rows",
+            closedSize,
+            sizes.last(),
+        )
     }
 
-    /**
-     * With no modifier armed the screen stays out of the way: a plain letter
-     * goes through the vendored path into the session's own queue, exactly as
-     * it did before U-5, and never through the byte-bar send path.
-     */
     @Test
-    fun `an unmodified keystroke does not go through the key bar send path`() {
-        val sent = mutableListOf<ByteArray>()
-        setContent(SessionUiState.Live(createRemoteTerminalSession()), onSend = { sent += it })
+    fun `opening the hotkeys overlay does not change the terminal slot size`() {
+        val sizes = mutableListOf<Pair<Int, Int>>()
+        setContent(
+            SessionUiState.Connecting,
+            onResized = { c, r -> sizes += c to r },
+            cellMetrics = NARROW_CELLS,
+        )
+        composeRule.waitForIdle()
+        val closedSize = sizes.last()
 
-        typeCodePoint('c')
+        composeRule.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).performClick()
+        composeRule.waitForIdle()
 
-        assertTrue("unmodified typing must not be re-routed, got $sent", sent.isEmpty())
+        assertEquals(
+            "opening the hotkeys panel must not steal terminal rows",
+            closedSize,
+            sizes.last(),
+        )
     }
 
-    // --- pre-attach geometry -------------------------------------------------
-
-    /**
-     * The terminal slot's measured size is reported BEFORE the terminal
-     * exists, which is what lets the PTY open at the phone's real geometry
-     * instead of 80x24 and then reflow.
-     *
-     * The exact pixel arithmetic is `TerminalGeometryTest`'s business; what
-     * this pins is that the screen measures its terminal slot, runs it through
-     * that arithmetic with the metrics it was handed, and reports the result —
-     * proven by handing it TWO different faces and getting two different
-     * answers. A hard-coded 80x24 or a dropped report passes neither half.
-     */
     @Test
     fun `the terminal slot reports its size while still attaching`() {
         val sizes = mutableListOf<Pair<Int, Int>>()
@@ -241,16 +171,6 @@ class SessionKeyBarTest {
         assertTrue("rows must be usable, got $rows", rows >= MIN_TERMINAL_CELLS)
     }
 
-    /**
-     * The reported columns are the REAL viewport divided by the REAL glyph
-     * width, not a constant.
-     *
-     * The terminal slot is `fillMaxWidth`, so its width is the composition
-     * root's — which makes the expected column count computable here from
-     * numbers the test did not invent: Robolectric's display width and the
-     * metrics handed in above. An 80x24 default, a dropped report or an
-     * estimate that ignored the metrics all fail this.
-     */
     @Test
     fun `the reported columns are the measured viewport divided by the glyph width`() {
         val sizes = mutableListOf<Pair<Int, Int>>()
@@ -270,12 +190,6 @@ class SessionKeyBarTest {
         assertEquals(expected, sizes.last().first)
     }
 
-    /**
-     * Once the session is live the vendored view owns the size — it holds the
-     * renderer, so it holds the real font metrics — and the screen's estimate
-     * must go quiet. Two reporters would fight on every layout pass and push a
-     * resize to the remote each time.
-     */
     @Test
     fun `the screen stops estimating the size once the terminal exists`() {
         val sizes = mutableListOf<Pair<Int, Int>>()
@@ -285,22 +199,45 @@ class SessionKeyBarTest {
         )
 
         composeRule.waitForIdle()
-
-        // Robolectric never lays the vendored view out to a non-zero size, so
-        // the view itself reports nothing here either: any report at all would
-        // have come from the estimate that must be off.
         assertTrue("the estimate must not run while live, got $sizes", sizes.isEmpty())
     }
 
-    // --- helpers -------------------------------------------------------------
+    @Test
+    fun `an unmodified keystroke does not go through the hotkey send path`() {
+        val sent = mutableListOf<ByteArray>()
+        setContent(SessionUiState.Live(createRemoteTerminalSession()), onSend = { sent += it })
+
+        typeCodePoint('c')
+
+        assertTrue("unmodified typing must not be re-routed, got $sent", sent.isEmpty())
+    }
 
     /**
-     * Types one character the way the IME does: straight into
-     * `TerminalView.inputCodePoint`, which is where both the soft keyboard's
-     * committed text and a hardware keyboard's key events end up.
-     *
-     * `eventSource = 0` is upstream's `KEY_EVENT_SOURCE_SOFT_KEYBOARD`.
+     * Drive the production panel + [keyBarBytes] without the modal window.
+     * Robolectric drops clicks inside `ModalBottomSheet`; J03 covers the
+     * sheet on a real device.
      */
+    private fun tapHotkey(label: String): List<ByteArray> {
+        val sent = mutableListOf<ByteArray>()
+        composeRule.setContent {
+            PocketShellTheme {
+                TerminalHotkeysPanel(
+                    sections = HOTKEY_MAIN_SECTIONS,
+                    page = TerminalHotkeysPage.Main,
+                    onKey = { binding: KeyBinding ->
+                        keyBarBytes(binding.label)?.let { sent += it }
+                    },
+                    onClose = {},
+                    modifier = Modifier.testTag(TERMINAL_HOTKEYS_PANEL_TAG),
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(label).performClick()
+        composeRule.waitForIdle()
+        return sent
+    }
+
     private fun typeCodePoint(character: Char) {
         val view = requireNotNull(terminalView()) { "no TerminalView in the composition" }
         composeRule.runOnUiThread {
@@ -328,6 +265,8 @@ class SessionKeyBarTest {
         onResized: (Int, Int) -> Unit = { _, _ -> },
         onSend: (ByteArray) -> Unit = {},
         cellMetrics: TerminalCellMetrics = NARROW_CELLS,
+        initiallyShowComposer: Boolean = false,
+        initiallyShowHotkeys: Boolean = false,
     ) {
         composeRule.setContent {
             rootView = LocalView.current
@@ -339,9 +278,10 @@ class SessionKeyBarTest {
                     onBack = {},
                     onResized = onResized,
                     onRetry = {},
-                    onKeyBarSend = onSend,
+                    onHotkeySend = onSend,
                     onDraftChange = {},
                     onSend = {},
+                    onInsert = {},
                     onAttach = {},
                     onMicTap = {},
                     onCancelRecording = {},
@@ -352,6 +292,8 @@ class SessionKeyBarTest {
                     onDiscardDraft = {},
                     onUseHistoryEntry = {},
                     cellMetrics = cellMetrics,
+                    initiallyShowComposer = initiallyShowComposer,
+                    initiallyShowHotkeys = initiallyShowHotkeys,
                 )
             }
         }
@@ -361,12 +303,6 @@ class SessionKeyBarTest {
     private companion object {
         const val SESSION = "git-pocketshell"
 
-        /**
-         * JetBrainsMono Regular at the shipped 28 raw px, as a device measures
-         * it. Supplied explicitly because Robolectric's `Paint` reports a 1 px
-         * glyph with zero ascent and descent, which would make every size
-         * estimate unmeasurable and the assertions above vacuous.
-         */
         val NARROW_CELLS = TerminalCellMetrics(
             cellWidthPx = 16.8f,
             lineHeightPx = 31,

--- a/app2/src/test/java/com/pocketshell/next/terminal/SessionScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/SessionScreenTest.kt
@@ -6,10 +6,16 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.next.composer.COMPOSER_INSERT_TAG
+import com.pocketshell.next.composer.COMPOSER_SEND_TAG
 import com.pocketshell.next.composer.COMPOSER_TAG
+import com.pocketshell.next.composer.COMPOSER_TITLE_TAG
 import com.pocketshell.next.composer.COMPOSER_UNDELIVERED_TAG
 import com.pocketshell.next.composer.ComposerNotice
 import com.pocketshell.next.composer.ComposerUiState
+import com.pocketshell.uikit.components.SESSION_COMPOSER_LAUNCHER_TAG
+import com.pocketshell.uikit.components.SESSION_HOTKEYS_LAUNCHER_TAG
+import com.pocketshell.uikit.components.SESSION_LAUNCHER_BAR_TAG
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -199,40 +205,66 @@ class SessionScreenTest {
     }
 
     /**
-     * The composer stays mounted through a failure ON PURPOSE (task P-1): that
-     * is the state in which a kept draft matters most, and hiding it would
-     * delete the one thing the send contract promises.
+     * #2521: closed chrome is the compact launcher only. The circled stack
+     * (Ctrl Esc Tab Enter + draft + Send + mic) must not sit in the session
+     * column.
      */
     @Test
-    fun `the composer is present while connecting`() {
-        setContent(SessionUiState.Connecting)
-
-        composeRule.onNodeWithTag(COMPOSER_TAG).assertIsDisplayed()
-    }
-
-    @Test
-    fun `the composer is present on a live session`() {
+    fun `closed chrome is the compact launcher, not the composer or key bar`() {
         setContent(SessionUiState.Live(createRemoteTerminalSession()))
 
-        composeRule.onNodeWithTag(COMPOSER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_LAUNCHER_BAR_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("Ctrl").assertDoesNotExist()
+        composeRule.onNodeWithText("Esc").assertDoesNotExist()
+        composeRule.onNodeWithText("Tab").assertDoesNotExist()
+        composeRule.onNodeWithText("Enter").assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_SEND_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).assertDoesNotExist()
     }
 
     @Test
-    fun `the composer survives a failure, because that is when a draft matters`() {
+    fun `the compact launcher is present while connecting`() {
+        setContent(SessionUiState.Connecting)
+
+        composeRule.onNodeWithTag(SESSION_LAUNCHER_BAR_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(COMPOSER_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a failed session keeps the composer launcher so a draft can still be kept`() {
         setContent(SessionUiState.Failed("no route to host"))
 
         composeRule.onNodeWithTag(SESSION_ERROR_BANNER_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(COMPOSER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).assertDoesNotExist()
     }
 
     @Test
-    fun `an undelivered draft is visible above the terminal`() {
+    fun `opening the composer shows a Prompt Composer sheet, not an inline bar`() {
+        setContent(
+            SessionUiState.Live(createRemoteTerminalSession()),
+            initiallyShowComposer = true,
+        )
+
+        composeRule.onNodeWithTag(COMPOSER_TITLE_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(COMPOSER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(COMPOSER_SEND_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_LAUNCHER_BAR_TAG).assertIsDisplayed()
+    }
+
+    @Test
+    fun `an undelivered draft is visible inside the composer sheet`() {
         setContent(
             SessionUiState.Live(createRemoteTerminalSession()),
             composerState = ComposerUiState(
                 draft = "kept text",
                 notice = ComposerNotice.Undelivered,
             ),
+            initiallyShowComposer = true,
         )
 
         composeRule.onNodeWithTag(COMPOSER_UNDELIVERED_TAG).assertIsDisplayed()
@@ -245,7 +277,9 @@ class SessionScreenTest {
         onBack: () -> Unit = {},
         onResized: (Int, Int) -> Unit = { _, _ -> },
         onRetry: () -> Unit = {},
-        onKeyBarSend: (ByteArray) -> Unit = {},
+        onHotkeySend: (ByteArray) -> Unit = {},
+        initiallyShowComposer: Boolean = false,
+        initiallyShowHotkeys: Boolean = false,
     ) {
         composeRule.setContent {
             PocketShellTheme {
@@ -256,9 +290,10 @@ class SessionScreenTest {
                     onBack = onBack,
                     onResized = onResized,
                     onRetry = onRetry,
-                    onKeyBarSend = onKeyBarSend,
+                    onHotkeySend = onHotkeySend,
                     onDraftChange = {},
                     onSend = {},
+                    onInsert = {},
                     onAttach = {},
                     onMicTap = {},
                     onCancelRecording = {},
@@ -268,6 +303,8 @@ class SessionScreenTest {
                     onDismissNotice = {},
                     onDiscardDraft = {},
                     onUseHistoryEntry = {},
+                    initiallyShowComposer = initiallyShowComposer,
+                    initiallyShowHotkeys = initiallyShowHotkeys,
                 )
             }
         }

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/SessionLauncherBar.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/SessionLauncherBar.kt
@@ -1,0 +1,64 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellSpacing
+
+const val SESSION_LAUNCHER_BAR_TAG: String = "session-launcher-bar"
+const val SESSION_COMPOSER_LAUNCHER_TAG: String = "session-composer-launcher"
+const val SESSION_HOTKEYS_LAUNCHER_TAG: String = "session-hotkeys-launcher"
+
+const val SESSION_COMPOSER_LAUNCHER_LABEL: String = "Prompt Composer"
+const val SESSION_HOTKEYS_LAUNCHER_LABEL: String = "⌨"
+
+/**
+ * Closed-session compact chrome (#2521): a thin chip row that opens the
+ * Prompt Composer sheet and the terminal hotkeys panel.
+ *
+ * No draft field, no 4-key bar, no Send/mic. Those live in the floating
+ * sheets this bar launches. The hotkeys chip is omitted when [onOpenHotkeys]
+ * is null (no pane to receive control bytes).
+ */
+@Composable
+fun SessionLauncherBar(
+    onOpenComposer: () -> Unit,
+    onOpenHotkeys: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = PocketShellColors.Surface)
+            .border(width = 1.dp, color = PocketShellColors.BorderSoft)
+            .padding(
+                horizontal = PocketShellSpacing.sm,
+                vertical = PocketShellSpacing.sm,
+            )
+            .testTag(SESSION_LAUNCHER_BAR_TAG),
+        horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CommandChip(
+            label = SESSION_COMPOSER_LAUNCHER_LABEL,
+            onClick = onOpenComposer,
+            modifier = Modifier.testTag(SESSION_COMPOSER_LAUNCHER_TAG),
+        )
+        if (onOpenHotkeys != null) {
+            CommandChip(
+                label = SESSION_HOTKEYS_LAUNCHER_LABEL,
+                onClick = onOpenHotkeys,
+                modifier = Modifier.testTag(SESSION_HOTKEYS_LAUNCHER_TAG),
+            )
+        }
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/SessionLauncherBarTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/components/SessionLauncherBarTest.kt
@@ -1,0 +1,57 @@
+package com.pocketshell.uikit.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SessionLauncherBarTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun `the closed bar is Prompt Composer plus the hotkeys chip`() {
+        var composer = 0
+        var hotkeys = 0
+        compose.setContent {
+            PocketShellTheme {
+                SessionLauncherBar(
+                    onOpenComposer = { composer += 1 },
+                    onOpenHotkeys = { hotkeys += 1 },
+                )
+            }
+        }
+
+        compose.onNodeWithTag(SESSION_LAUNCHER_BAR_TAG).assertIsDisplayed()
+        compose.onNodeWithText(SESSION_COMPOSER_LAUNCHER_LABEL).assertIsDisplayed()
+        compose.onNodeWithText(SESSION_HOTKEYS_LAUNCHER_LABEL).assertIsDisplayed()
+        compose.onNodeWithText("Ctrl").assertDoesNotExist()
+        compose.onNodeWithText("Enter").assertDoesNotExist()
+
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).performClick()
+        compose.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).performClick()
+        assertEquals(1, composer)
+        assertEquals(1, hotkeys)
+    }
+
+    @Test
+    fun `hotkeys chip is omitted when there is no pane`() {
+        compose.setContent {
+            PocketShellTheme {
+                SessionLauncherBar(onOpenComposer = {}, onOpenHotkeys = null)
+            }
+        }
+
+        compose.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).assertIsDisplayed()
+        compose.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).assertDoesNotExist()
+    }
+}

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/ComposerRenderFixtures.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/ComposerRenderFixtures.kt
@@ -25,9 +25,59 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.CommandChip
+import com.pocketshell.uikit.components.MicButton
+import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.uikit.components.SheetHeader
+import com.pocketshell.uikit.model.MicButtonState
 import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
+
+/**
+ * Issue #2521: Prompt Composer as a floating sheet — title, close, draft,
+ * Insert, Send, mic. The real `PromptComposerSheet` lives in app2; this is
+ * the ui-kit visual mirror `scripts/render.sh` can actually run.
+ */
+@Composable
+internal fun PromptComposerSheetRender() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(PocketShellColors.Surface, RoundedCornerShape(20.dp))
+            .padding(horizontal = 18.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+    ) {
+        SheetHeader(title = "Prompt Composer", onClose = {})
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(96.dp)
+                .background(PocketShellColors.SurfaceElev, RoundedCornerShape(12.dp))
+                .border(1.dp, PocketShellColors.Border, RoundedCornerShape(12.dp))
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+        ) {
+            Text(
+                text = "check the deploy log and tell me what failed",
+                color = PocketShellColors.Text,
+                fontSize = 15.sp,
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs),
+        ) {
+            PocketShellButton(text = "Recent", onClick = {}, variant = ButtonVariant.Text, compact = true)
+            PocketShellButton(text = "Preview", onClick = {}, variant = ButtonVariant.Text, compact = true)
+            Spacer(Modifier.weight(1f))
+            PocketShellButton(text = "Insert", onClick = {}, variant = ButtonVariant.Secondary, compact = true)
+            PocketShellButton(text = "Send", onClick = {}, compact = true)
+            MicButton(state = MicButtonState.Idle, onClick = {})
+        }
+    }
+}
 
 @Composable
 internal fun ComposerControlsRowRender() {

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -104,6 +104,18 @@ import org.robolectric.annotation.GraphicsMode
 @Config(qualifiers = "w412dp-h915dp-night-xxhdpi")
 class DesignRenders {
 
+    /** Issue #2521: closed-session compact launcher (Prompt Composer + ⌨). */
+    @Test
+    fun sessionCompactLauncherBar() = render("session-compact-launcher-bar") {
+        SessionCompactLauncherBarRender()
+    }
+
+    /** Issue #2521: Prompt Composer sheet chrome (title, draft, Insert, Send, mic). */
+    @Test
+    fun promptComposerSheet() = render("prompt-composer-sheet") {
+        PromptComposerSheetRender()
+    }
+
     /** Issue #1662 common hotkeys page, including the visible hold cues. */
     @Test
     fun terminalHotkeysPanel() = render("terminal-hotkeys-panel") {

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/TerminalRenderFixtures.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/TerminalRenderFixtures.kt
@@ -27,6 +27,7 @@ import com.pocketshell.uikit.components.HotkeyLongPressAction
 import com.pocketshell.uikit.components.HotkeySection
 import com.pocketshell.uikit.components.LoadingIndicator
 import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.uikit.components.SessionLauncherBar
 import com.pocketshell.uikit.components.SpinnerSize
 import com.pocketshell.uikit.components.TerminalHotkeysPanel
 import com.pocketshell.uikit.components.TerminalHotkeysPage
@@ -35,6 +36,28 @@ import com.pocketshell.uikit.model.KeyKind
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellType
+
+@Composable
+internal fun SessionCompactLauncherBarRender() {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(560.dp)
+                .background(PocketShellColors.Background),
+        ) {
+            Text(
+                text = "terminal stays full-size underneath",
+                color = PocketShellColors.TextMuted,
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+        SessionLauncherBar(
+            onOpenComposer = {},
+            onOpenHotkeys = {},
+        )
+    }
+}
 
 @Composable
 internal fun TerminalHotkeysPanelRender() {


### PR DESCRIPTION
Closes #2521

Closed session chrome is a compact Prompt + ⌨ bar. Composer and hotkeys open as floating sheets and do not shrink the terminal. Mic requests RECORD_AUDIO. Rebased onto the #2526 Enter delay so Send is still body, wait, then CR.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2521#issuecomment-5553028926