### PR TITLE
feat: desktop-style session tree (root → folder → session)

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/tree/J02SessionTreeListJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/tree/J02SessionTreeListJourney.kt
@@ -226,17 +226,18 @@ class J02SessionTreeListJourney {
         }
         JourneyScreenshots.capture("01-session-tree", JOURNEY)
 
-        // Grouped by the workspace the host reported — including the "other"
-        // bucket for the session it reported with none.
-        compose.onNodeWithTag(workspaceHeaderTag(WORKSPACE_MAIN)).assertIsDisplayed()
-        compose.onNodeWithTag(workspaceHeaderTag(WORKSPACE_APLEXER)).assertIsDisplayed()
-        compose.onNodeWithTag(workspaceHeaderTag(OTHER_WORKSPACE_LABEL)).assertIsDisplayed()
+        // Root → folder → session: both Docker workspaces sit under `~/git`,
+        // and the session the host reported with no cwd lands in `other`.
+        compose.onNodeWithTag(rootHeaderTag("~/git")).assertIsDisplayed()
+        compose.onNodeWithTag(folderHeaderTag("~/git/pocketshell")).assertIsDisplayed()
+        compose.onNodeWithTag(folderHeaderTag("~/git/aplexer")).assertIsDisplayed()
+        compose.onNodeWithTag(rootHeaderTag(OTHER_ROOT_KEY)).assertIsDisplayed()
 
-        // The aplexer row carries its engine badge, so BOTH managers are really
-        // rendered rather than the tmux half only.
-        compose.onNodeWithContentDescription("codex").assertIsDisplayed()
-        // And the reported agent state became a chip.
-        compose.onNodeWithContentDescription("Working").assertIsDisplayed()
+        // No engine/agent chrome — the tree names the session, not the engine.
+        compose.onNodeWithContentDescription("codex").assertDoesNotExist()
+        compose.onNodeWithContentDescription("claude").assertDoesNotExist()
+        compose.onNodeWithContentDescription("Working").assertDoesNotExist()
+        compose.onNodeWithContentDescription("Waiting for input").assertDoesNotExist()
 
         // The happy path raises NO banner. A partial-listing banner here would
         // mean a backend silently failed and the list is short.

--- a/app2/src/main/java/com/pocketshell/next/tree/SessionTreeScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/SessionTreeScreen.kt
@@ -19,14 +19,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
-import com.pocketshell.core.hostapi.AgentState
-import com.pocketshell.core.hostapi.Backend
 import com.pocketshell.core.hostapi.SessionRow
-import com.pocketshell.uikit.components.AgentKindBadge
-import com.pocketshell.uikit.components.AgentStateChip
 import com.pocketshell.uikit.components.Banner
 import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
@@ -37,8 +35,8 @@ import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.components.StatusDot
 import com.pocketshell.uikit.model.ConnectionStatus
-import com.pocketshell.uikit.model.SessionAgentState
 import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellSpacing
 
@@ -68,7 +66,9 @@ const val SESSION_TREE_PORTS_TAG: String = "session-tree-ports"
 
 fun sessionRowTag(name: String): String = "session-row-$name"
 
-fun workspaceHeaderTag(label: String): String = "workspace-header-$label"
+fun rootHeaderTag(key: String): String = "root-header-$key"
+
+fun folderHeaderTag(key: String): String = "folder-header-$key"
 
 /**
  * Route-level entry point: binds the Hilt-provided [SessionTreeViewModel] to
@@ -121,12 +121,14 @@ fun SessionTreeRoute(
  *
  * ## What it draws, and what it deliberately does not
  *
- * One section per workspace the host reported, each holding that workspace's
- * sessions. There is no collapse state, no drag reordering, no persisted node
- * registry, and no per-row action menu — the old client's tree had all four and
- * they are the machinery the rewrite is removing, not features being deferred.
- * A tap opens the session and the FAB creates one (U-6); that is the screen's
- * whole interaction budget (swipe actions are out of scope entirely).
+ * A three-level tree: root (`~/git`) → folder (cwd basename) → session. Root
+ * and folder rows are headers, not attach targets; only a session row tap
+ * opens the session. There is no collapse state, no drag reordering, no
+ * persisted node registry, and no per-row action menu — the old client's tree
+ * had all four and they are the machinery the rewrite is removing, not
+ * features being deferred. A 1-session folder still draws its folder row
+ * (collapsing it is the "grouping doesn't work" failure). The FAB creates a
+ * session (U-6); that plus a row tap is the screen's whole interaction budget.
  *
  * ## The partial-list banner is the point of the screen, not decoration
  *
@@ -138,8 +140,11 @@ fun SessionTreeRoute(
  * arrive are real and usable.
  *
  * Built from ui-kit primitives ([ScreenHeader], [SectionHeader], [ListRow],
- * [Banner], [EmptyState], [StatusDot], [AgentKindBadge], [AgentStateChip]) so
- * the row density, tap-target floor and status vocabulary are the shared ones.
+ * [Banner], [EmptyState], [StatusDot]) so the row density, tap-target floor and
+ * status vocabulary are the shared ones. Agent/engine chrome is deliberately
+ * absent (rewrite U-9 stays cut): no [com.pocketshell.uikit.components.AgentKindBadge],
+ * no [com.pocketshell.uikit.components.AgentStateChip], no engine/profile/backend
+ * in the subtitle. Attached is the green [StatusDot] only.
  *
  * Stateless: everything it paints comes from [state], so it renders identically
  * from a journey, a Robolectric test and a design render.
@@ -317,23 +322,40 @@ private fun SessionTreeBody(
                         .testTag(SESSION_TREE_LIST_TAG),
                     contentPadding = PaddingValues(bottom = PocketShellSpacing.lg),
                 ) {
-                    state.groups.forEach { group ->
-                        item(key = "workspace:${group.label}") {
+                    state.roots.forEach { root ->
+                        item(key = "root:${root.key}") {
                             SectionHeader(
-                                label = group.label,
-                                count = group.rows.size,
-                                modifier = Modifier.testTag(workspaceHeaderTag(group.label)),
+                                label = root.headerLabel,
+                                count = root.sessionCount,
+                                modifier = Modifier.testTag(rootHeaderTag(root.key)),
                             )
                         }
-                        items(
-                            count = group.rows.size,
-                            key = { index -> "session:${group.label}:${group.rows[index].name}" },
-                        ) { index ->
-                            SessionTreeRow(
-                                row = group.rows[index],
-                                nowSec = nowSec,
-                                onClick = { onOpenSession(group.rows[index].name) },
-                            )
+                        root.folders.forEach { folder ->
+                            if (!folder.untracked) {
+                                item(key = "folder:${root.key}:${folder.key}") {
+                                    SectionHeader(
+                                        label = folder.label,
+                                        count = folder.rows.size.takeIf { it >= 2 },
+                                        modifier = Modifier
+                                            .padding(start = PocketShellDensity.treeIndent)
+                                            .testTag(folderHeaderTag(folder.key)),
+                                    )
+                                }
+                            }
+                            items(
+                                count = folder.rows.size,
+                                key = { index ->
+                                    "session:${root.key}:${folder.key}:${folder.rows[index].name}"
+                                },
+                            ) { index ->
+                                val row = folder.rows[index]
+                                SessionTreeRow(
+                                    row = row,
+                                    nowSec = nowSec,
+                                    indentLevels = if (folder.untracked) 1 else 2,
+                                    onClick = { onOpenSession(row.name) },
+                                )
+                            }
                         }
                     }
                 }
@@ -343,46 +365,47 @@ private fun SessionTreeBody(
 }
 
 /**
- * One session row: attach dot, name, "backend · tag · last activity", the
- * engine/manager monogram and the agent-state glyph.
+ * One session row: attach dot, session name, optional relative activity.
  *
- * The leading dot is always drawn (green when attached, muted when not) rather
- * than drawn-only-when-attached, so every row's title starts at the same x and
- * a column of rows scans as a column.
+ * No engine/agent chrome — U-9 stays cut. The leading dot is always drawn
+ * (green when attached, muted when not) rather than drawn-only-when-attached,
+ * so every row's title starts at the same x and a column of rows scans as a
+ * column.
  */
 @Composable
 private fun SessionTreeRow(
     row: SessionRow,
     nowSec: Long,
+    indentLevels: Int,
     onClick: () -> Unit,
 ) {
     ListRow(
         title = row.name,
-        subtitle = rowSubtitle(row, nowSec),
+        subtitle = relativeActivityLabel(row.activityEpoch, nowSec),
         leading = {
             StatusDot(
                 status = if (row.attached) ConnectionStatus.Connected else ConnectionStatus.Idle,
             )
         },
-        trailing = {
-            AgentStateChip(state = row.agentState.toUiState())
-            val badge = row.badge()
-            AgentKindBadge(
-                monogram = badge.monogram,
-                label = badge.label,
-                isAgent = badge.isAgent,
-            )
-        },
         onClick = onClick,
-        modifier = Modifier.testTag(sessionRowTag(row.name)),
+        modifier = Modifier
+            .padding(start = PocketShellDensity.treeIndent * indentLevels)
+            .testTag(sessionRowTag(row.name))
+            .then(
+                if (row.attached) {
+                    Modifier.semantics { contentDescription = ATTACHED_DESCRIPTION }
+                } else {
+                    Modifier
+                },
+            ),
     )
 }
 
-/** `4 sessions · 2 workspaces`, or a quieter line before the first listing. */
+/** `4 sessions · 2 roots`, or a quieter line before the first listing. */
 private fun headerSubtitle(state: SessionTreeUiState): String = when {
     !state.loaded -> "host ${state.hostId}"
     else -> "${state.sessionCount} " + plural(state.sessionCount, "session") +
-        " · ${state.groups.size} " + plural(state.groups.size, "workspace")
+        " · ${state.roots.size} " + plural(state.roots.size, "root")
 }
 
 private fun plural(count: Int, noun: String): String = if (count == 1) noun else "${noun}s"
@@ -391,72 +414,4 @@ private fun plural(count: Int, noun: String): String = if (count == 1) noun else
 private fun partialManagers(state: SessionTreeUiState): String =
     state.errors.map { it.manager }.distinct().joinToString(", ")
 
-/**
- * `tmux · reviews · 5m ago`. Every part is optional: a plain tmux session with
- * no tag and no reported activity renders just `tmux`.
- */
-private fun rowSubtitle(row: SessionRow, nowSec: Long): String = listOfNotNull(
-    row.backend.label(),
-    row.tag,
-    relativeActivityLabel(row.activityEpoch, nowSec),
-).joinToString(" · ")
-
-private fun Backend.label(): String = when (this) {
-    Backend.TMUX -> Backend.WIRE_TMUX
-    Backend.APLEXER -> Backend.WIRE_APLEXER
-    // A manager this build does not know about. Named rather than hidden: the
-    // row is real, the app just cannot say what runs it.
-    Backend.UNKNOWN -> "unknown manager"
-}
-
-/**
- * The badge slot: the ENGINE when the host named one (that is the useful
- * identity — "which agent is in here"), otherwise the manager.
- *
- * `isAgent` drives the accent colour, so an agent session's monogram reads
- * differently from a plain shell's at a glance.
- */
-private data class RowBadge(val monogram: String, val label: String, val isAgent: Boolean)
-
-private fun SessionRow.badge(): RowBadge {
-    val engine = this.engine?.takeIf { it.isNotBlank() }
-    if (engine != null) {
-        return RowBadge(monogram = monogram(engine), label = engine, isAgent = true)
-    }
-    return when (backend) {
-        Backend.TMUX -> RowBadge("TM", "tmux session", isAgent = false)
-        Backend.APLEXER -> RowBadge("AP", "aplexer session", isAgent = false)
-        Backend.UNKNOWN -> RowBadge("?", "unknown manager", isAgent = false)
-    }
-}
-
-/**
- * Two-letter monogram for an engine name — its first two alphanumerics, so
- * `claude` → `CL`, `codex` → `CO`, `opencode` → `OP`, `grok` → `GR`.
- *
- * A rule rather than a lookup table on purpose: `engines list` is the HOST's to
- * define, so a phone that only badges names it knows would render `?` for an
- * engine the user added last week. The rule collides (`claude`/`clyde` both
- * `CL`), which is acceptable — the badge is a glance-level hint and the full
- * name is on the row's accessibility description.
- */
-private fun monogram(engine: String): String {
-    val letters = engine.filter { it.isLetterOrDigit() }
-    return when {
-        letters.isEmpty() -> "?"
-        letters.length == 1 -> letters.uppercase()
-        else -> letters.take(2).uppercase()
-    }
-}
-
-/**
- * `core-hostapi`'s reported state → the ui-kit chip vocabulary. `null` (the
- * host has no opinion) maps to [SessionAgentState.Unknown], which renders
- * NOTHING — absent, never a wrong chip.
- */
-private fun AgentState?.toUiState(): SessionAgentState = when (this) {
-    AgentState.IDLE -> SessionAgentState.Idle
-    AgentState.WAITING -> SessionAgentState.WaitingForInput
-    AgentState.WORKING -> SessionAgentState.Working
-    null -> SessionAgentState.Unknown
-}
+internal const val ATTACHED_DESCRIPTION: String = "Attached"

--- a/app2/src/main/java/com/pocketshell/next/tree/SessionTreeViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/SessionTreeViewModel.kt
@@ -7,6 +7,7 @@ import com.pocketshell.core.hostapi.BackendError
 import com.pocketshell.core.hostapi.EngineInfo
 import com.pocketshell.core.hostapi.HostCliError
 import com.pocketshell.core.hostapi.ProfileInfo
+import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.transport.ConnectResult
 import com.pocketshell.core.transport.HostConnection
 import com.pocketshell.next.connect.ConnectionsRegistry
@@ -18,6 +19,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -29,13 +31,13 @@ import kotlinx.coroutines.launch
  * (#2426) was introduced to end:
  *
  * - **still loading** — [loading] is true and [loaded] is false.
- * - **empty and healthy** — [loaded] with no [groups], no [errors], no
+ * - **empty and healthy** — [loaded] with no sessions, no [errors], no
  *   [failure]. The host really has no sessions.
  * - **empty and broken** — [failure] set (the whole listing failed), or
  *   [errors] non-empty (one backend failed to enumerate while the other
  *   answered). Either way the screen says so instead of printing "No sessions".
  *
- * [failure] and [groups] coexist on purpose: a refresh that fails after a good
+ * [failure] and [roots] coexist on purpose: a refresh that fails after a good
  * listing keeps the last known sessions on screen under an error banner. A
  * screen that blanked itself on a transient SSH hiccup would be less useful and
  * less truthful than one that says "this list is from a minute ago, the refresh
@@ -47,9 +49,9 @@ data class SessionTreeUiState(
     val loading: Boolean = false,
     /** A refresh over content that is already on screen. */
     val refreshing: Boolean = false,
-    /** At least one listing has succeeded, so [groups] is a real answer. */
+    /** At least one listing has succeeded, so [roots] is a real answer. */
     val loaded: Boolean = false,
-    val groups: List<WorkspaceGroup> = emptyList(),
+    val roots: List<SessionRoot> = emptyList(),
     /** Backends that failed to enumerate. Non-empty ⇒ this list may be short. */
     val errors: List<BackendError> = emptyList(),
     /** The whole listing failed. Distinct from "empty and healthy". */
@@ -57,24 +59,30 @@ data class SessionTreeUiState(
     /** Everything the create-session sheet needs (task U-6). */
     val create: CreateSessionState = CreateSessionState(),
 ) {
-    val sessionCount: Int get() = groups.sumOf { it.rows.size }
+    val sessionCount: Int get() = roots.sumOf { it.sessionCount }
 
     /** True when the screen should say "no sessions" rather than stay blank. */
     val isEmptyAndHealthy: Boolean
-        get() = loaded && groups.isEmpty() && errors.isEmpty() && failure == null
+        get() = loaded && sessionCount == 0 && errors.isEmpty() && failure == null
 
     /**
      * What the create sheet's folder field is prefilled with: the workspace of
      * the most recently active session, when the host reported one.
      *
-     * The listing is the only folder knowledge this screen has, and its groups
-     * are already ordered most-recent-first, so the first ABSOLUTE workspace
-     * path is "where you were last". The [OTHER_WORKSPACE_LABEL] bucket is not
-     * a path and is skipped; with nothing usable the field starts empty, which
-     * means "no `--cwd`" and lets the host's own default apply.
+     * Tree *order* is creation, but the prefill is still "where you were last"
+     * — a create affordance, not a reason to shuffle the list. The
+     * [OTHER_ROOT_LABEL] bucket is not a path and is skipped; with nothing
+     * usable the field starts empty, which means "no `--cwd`" and lets the
+     * host's own default apply.
      */
     val suggestedFolder: String
-        get() = groups.firstOrNull { it.workspace?.startsWith("/") == true }?.label ?: ""
+        get() = roots.asSequence()
+            .flatMap { it.folders }
+            .flatMap { it.rows }
+            .filter { it.workspace?.startsWith("/") == true }
+            .maxByOrNull { it.activityEpoch ?: Long.MIN_VALUE }
+            ?.workspace
+            ?: ""
 }
 
 /**
@@ -117,7 +125,7 @@ data class CreateSessionState(
  * The session tree for one host (rewrite task U-3, journey J02).
  *
  * One refresh is one `pocketshell sessions list --json` over the host's live
- * connection, parsed by `core-hostapi` and bucketed by [groupSessionsByWorkspace].
+ * connection, parsed by `core-hostapi` and bucketed by [groupSessionsIntoRoots].
  * There is no poll loop, no cache, no incremental reconcile and no per-session
  * probe: agent-state polling is U-9's problem, and the old client's tree cache —
  * with its hydrate/reconcile/staleness machinery and its own persisted registry —
@@ -155,6 +163,7 @@ class SessionTreeViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val registry: ConnectionsRegistry,
     private val clients: HostCliClientFactory,
+    private val projectRootDao: ProjectRootDao,
 ) : ViewModel() {
 
     private val hostId: Long = requireNotNull(
@@ -374,6 +383,9 @@ class SessionTreeViewModel @Inject constructor(
     }
 
     private suspend fun applyListing(connection: HostConnection) {
+        val registered = projectRootDao.getByHostId(hostId).first()
+            .sortedWith(compareBy({ it.createdAt }, { it.id }))
+            .map { it.path }
         clients.create(connection).listSessions().fold(
             onSuccess = { listing ->
                 _state.update { current ->
@@ -381,7 +393,10 @@ class SessionTreeViewModel @Inject constructor(
                         loading = false,
                         refreshing = false,
                         loaded = true,
-                        groups = groupSessionsByWorkspace(listing.sessions),
+                        roots = groupSessionsIntoRoots(
+                            sessions = listing.sessions,
+                            registeredRoots = registered,
+                        ),
                         errors = listing.errors,
                         // A successful listing clears a previous failure; the
                         // partial-backend banner is driven by `errors`, which
@@ -397,7 +412,7 @@ class SessionTreeViewModel @Inject constructor(
     }
 
     /**
-     * Records a hard failure WITHOUT clearing [SessionTreeUiState.groups] — see
+     * Records a hard failure WITHOUT clearing [SessionTreeUiState.roots] — see
      * the state doc for why the last good listing stays on screen.
      */
     private fun fail(message: String) {

--- a/app2/src/main/java/com/pocketshell/next/tree/TreeGrouping.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/TreeGrouping.kt
@@ -3,110 +3,389 @@ package com.pocketshell.next.tree
 import com.pocketshell.core.hostapi.SessionRow
 
 /**
- * Label for the bucket that collects sessions the host reported with no
- * workspace.
- *
- * A literal, lowercase word rather than "Other" / "Ungrouped" so it reads as
- * one more section label next to the real workspace paths instead of a heading
- * that claims more than it knows.
+ * Catch-all root for sessions whose cwd matched no registered (or inferred)
+ * root — blank/null workspace, `$HOME` itself, or a path outside `$HOME`.
  */
-const val OTHER_WORKSPACE_LABEL: String = "other"
+const val OTHER_ROOT_KEY: String = "::other::"
+const val OTHER_ROOT_LABEL: String = "other"
+
+/** @see OTHER_ROOT_LABEL */
+const val OTHER_WORKSPACE_LABEL: String = OTHER_ROOT_LABEL
+
+/** Sentinel path for a session the host reported with no workspace. */
+const val UNTRACKED_PATH: String = "::untracked::"
+
+private const val HOME_LABEL: String = "~ (home)"
+private const val ROOT_LABEL: String = "/ (root)"
 
 /**
- * One workspace section of the session tree.
+ * One top-level folder in the session tree: a `$HOME` child (`~/git`), a
+ * registered workspace root, or the [OTHER_ROOT_LABEL] bucket.
  *
- * [workspace] is the host's own string, verbatim, or `null` for the [
- * OTHER_WORKSPACE_LABEL] bucket. [rows] are the sessions in that workspace,
- * already ordered by [groupSessionsByWorkspace].
+ * [headerLabel] is what the screen prints (`~/git`, `other`). [folders] are
+ * the working directories under this root; a 1-session folder still occupies
+ * its own node — collapsing it is the "grouping doesn't work" failure the
+ * desktop learned (SESSIONLIST.md revision 3).
  */
-data class WorkspaceGroup(
-    val workspace: String?,
-    val rows: List<SessionRow>,
+data class SessionRoot(
+    val key: String,
+    val label: String,
+    val folders: List<SessionFolderNode>,
+    val sessionCount: Int,
+    val createdEpoch: Long,
+    val attached: Boolean,
+    val other: Boolean,
+    val configured: Boolean,
 ) {
-    /** What the section header prints. */
-    val label: String get() = workspace ?: OTHER_WORKSPACE_LABEL
-
-    /**
-     * The newest activity anywhere in this group, or `null` when the host
-     * reported no activity for any of its sessions. Drives the group ordering.
-     */
-    val latestActivityEpoch: Long? get() = rows.mapNotNull { it.activityEpoch }.maxOrNull()
+    /** Root header text: the home-relative key (`~/git`), or `other`. */
+    val headerLabel: String
+        get() = when {
+            other -> OTHER_ROOT_LABEL
+            key == "~" || key == "\$HOME" -> HOME_LABEL
+            else -> key
+        }
 }
 
 /**
- * Groups a host's sessions into workspace sections — the whole content model of
- * the session tree screen (rewrite task U-3).
+ * One working directory under a [SessionRoot] — the tree's middle level.
  *
- * ## Grouping is a lookup, never an inference
- *
- * Rows are bucketed by the `workspace` field the host CLI reported, compared as
- * an EXACT string. Nothing here parses a session name, strips a `git-` prefix,
- * splits an `aplexer` `workspace:tag` name, or maps two paths onto one project.
- * The old client did all of that and it is why a session could appear under a
- * folder it did not belong to: the phone was guessing at structure the host
- * already knew. Schema 2 reports the workspace, so the phone's job is to bucket,
- * not to deduce.
- *
- * The single normalisation is that a `null` OR blank workspace lands in the
- * [OTHER_WORKSPACE_LABEL] bucket. Blank is folded in because a section header
- * printing an empty string is an invisible heading, not a group — and "the host
- * sent an empty string" and "the host sent nothing" are the same statement about
- * what it knows. That is a rendering decision, not name parsing.
- *
- * ## Ordering
- *
- * Both levels sort by "most recently active first", because the question this
- * screen answers is "where was I / who needs me", and that is a recency
- * question:
- *
- * - Rows inside a group: `activityEpoch` descending, rows with no activity
- *   timestamp last, ties broken by name ascending.
- * - Groups: by their newest member's `activityEpoch` descending, groups with no
- *   activity at all last, ties broken by [WorkspaceGroup.label] ascending.
- *
- * The [OTHER_WORKSPACE_LABEL] bucket is deliberately NOT pinned to the bottom.
- * A busy session the host could not attribute to a workspace is still the
- * session the user most likely wants, and burying it under every quiet named
- * workspace would hide exactly the row recency is supposed to surface.
- *
- * The name tie-breaks exist so the output is a pure function of the input set:
- * without them two rows sharing a timestamp would keep the host's enumeration
- * order, and the same host state could render two different screens.
- *
- * ## What is never dropped
- *
- * Every input row appears in exactly one output group. A [
- * com.pocketshell.core.hostapi.Backend.UNKNOWN] row (a manager this build does
- * not know) is grouped and rendered like any other — dropping it would recreate
- * the "the list is silently short" failure the schema-2 `errors[]` contract
- * exists to prevent.
- *
- * Pure data transformation: no Android, no Compose, no coroutines, no clock.
+ * Always a header with its sessions nested beneath it, whatever it holds.
+ * The one exception is [untracked]: a session with no reported cwd has no
+ * directory to name, so the renderer draws it as an orphan row under the
+ * root rather than inventing a folder whose label would duplicate the
+ * session name.
  */
-fun groupSessionsByWorkspace(sessions: List<SessionRow>): List<WorkspaceGroup> =
-    sessions
-        .groupBy { it.workspace?.takeIf { workspace -> workspace.isNotBlank() } }
-        .map { (workspace, rows) -> WorkspaceGroup(workspace, rows.sortedWith(ROW_ORDER)) }
-        .sortedWith(GROUP_ORDER)
+data class SessionFolderNode(
+    val key: String,
+    val path: String,
+    val label: String,
+    val rows: List<SessionRow>,
+    val createdEpoch: Long,
+    val attached: Boolean,
+    val untracked: Boolean,
+)
+
+private data class ResolvedRoot(
+    val key: String,
+    val label: String,
+)
+
+internal data class RootPlacement(
+    val key: String,
+    val label: String,
+)
 
 /**
- * `activityEpoch` descending with nulls last, then name ascending.
+ * Group sessions into the desktop-style `root → folder → session` tree
+ * (issue #2530; pocketshell-electron `groupSessionsIntoRoots`).
  *
- * Written as "is it null" + "descending value" rather than a nullable
- * descending comparator because Kotlin's `compareByDescending` puts nulls
- * FIRST, which would float sessions the host knows nothing about above the one
- * the user was just in.
+ * ## Grouping is a path lookup, never a name parse
+ *
+ * [SessionRow.workspace] is the cwd, the same field desktop calls `path`.
+ * Nothing here strips a `git-` prefix, splits an aplexer `workspace:tag`
+ * name, or recovers a root from the session name. Blank/null workspace is
+ * untracked and lands in [OTHER_ROOT_LABEL].
+ *
+ * ## Roots
+ *
+ * When [registeredRoots] is non-empty those paths (Settings → Workspace
+ * roots) are the top level, in the order they were passed — which the
+ * caller keeps as registration/`createdAt` order. Longest prefix match on a
+ * `/` boundary wins, so `~/git` never swallows `~/gitlab`. Anything that
+ * matches none of them goes to `other`, pinned last. A registered root with
+ * no sessions still renders.
+ *
+ * When nothing is registered, roots are synthesised from `$HOME`'s children
+ * the way desktop does with an empty settings list (`inferHome` +
+ * `rootForPath`). [home] is used when the caller already knows it; otherwise
+ * it is inferred from the session paths (`/home/<user>`, `/Users/<user>`,
+ * `/var/home/<user>`, `/root`).
+ *
+ * ## Folders
+ *
+ * Inside a root, sessions group by the full working directory (home-relative
+ * so `/home/x/git/a` and `~/git/a` are one node). The folder label is the
+ * path basename; a collision inside the same root grows a parent segment
+ * (`git/foo` vs `nested/foo`). A 1:1 folder is still a folder — never folded
+ * into the session row.
+ *
+ * ## Order is creation, never activity
+ *
+ * Sessions: [SessionRow.createdEpoch] oldest first, name ascending.
+ * Folders: oldest session in the folder, then case-insensitive label.
+ * Derived roots: oldest session under the root, then case-insensitive label.
+ * Registered roots: the incoming list order. `other` is always last.
+ *
+ * [SessionRow.activityEpoch] is display-only. Bumping it must not move a
+ * row; that is the whole complaint the desktop panel was rewritten to end.
+ *
+ * Every input row appears in exactly one output folder. Pure data
+ * transformation: no Android, no Compose, no coroutines, no clock.
  */
-private val ROW_ORDER: Comparator<SessionRow> =
-    compareBy<SessionRow> { it.activityEpoch == null }
-        .thenByDescending { it.activityEpoch ?: Long.MIN_VALUE }
-        .thenBy { it.name }
+fun groupSessionsIntoRoots(
+    sessions: List<SessionRow>,
+    home: String? = null,
+    registeredRoots: List<String> = emptyList(),
+): List<SessionRoot> {
+    val resolvedHome = normaliseHome(home) ?: inferHome(sessions.map { it.workspace })
+    val configured = resolveRoots(registeredRoots, resolvedHome)
+    val configuredKeys = configured.map { it.key }.toSet()
 
-/** Same rule as [ROW_ORDER], one level up. */
-private val GROUP_ORDER: Comparator<WorkspaceGroup> =
-    compareBy<WorkspaceGroup> { it.latestActivityEpoch == null }
-        .thenByDescending { it.latestActivityEpoch ?: Long.MIN_VALUE }
-        .thenBy { it.label }
+    val byRoot = linkedMapOf<String, MutableList<SessionRow>>()
+    val rootMeta = linkedMapOf<String, RootPlacement>()
+    for (root in configured) {
+        byRoot[root.key] = mutableListOf()
+        rootMeta[root.key] = RootPlacement(key = root.key, label = root.label)
+    }
+
+    for (session in sessions) {
+        val placement = placeSession(session, resolvedHome, configured)
+        val bucket = byRoot.getOrPut(placement.key) { mutableListOf() }
+        bucket.add(session)
+        rootMeta.putIfAbsent(placement.key, placement)
+    }
+
+    val folders = byRoot.map { (key, rows) ->
+        val meta = rootMeta.getValue(key)
+        val directories = buildDirectories(rows, resolvedHome)
+        disambiguateLabels(directories)
+        directories.sortWith(FOLDER_ORDER)
+        val created = directories.minOfOrNull { it.createdEpoch } ?: Long.MAX_VALUE
+        SessionRoot(
+            key = meta.key,
+            label = meta.label,
+            folders = directories,
+            sessionCount = rows.size,
+            createdEpoch = created,
+            attached = directories.any { it.attached },
+            other = meta.key == OTHER_ROOT_KEY,
+            configured = meta.key in configuredKeys,
+        )
+    }
+
+    val rooted = folders.filterNot { it.other }.toMutableList()
+    val other = folders.filter { it.other }
+    if (configured.isNotEmpty()) {
+        val rank = configured.mapIndexed { index, root -> root.key to index }.toMap()
+        rooted.sortBy { rank[it.key] ?: Int.MAX_VALUE }
+    } else {
+        rooted.sortWith(ROOT_ORDER)
+    }
+    return rooted + other
+}
+
+private fun placeSession(
+    session: SessionRow,
+    home: String?,
+    configured: List<ResolvedRoot>,
+): RootPlacement {
+    val folderPath = canonicalisePath(session.workspace)
+    if (configured.isEmpty()) return rootForPath(folderPath, home)
+    val match = bestRootForPath(folderPath, home, configured)
+    return if (match == null) {
+        RootPlacement(OTHER_ROOT_KEY, OTHER_ROOT_LABEL)
+    } else {
+        RootPlacement(match.key, match.label)
+    }
+}
+
+private fun buildDirectories(
+    sessions: List<SessionRow>,
+    home: String?,
+): MutableList<SessionFolderNode> {
+    val ordered = sessions.sortedWith(ROW_ORDER)
+    val byKey = linkedMapOf<String, MutableList<SessionRow>>()
+    val meta = linkedMapOf<String, Triple<String, String, Boolean>>()
+    for (session in ordered) {
+        val folderPath = canonicalisePath(session.workspace)
+        val untracked = folderPath == UNTRACKED_PATH
+        val path = if (untracked) UNTRACKED_PATH else directoryKey(folderPath, home)
+        val key = if (untracked) "$UNTRACKED_PATH\u0000${session.name}" else path
+        val bucket = byKey.getOrPut(key) { mutableListOf() }
+        bucket.add(session)
+        if (key !in meta) {
+            val label = if (untracked) session.name else defaultLabelForPath(path)
+            meta[key] = Triple(path, label, untracked)
+        }
+    }
+    return byKey.map { (key, rows) ->
+        val (path, label, untracked) = meta.getValue(key)
+        SessionFolderNode(
+            key = key,
+            path = path,
+            label = label,
+            rows = rows,
+            createdEpoch = rows.minOf { sessionCreated(it) },
+            attached = rows.any { it.attached },
+            untracked = untracked,
+        )
+    }.toMutableList()
+}
+
+/** Oldest created first, name ascending. Never [SessionRow.activityEpoch]. */
+private val ROW_ORDER: Comparator<SessionRow> =
+    compareBy<SessionRow> { sessionCreated(it) }.thenBy { it.name }
+
+private val FOLDER_ORDER: Comparator<SessionFolderNode> =
+    compareBy<SessionFolderNode> { it.createdEpoch }.thenBy { it.label.lowercase() }
+
+private val ROOT_ORDER: Comparator<SessionRoot> =
+    compareBy<SessionRoot> { it.createdEpoch }.thenBy { it.label.lowercase() }
+
+internal fun sessionCreated(session: SessionRow): Long = session.createdEpoch ?: 0L
+
+internal fun canonicalisePath(value: String?): String {
+    val trimmed = value?.trim().orEmpty()
+    if (trimmed.isEmpty()) return UNTRACKED_PATH
+    val stripped = trimmed.trimEnd('/')
+    return stripped.ifEmpty { "/" }
+}
+
+internal fun defaultLabelForPath(path: String): String {
+    if (path == UNTRACKED_PATH) return OTHER_ROOT_LABEL
+    val stripped = path.trim().trimEnd('/')
+    if (stripped.isEmpty()) return ROOT_LABEL
+    if (stripped == "~" || stripped == "\$HOME") return HOME_LABEL
+    val tail = stripped.substringAfterLast('/')
+    return tail.ifBlank { stripped }
+}
+
+internal fun inferHome(paths: List<String?>): String? {
+    val votes = mutableMapOf<String, Int>()
+    for (raw in paths) {
+        val path = canonicalisePath(raw)
+        if (path == UNTRACKED_PATH) continue
+        val candidate = homeCandidate(path) ?: continue
+        votes[candidate] = (votes[candidate] ?: 0) + 1
+    }
+    return votes.maxByOrNull { it.value }?.key
+}
+
+private fun homeCandidate(path: String): String? {
+    if (path == ROOT_HOME || path.startsWith("$ROOT_HOME/")) return ROOT_HOME
+    for (parent in HOME_PARENTS) {
+        if (!path.startsWith("$parent/")) continue
+        val user = path.removePrefix("$parent/").substringBefore('/')
+        if (user.isNotEmpty()) return "$parent/$user"
+    }
+    return null
+}
+
+private val HOME_PARENTS: List<String> = listOf("/home", "/Users", "/var/home")
+private const val ROOT_HOME: String = "/root"
+
+private fun normaliseHome(home: String?): String? {
+    val trimmed = home?.trim()?.trimEnd('/')
+    return trimmed?.takeIf { it.isNotEmpty() }
+}
+
+private fun homeRelative(folderPath: String, home: String?): String? {
+    if (folderPath == "~" || folderPath == "\$HOME") return ""
+    if (folderPath.startsWith("~/")) return folderPath.removePrefix("~/")
+    val homePrefix = normaliseHome(home) ?: return null
+    if (folderPath == homePrefix) return ""
+    if (folderPath.startsWith("$homePrefix/")) return folderPath.removePrefix("$homePrefix/")
+    return null
+}
+
+internal fun rootForPath(folderPath: String, home: String?): RootPlacement {
+    val other = RootPlacement(OTHER_ROOT_KEY, OTHER_ROOT_LABEL)
+    if (folderPath == UNTRACKED_PATH) return other
+    val relative = homeRelative(folderPath, home) ?: return other
+    val first = relative.split('/').firstOrNull { it.isNotEmpty() } ?: return other
+    return RootPlacement(key = "~/$first", label = first)
+}
+
+internal fun directoryKey(folderPath: String, home: String?): String {
+    if (folderPath == UNTRACKED_PATH) return UNTRACKED_PATH
+    val relative = homeRelative(folderPath, home) ?: return folderPath
+    return if (relative.isEmpty()) "~" else "~/$relative"
+}
+
+internal fun pathWithinRoot(path: String, root: String): Boolean {
+    if (path == root) return true
+    val prefix = if (root.endsWith("/")) root else "$root/"
+    return path.startsWith(prefix)
+}
+
+internal fun normaliseRootPath(value: String): String? {
+    if (value.any { it < ' ' }) return null
+    val canonical = canonicalisePath(value)
+    if (canonical == UNTRACKED_PATH) return null
+    if (canonical.split('/').contains("..")) return null
+    if (canonical != "~" && !canonical.startsWith("~/") && !canonical.startsWith("/")) return null
+    return canonical
+}
+
+private fun resolveRoots(roots: List<String>, home: String?): List<ResolvedRoot> {
+    val resolved = mutableListOf<ResolvedRoot>()
+    val seen = mutableSetOf<String>()
+    for (source in roots) {
+        val canonical = normaliseRootPath(source) ?: continue
+        val key = directoryKey(canonical, home)
+        if (!seen.add(key)) continue
+        resolved.add(ResolvedRoot(key = key, label = defaultLabelForPath(key)))
+    }
+    labelRootsApart(resolved)
+    return resolved
+}
+
+private fun labelRootsApart(roots: MutableList<ResolvedRoot>) {
+    val counts = roots.groupingBy { it.label }.eachCount()
+    for (i in roots.indices) {
+        val root = roots[i]
+        if ((counts[root.label] ?: 0) < 2) continue
+        val grown = if (root.key.startsWith("~/")) root.key.removePrefix("~/") else root.key
+        roots[i] = root.copy(label = grown)
+    }
+}
+
+private fun bestRootForPath(
+    folderPath: String,
+    home: String?,
+    roots: List<ResolvedRoot>,
+): ResolvedRoot? {
+    if (folderPath == UNTRACKED_PATH) return null
+    val key = directoryKey(folderPath, home)
+    var best: ResolvedRoot? = null
+    for (root in roots) {
+        if (!pathWithinRoot(key, root.key)) continue
+        if (best == null || root.key.length > best.key.length) best = root
+    }
+    return best
+}
+
+/**
+ * Two directories in the same root can share a basename (`~/git/foo` and
+ * `~/git/nested/foo`). Grow every colliding label by parent segments until
+ * unique. Untracked nodes are left alone — their label is the session name.
+ */
+private fun disambiguateLabels(folders: MutableList<SessionFolderNode>) {
+    val pathsByLabel = linkedMapOf<String, MutableSet<String>>()
+    for (folder in folders) {
+        if (folder.untracked) continue
+        pathsByLabel.getOrPut(folder.label) { mutableSetOf() }.add(folder.path)
+    }
+    for ((label, paths) in pathsByLabel) {
+        if (paths.size < 2) continue
+        val deepest = paths.maxOf { it.split('/').count { part -> part.isNotEmpty() } }
+        var depth = 2
+        while (depth < deepest) {
+            val expanded = paths.map { tailSegments(it, depth) }.toSet()
+            if (expanded.size == paths.size) break
+            depth += 1
+        }
+        for (i in folders.indices) {
+            val folder = folders[i]
+            if (folder.untracked || folder.label != label) continue
+            val grown = tailSegments(folder.path, depth).ifEmpty { folder.label }
+            folders[i] = folder.copy(label = grown)
+        }
+    }
+}
+
+private fun tailSegments(path: String, count: Int): String =
+    path.split('/').filter { it.isNotEmpty() }.takeLast(count).joinToString("/")
 
 /**
  * Coarse "how long ago" label for a session's last activity.
@@ -118,11 +397,12 @@ private val GROUP_ORDER: Comparator<WorkspaceGroup> =
  *
  * [epochSec] is the host's `activity_epoch` (seconds), [nowSec] the phone's
  * current time in the same unit. `null` in gives `null` out — the caller renders
- * nothing rather than inventing "unknown", the same "absent, not wrong" rule the
- * agent-state chip follows.
+ * nothing rather than inventing "unknown".
  *
  * A timestamp in the future (host clock ahead of the phone's, which happens) is
  * clamped to "now" rather than rendering a negative age.
+ *
+ * Display only: this string is never a sort key.
  */
 fun relativeActivityLabel(epochSec: Long?, nowSec: Long): String? {
     if (epochSec == null) return null

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeRouteTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeRouteTest.kt
@@ -72,6 +72,7 @@ class SessionTreeRouteTest {
             savedStateHandle = SavedStateHandle(mapOf(Destination.ARG_HOST_ID to hostId)),
             registry = stack.registry,
             clients = HostCliClientFactory { connection -> HostCliClient(connection.asRemoteExec()) },
+            projectRootDao = stack.db.projectRootDao(),
         )
         val opened = mutableListOf<String>()
 

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeScreenTest.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.next.tree
 
+import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -38,47 +39,66 @@ class SessionTreeScreenTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun `sections render in group order with their sessions underneath`() {
+    fun `sections render as root then folder then session`() {
         setContent(
             state(
                 loaded = true,
                 sessions = listOf(
-                    row("claude-main", "/home/a/git/pocketshell", activity = NOW - 120),
-                    row("codex", "/home/a/git/pocketshell", activity = NOW - 4_000),
-                    row("aplexer-follow:yolo", "/home/a/git/aplexer", activity = NOW - 30),
+                    row("claude-main", "/home/a/git/pocketshell", activity = NOW - 120, created = 2),
+                    row("codex", "/home/a/git/pocketshell", activity = NOW - 4_000, created = 1),
+                    row("aplexer-follow:yolo", "/home/a/git/aplexer", activity = NOW - 30, created = 3),
                 ),
             ),
         )
 
-        composeRule.onNodeWithTag(workspaceHeaderTag("/home/a/git/aplexer")).assertIsDisplayed()
-        composeRule.onNodeWithTag(workspaceHeaderTag("/home/a/git/pocketshell")).assertIsDisplayed()
+        composeRule.onNodeWithTag(rootHeaderTag("~/git")).assertIsDisplayed()
+        composeRule.onNodeWithTag(folderHeaderTag("~/git/pocketshell")).assertIsDisplayed()
+        composeRule.onNodeWithTag(folderHeaderTag("~/git/aplexer")).assertIsDisplayed()
         composeRule.onNodeWithTag(sessionRowTag("claude-main")).assertIsDisplayed()
         composeRule.onNodeWithTag(sessionRowTag("codex")).assertIsDisplayed()
         composeRule.onNodeWithTag(sessionRowTag("aplexer-follow:yolo")).assertIsDisplayed()
+        composeRule.onNodeWithText("pocketshell").assertIsDisplayed()
+        composeRule.onNodeWithText("aplexer").assertIsDisplayed()
 
-        // Header counts the whole listing.
-        composeRule.onNodeWithText("3 sessions · 2 workspaces").assertIsDisplayed()
+        // Header counts the whole listing. Both folders sit under one root.
+        composeRule.onNodeWithText("3 sessions · 1 root").assertIsDisplayed()
     }
 
     @Test
-    fun `a workspace-less session renders under the other heading`() {
+    fun `a 1-to-1 folder still draws the folder row above the session`() {
+        setContent(
+            state(
+                loaded = true,
+                sessions = listOf(row("git-aplexer", "/home/a/git/aplexer", activity = NOW, created = 1)),
+            ),
+        )
+
+        composeRule.onNodeWithTag(rootHeaderTag("~/git")).assertIsDisplayed()
+        composeRule.onNodeWithTag(folderHeaderTag("~/git/aplexer")).assertIsDisplayed()
+        composeRule.onNodeWithTag(sessionRowTag("git-aplexer")).assertIsDisplayed()
+        composeRule.onNodeWithText("aplexer").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a workspace-less session renders under the other heading with no folder`() {
         setContent(
             state(loaded = true, sessions = listOf(row("homeless", workspace = null, activity = NOW))),
         )
 
-        composeRule.onNodeWithTag(workspaceHeaderTag(OTHER_WORKSPACE_LABEL)).assertIsDisplayed()
+        composeRule.onNodeWithTag(rootHeaderTag(OTHER_ROOT_KEY)).assertIsDisplayed()
         composeRule.onNodeWithTag(sessionRowTag("homeless")).assertIsDisplayed()
+        composeRule.onNodeWithTag(folderHeaderTag(UNTRACKED_PATH)).assertDoesNotExist()
     }
 
     @Test
-    fun `a row shows its manager, tag and relative activity`() {
+    fun `a row shows relative activity and never engine, tag or manager text`() {
         setContent(
             state(
                 loaded = true,
                 sessions = listOf(
                     row(
                         "aplexer-follow:yolo",
-                        "/w",
+                        "/home/a/git/aplexer",
                         activity = NOW - 7_200,
                         backend = Backend.APLEXER,
                         tag = "yolo",
@@ -88,49 +108,64 @@ class SessionTreeScreenTest {
             ),
         )
 
-        composeRule.onNodeWithText("aplexer · yolo · 2h ago").assertIsDisplayed()
-        // The engine, not the manager, owns the badge when the host named one.
-        composeRule.onNodeWithContentDescription("codex").assertIsDisplayed()
+        composeRule.onNodeWithText("2h ago").assertIsDisplayed()
+        composeRule.onNodeWithText("aplexer · yolo · 2h ago").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("codex").assertDoesNotExist()
     }
 
     @Test
-    fun `an unknown manager row is rendered and labelled, never hidden`() {
+    fun `an unknown manager row is rendered, never hidden, and carries no manager badge`() {
         setContent(
             state(
                 loaded = true,
                 sessions = listOf(
-                    row("from-the-future", "/w", activity = NOW, backend = Backend.UNKNOWN),
+                    row("from-the-future", "/home/a/git/w", activity = NOW, backend = Backend.UNKNOWN),
                 ),
             ),
         )
 
         composeRule.onNodeWithTag(sessionRowTag("from-the-future")).assertIsDisplayed()
-        composeRule.onNodeWithContentDescription("unknown manager").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("unknown manager").assertDoesNotExist()
     }
 
+    /**
+     * Issue #2530: the tree must not show which engine/agent is running.
+     * Attached is the green dot only.
+     */
     @Test
-    fun `an agent state renders a chip and no state renders nothing`() {
+    fun `the tree has no agent badge or chip and an attached row keeps its green dot`() {
         setContent(
             state(
                 loaded = true,
                 sessions = listOf(
                     row(
                         "waiting-agent",
-                        "/w",
+                        "/home/a/git/w",
                         activity = NOW,
+                        engine = "claude",
+                        attached = true,
                         agentState = AgentState.WAITING,
                         agentStateSource = AgentStateSource.REPORTED,
                     ),
-                    row("plain-shell", "/w", activity = NOW - 1),
+                    row(
+                        "working-codex",
+                        "/home/a/git/w",
+                        activity = NOW - 1,
+                        engine = "codex",
+                        agentState = AgentState.WORKING,
+                        agentStateSource = AgentStateSource.REPORTED,
+                    ),
                 ),
             ),
         )
 
-        // The chip is an icon with an explicit state description; the shell row
-        // must contribute no second one.
-        composeRule.onNodeWithContentDescription("Waiting for input").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Waiting for input").assertDoesNotExist()
         composeRule.onNodeWithContentDescription("Idle (finished)").assertDoesNotExist()
         composeRule.onNodeWithContentDescription("Working").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("claude").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("codex").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription(ATTACHED_DESCRIPTION).assertIsDisplayed()
+        composeRule.onNodeWithTag(sessionRowTag("waiting-agent")).assertIsDisplayed()
     }
 
     @Test
@@ -228,6 +263,24 @@ class SessionTreeScreenTest {
         assertEquals(listOf("my project:review"), opened)
     }
 
+    @Test
+    fun `root and folder headers are not attach targets`() {
+        val opened = mutableListOf<String>()
+        setContent(
+            state(
+                loaded = true,
+                sessions = listOf(
+                    row("git-aplexer", "/home/a/git/aplexer", activity = NOW, created = 1),
+                ),
+            ),
+            onOpenSession = { opened += it },
+        )
+
+        composeRule.onNodeWithTag(rootHeaderTag("~/git")).assertHasNoClickAction()
+        composeRule.onNodeWithTag(folderHeaderTag("~/git/aplexer")).assertHasNoClickAction()
+        assertEquals(emptyList<String>(), opened)
+    }
+
     // --- create affordance (task U-6) --------------------------------------
 
     @Test
@@ -321,7 +374,7 @@ class SessionTreeScreenTest {
     ) = SessionTreeUiState(
         hostId = 7,
         loaded = loaded,
-        groups = groupSessionsByWorkspace(sessions),
+        roots = groupSessionsIntoRoots(sessions),
         errors = errors,
         failure = failure,
     )
@@ -336,6 +389,7 @@ class SessionTreeScreenTest {
         attached: Boolean = false,
         agentState: AgentState? = null,
         agentStateSource: AgentStateSource? = null,
+        created: Long? = null,
     ) = SessionRow(
         name = name,
         backend = backend,
@@ -347,7 +401,7 @@ class SessionTreeScreenTest {
         agentState = agentState,
         agentStateSource = agentStateSource,
         attached = attached,
-        createdEpoch = null,
+        createdEpoch = created,
         activityEpoch = activity,
     )
 

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeViewModelTest.kt
@@ -7,6 +7,7 @@ import com.pocketshell.core.hostapi.AgentStateSource
 import com.pocketshell.core.hostapi.Backend
 import com.pocketshell.core.hostapi.ExecOutcome
 import com.pocketshell.core.hostapi.HostCliClient
+import com.pocketshell.core.storage.entity.ProjectRootEntity
 import com.pocketshell.core.transport.ExecResult
 import com.pocketshell.core.transport.FakeHostConnection
 import com.pocketshell.next.connect.TestConnectStack
@@ -65,7 +66,7 @@ class SessionTreeViewModelTest {
     }
 
     @Test
-    fun `a healthy listing groups every session by workspace`() = runTest(dispatcher) {
+    fun `a healthy listing groups every session into root then folder`() = runTest(dispatcher) {
         val hostId = stack.seedHost()
         answerSessions(HEALTHY_LISTING)
         val viewModel = viewModel(hostId)
@@ -80,26 +81,23 @@ class SessionTreeViewModelTest {
         assertFalse(state.loading)
         assertFalse(state.refreshing)
 
-        // Two named workspaces plus the "other" bucket, most-recent first.
-        assertEquals(
-            listOf("/home/testuser/git/pocketshell", "/home/testuser/git/aplexer", OTHER_WORKSPACE_LABEL),
-            state.groups.map { it.label },
-        )
-        assertEquals(
-            listOf("claude-main", "codex"),
-            state.groups[0].rows.map { it.name },
-        )
-        assertEquals(listOf("aplexer-follow:yolo"), state.groups[1].rows.map { it.name })
-        assertEquals(listOf("opencode-lab"), state.groups[2].rows.map { it.name })
+        // One inferred `~/git` root (pocketshell + aplexer folders) plus `other`.
+        // Creation order: aplexer (1788350000) is older than pocketshell (1788370000).
+        assertEquals(listOf("~/git", OTHER_ROOT_LABEL), state.roots.map { it.headerLabel })
+        assertEquals(listOf("aplexer", "pocketshell"), state.roots[0].folders.map { it.label })
+        assertEquals(listOf("aplexer-follow:yolo"), state.roots[0].folders[0].rows.map { it.name })
+        assertEquals(listOf("codex", "claude-main"), state.roots[0].folders[1].rows.map { it.name })
+        assertEquals(listOf("opencode-lab"), state.roots[1].folders.single().rows.map { it.name })
+        assertTrue(state.roots[1].folders.single().untracked)
         assertEquals(4, state.sessionCount)
 
         // The parsed detail the screen renders actually survived the round trip.
-        val claude = state.groups[0].rows.first()
+        val claude = state.roots[0].folders[1].rows.single { it.name == "claude-main" }
         assertEquals(Backend.TMUX, claude.backend)
         assertEquals(AgentState.WORKING, claude.agentState)
         assertEquals(AgentStateSource.REPORTED, claude.agentStateSource)
         assertTrue(claude.attached)
-        val aplexer = state.groups[1].rows.single()
+        val aplexer = state.roots[0].folders[0].rows.single()
         assertEquals(Backend.APLEXER, aplexer.backend)
         assertEquals("codex", aplexer.engine)
         assertEquals("yolo", aplexer.tag)
@@ -110,6 +108,32 @@ class SessionTreeViewModelTest {
             connection().executedCommands,
         )
     }
+
+    @Test
+    fun `registered workspace roots become the root list and unmatched go to other`() =
+        runTest(dispatcher) {
+            val hostId = stack.seedHost()
+            stack.db.projectRootDao().insert(
+                ProjectRootEntity(hostId = hostId, label = "tmp", path = "~/tmp", createdAt = 1),
+            )
+            stack.db.projectRootDao().insert(
+                ProjectRootEntity(hostId = hostId, label = "git", path = "~/git", createdAt = 2),
+            )
+            answerSessions(HEALTHY_LISTING)
+            val viewModel = viewModel(hostId)
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            // Registration order (tmp then git), not recency, and the unmatched
+            // workspace-less session lands in `other`.
+            assertEquals(listOf("~/tmp", "~/git", OTHER_ROOT_LABEL), state.roots.map { it.headerLabel })
+            assertEquals(0, state.roots[0].sessionCount)
+            assertTrue(state.roots[0].configured)
+            assertEquals(listOf("aplexer", "pocketshell"), state.roots[1].folders.map { it.label })
+            assertEquals(listOf("opencode-lab"), state.roots[2].folders.single().rows.map { it.name })
+        }
 
     @Test
     fun `an UNKNOWN manager row is still rendered rather than dropped`() = runTest(dispatcher) {
@@ -125,7 +149,7 @@ class SessionTreeViewModelTest {
         assertEquals(2, state.sessionCount)
         assertTrue(
             "a manager this build does not know must survive as UNKNOWN",
-            state.groups.flatMap { it.rows }.any { it.backend == Backend.UNKNOWN },
+            state.roots.flatMap { it.folders }.flatMap { it.rows }.any { it.backend == Backend.UNKNOWN },
         )
     }
 
@@ -165,7 +189,7 @@ class SessionTreeViewModelTest {
         val state = viewModel.state.value
         assertTrue(state.isEmptyAndHealthy)
         assertNull(state.failure)
-        assertEquals(emptyList<WorkspaceGroup>(), state.groups)
+        assertEquals(emptyList<SessionRoot>(), state.roots)
     }
 
     @Test
@@ -695,6 +719,7 @@ class SessionTreeViewModelTest {
         registry = stack.registry,
         // The production binding, verbatim (see AppModule.provideHostCliClientFactory).
         clients = HostCliClientFactory { connection -> HostCliClient(connection.asRemoteExec()) },
+        projectRootDao = stack.db.projectRootDao(),
     )
 
     private fun answerSessions(json: String) {

--- a/app2/src/test/java/com/pocketshell/next/tree/TreeGroupingTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/TreeGroupingTest.kt
@@ -6,218 +6,315 @@ import com.pocketshell.core.hostapi.Backend
 import com.pocketshell.core.hostapi.SessionRow
 import com.pocketshell.core.hostapi.SessionsJson
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * [groupSessionsByWorkspace] and [relativeActivityLabel] are pure functions, so
+ * [groupSessionsIntoRoots] and [relativeActivityLabel] are pure functions, so
  * this suite is plain JUnit — no Robolectric, no coroutines, no clock.
  *
  * The properties worth pinning are the ones a "looks right on my screen" pass
- * cannot see: that the ordering is total (so the same host state always renders
- * the same screen), that a row is never dropped, and that the "other" bucket is
- * the only place a workspace-less session can end up.
+ * cannot see: root → folder → session (never exact workspace paths as headers),
+ * creation order that does not move under an activity bump, 1:1 folders that
+ * still occupy a folder row, registered roots with `other` for the rest, and
+ * that a row is never dropped.
  */
 class TreeGroupingTest {
 
+    /**
+     * Issue #2530: `/home/x/git/a` and `/home/x/tmp/b` must become two ROOTS
+     * (`~/git` / `~/tmp`), not two section headers that print the full cwd.
+     * Was RED on exact-workspace-path grouping.
+     */
     @Test
-    fun `groups by the exact workspace string, never by name similarity`() {
-        val groups = groupSessionsByWorkspace(
+    fun `git and tmp under home become two roots not two full-path headers`() {
+        val roots = groupSessionsIntoRoots(
             listOf(
-                row("git-pocketshell", workspace = "/home/alexey/git/pocketshell", activity = 300),
-                row("git-pocketshell-2", workspace = "/home/alexey/git/pocketshell", activity = 200),
-                // Same-looking project, DIFFERENT path: two workspaces, not one.
-                row("worktree-run", workspace = "/data/worktrees/pocketshell", activity = 100),
+                row("sess-a", workspace = "/home/x/git/a", activity = 50, created = 10),
+                row("sess-b", workspace = "/home/x/tmp/b", activity = 90, created = 20),
             ),
         )
-
-        assertEquals(
-            listOf("/home/alexey/git/pocketshell", "/data/worktrees/pocketshell"),
-            groups.map { it.label },
+        val labels = roots.map { it.headerLabel }
+        assertEquals(listOf("~/git", "~/tmp"), labels)
+        assertTrue(
+            "must not use the exact workspace path as the section header, got $labels",
+            labels.none { it.contains("/home/x/") },
         )
+        assertEquals(listOf("a"), roots[0].folders.map { it.label })
+        assertEquals(listOf("b"), roots[1].folders.map { it.label })
+    }
+
+    /**
+     * Issue #2530: bumping `activityEpoch` must not move rows. Creation order
+     * (oldest first) is the only key. Was RED on the recency sort.
+     */
+    @Test
+    fun `activityEpoch bump does not reorder rows`() {
+        fun listing(oldActivity: Long) = listOf(
+            row("older", workspace = "/home/x/git/a", activity = oldActivity, created = 1),
+            row("newer", workspace = "/home/x/git/a", activity = 50, created = 2),
+        )
+        val before = leafNames(groupSessionsIntoRoots(listing(10)))
+        val after = leafNames(groupSessionsIntoRoots(listing(999)))
+        assertEquals("creation order must survive an activity bump", before, after)
+        assertEquals(listOf("older", "newer"), before)
+    }
+
+    @Test
+    fun `a newer session appends in creation order`() {
+        val roots = groupSessionsIntoRoots(
+            listOf(
+                row("first", workspace = "/home/x/git/a", activity = 9, created = 10),
+                row("second", workspace = "/home/x/git/a", activity = 1, created = 20),
+            ),
+        )
+        assertEquals(listOf("first", "second"), roots.single().folders.single().rows.map { it.name })
+    }
+
+    @Test
+    fun `two sessions in the same cwd sit under one folder`() {
+        val roots = groupSessionsIntoRoots(
+            listOf(
+                row("git-pocketshell", workspace = "/home/x/git/pocketshell", activity = 30, created = 1),
+                row("git-pocketshell-2", workspace = "/home/x/git/pocketshell", activity = 10, created = 2),
+            ),
+        )
+        val git = roots.single()
+        assertEquals("~/git", git.headerLabel)
+        assertEquals(1, git.folders.size)
+        assertEquals("pocketshell", git.folders.single().label)
         assertEquals(
             listOf("git-pocketshell", "git-pocketshell-2"),
-            groups[0].rows.map { it.name },
+            git.folders.single().rows.map { it.name },
         )
-        assertEquals(listOf("worktree-run"), groups[1].rows.map { it.name })
     }
 
     @Test
-    fun `two sessions whose names share a prefix do not merge into one group`() {
+    fun `a 1-to-1 folder still has a folder row then a session row`() {
+        val roots = groupSessionsIntoRoots(
+            listOf(row("git-aplexer", workspace = "/home/x/git/aplexer", activity = 5, created = 1)),
+        )
+        val git = roots.single()
+        assertEquals("~/git", git.headerLabel)
+        assertEquals(listOf("aplexer"), git.folders.map { it.label })
+        assertFalse("a 1:1 folder must not collapse into the session row", git.folders.single().untracked)
+        assertEquals(listOf("git-aplexer"), git.folders.single().rows.map { it.name })
+    }
+
+    @Test
+    fun `two sessions whose names share a prefix do not merge into one folder`() {
         // The old client derived a folder from the session NAME. If any of that
-        // ever creeps back, these two land in one group and this fails.
-        val groups = groupSessionsByWorkspace(
+        // ever creeps back, these two land in one folder and this fails.
+        val roots = groupSessionsIntoRoots(
             listOf(
-                row("dtc-website", workspace = "/home/a/git/dtc-website", activity = 20),
-                row("dtc-website-2", workspace = "/home/a/git/dtc-website-fork", activity = 10),
+                row("dtc-website", workspace = "/home/a/git/dtc-website", activity = 20, created = 1),
+                row("dtc-website-2", workspace = "/home/a/git/dtc-website-fork", activity = 10, created = 2),
             ),
         )
-
-        assertEquals(2, groups.size)
+        assertEquals(listOf("dtc-website", "dtc-website-fork"), roots.single().folders.map { it.label })
     }
 
     @Test
-    fun `rows inside a group sort by activity descending with nulls last`() {
-        val groups = groupSessionsByWorkspace(
+    fun `same-looking project at a different path is a different folder, not a name merge`() {
+        val roots = groupSessionsIntoRoots(
             listOf(
-                row("stale", workspace = "/w", activity = 100),
-                row("never-active", workspace = "/w", activity = null),
-                row("freshest", workspace = "/w", activity = 900),
-                row("middle", workspace = "/w", activity = 500),
+                row("git-pocketshell", workspace = "/home/alexey/git/pocketshell", activity = 300, created = 1),
+                row("git-pocketshell-2", workspace = "/home/alexey/git/pocketshell", activity = 200, created = 2),
+                row("worktree-run", workspace = "/data/worktrees/pocketshell", activity = 100, created = 3),
             ),
         )
-
-        assertEquals(
-            listOf("freshest", "middle", "stale", "never-active"),
-            groups.single().rows.map { it.name },
-        )
+        assertEquals(listOf("~/git", OTHER_ROOT_LABEL), roots.map { it.headerLabel })
+        assertEquals(listOf("pocketshell"), roots[0].folders.map { it.label })
+        assertEquals(listOf("pocketshell"), roots[1].folders.map { it.label })
+        assertEquals(listOf("worktree-run"), roots[1].folders.single().rows.map { it.name })
     }
 
     @Test
-    fun `rows with the same activity are ordered by name, so the output is deterministic`() {
-        val forward = groupSessionsByWorkspace(
+    fun `folders in one root with the same basename grow a parent segment`() {
+        val roots = groupSessionsIntoRoots(
             listOf(
-                row("beta", workspace = "/w", activity = 42),
-                row("alpha", workspace = "/w", activity = 42),
+                row("one", workspace = "/home/x/git/foo", activity = 1, created = 1),
+                row("two", workspace = "/home/x/git/nested/foo", activity = 2, created = 2),
             ),
         )
-        val reversed = groupSessionsByWorkspace(
-            listOf(
-                row("alpha", workspace = "/w", activity = 42),
-                row("beta", workspace = "/w", activity = 42),
-            ),
-        )
-
-        assertEquals(listOf("alpha", "beta"), forward.single().rows.map { it.name })
-        assertEquals(forward.single().rows.map { it.name }, reversed.single().rows.map { it.name })
+        assertEquals(setOf("git/foo", "nested/foo"), roots.single().folders.map { it.label }.toSet())
     }
 
     @Test
-    fun `groups are ordered by their most recent session, and quiet groups sink`() {
-        val groups = groupSessionsByWorkspace(
+    fun `a null workspace lands in the other bucket as an orphan, not a nameless folder`() {
+        val roots = groupSessionsIntoRoots(
             listOf(
-                row("old-a", workspace = "/quiet", activity = 10),
-                row("old-b", workspace = "/quiet", activity = 20),
-                row("no-activity", workspace = "/unknown-activity", activity = null),
-                // A single very fresh session pulls its whole workspace to the
-                // top even though the workspace also holds an ancient session.
-                row("ancient", workspace = "/busy", activity = 1),
-                row("fresh", workspace = "/busy", activity = 999),
+                row("homeless", workspace = null, activity = 50, created = 2),
+                row("placed", workspace = "/home/x/git/a", activity = 10, created = 1),
             ),
         )
-
-        assertEquals(listOf("/busy", "/quiet", "/unknown-activity"), groups.map { it.label })
-    }
-
-    @Test
-    fun `groups with equally recent sessions are ordered by label`() {
-        val groups = groupSessionsByWorkspace(
-            listOf(
-                row("z", workspace = "/zulu", activity = 7),
-                row("a", workspace = "/alpha", activity = 7),
-            ),
-        )
-
-        assertEquals(listOf("/alpha", "/zulu"), groups.map { it.label })
-    }
-
-    @Test
-    fun `a null workspace lands in the other bucket, not in a nameless group`() {
-        val groups = groupSessionsByWorkspace(
-            listOf(
-                row("homeless", workspace = null, activity = 50),
-                row("placed", workspace = "/w", activity = 10),
-            ),
-        )
-
-        val other = groups.single { it.workspace == null }
-        assertEquals(OTHER_WORKSPACE_LABEL, other.label)
-        assertEquals(listOf("homeless"), other.rows.map { it.name })
-        // And it is ordered by recency like any other group — a busy
-        // unattributed session is not banished to the bottom.
-        assertEquals(OTHER_WORKSPACE_LABEL, groups.first().label)
+        assertEquals(listOf("~/git", OTHER_ROOT_LABEL), roots.map { it.headerLabel })
+        val other = roots.single { it.other }
+        assertEquals(OTHER_ROOT_LABEL, other.headerLabel)
+        assertEquals(listOf("homeless"), other.folders.single().rows.map { it.name })
+        assertTrue("an untracked session has no directory to name", other.folders.single().untracked)
+        assertEquals("other is a bucket, pinned last", OTHER_ROOT_LABEL, roots.last().headerLabel)
     }
 
     @Test
     fun `a blank workspace joins the other bucket rather than rendering an empty header`() {
-        val groups = groupSessionsByWorkspace(
+        val roots = groupSessionsIntoRoots(
             listOf(
-                row("blank", workspace = "   ", activity = 5),
-                row("null", workspace = null, activity = 6),
+                row("blank", workspace = "   ", activity = 5, created = 2),
+                row("null", workspace = null, activity = 6, created = 1),
             ),
         )
+        assertEquals(1, roots.size)
+        assertEquals(OTHER_ROOT_LABEL, roots.single().headerLabel)
+        assertTrue(roots.single().other)
+        assertEquals(listOf("null", "blank"), leafNames(roots))
+        assertTrue(roots.single().folders.all { it.untracked })
+    }
 
-        assertEquals(1, groups.size)
-        assertEquals(OTHER_WORKSPACE_LABEL, groups.single().label)
-        assertNull(groups.single().workspace)
-        assertEquals(listOf("null", "blank"), groups.single().rows.map { it.name })
+    @Test
+    fun `registered roots become the root list and unmatched paths go to other`() {
+        val roots = groupSessionsIntoRoots(
+            sessions = listOf(
+                row("in-git", workspace = "/home/x/git/pocketshell", activity = 10, created = 1),
+                row("in-tmp", workspace = "/home/x/tmp/scratch", activity = 20, created = 2),
+                row("stray", workspace = "/var/log", activity = 30, created = 3),
+                row("homeless", workspace = null, activity = 40, created = 4),
+            ),
+            home = "/home/x",
+            registeredRoots = listOf("~/tmp", "~/git"),
+        )
+        assertEquals(listOf("~/tmp", "~/git", OTHER_ROOT_LABEL), roots.map { it.headerLabel })
+        assertEquals(listOf("scratch"), roots[0].folders.map { it.label })
+        assertEquals(listOf("pocketshell"), roots[1].folders.map { it.label })
+        assertEquals(listOf("log"), roots[2].folders.filterNot { it.untracked }.map { it.label })
+        assertEquals(listOf("homeless"), roots[2].folders.filter { it.untracked }.flatMap { it.rows.map { row -> row.name } })
+        assertTrue(roots[0].configured)
+        assertTrue(roots[1].configured)
+        assertFalse(roots[2].configured)
+    }
+
+    @Test
+    fun `an empty registered root still renders, ahead of other`() {
+        val roots = groupSessionsIntoRoots(
+            sessions = listOf(
+                row("stray", workspace = "/var/log", activity = 1, created = 1),
+            ),
+            home = "/home/x",
+            registeredRoots = listOf("~/git"),
+        )
+        assertEquals(listOf("~/git", OTHER_ROOT_LABEL), roots.map { it.headerLabel })
+        assertEquals(0, roots[0].sessionCount)
+        assertTrue(roots[0].configured)
+        assertEquals(emptyList<SessionFolderNode>(), roots[0].folders)
+    }
+
+    @Test
+    fun `tilde and absolute spellings of one directory fold into a single folder`() {
+        val roots = groupSessionsIntoRoots(
+            listOf(
+                row("abs", workspace = "/home/x/git/pocketshell", activity = 1, created = 1),
+                row("tilde", workspace = "~/git/pocketshell", activity = 2, created = 2),
+            ),
+            home = "/home/x",
+        )
+        assertEquals(1, roots.single().folders.size)
+        assertEquals(
+            listOf("abs", "tilde"),
+            roots.single().folders.single().rows.map { it.name },
+        )
+    }
+
+    @Test
+    fun `folders under a root order by their oldest session, not by recency`() {
+        val roots = groupSessionsIntoRoots(
+            listOf(
+                row("new-in-old-folder", workspace = "/home/x/git/alpha", activity = 999, created = 50),
+                row("first-in-old-folder", workspace = "/home/x/git/alpha", activity = 1, created = 10),
+                row("only-in-newer-folder", workspace = "/home/x/git/zeta", activity = 500, created = 20),
+            ),
+        )
+        assertEquals(listOf("alpha", "zeta"), roots.single().folders.map { it.label })
     }
 
     @Test
     fun `an UNKNOWN-backend row is grouped and kept, never dropped`() {
-        val groups = groupSessionsByWorkspace(
+        val roots = groupSessionsIntoRoots(
             listOf(
-                row("tmux-one", workspace = "/w", activity = 10, backend = Backend.TMUX),
-                // A manager this build has never heard of.
+                row("tmux-one", workspace = "/home/x/git/w", activity = 10, backend = Backend.TMUX, created = 1),
                 row(
                     "from-the-future",
-                    workspace = "/w",
+                    workspace = "/home/x/git/w",
                     activity = 20,
                     backend = Backend.fromWire("warpdrive"),
+                    created = 2,
                 ),
-                row("no-workspace-future", workspace = null, activity = 30, backend = Backend.UNKNOWN),
+                row(
+                    "no-workspace-future",
+                    workspace = null,
+                    activity = 30,
+                    backend = Backend.UNKNOWN,
+                    created = 3,
+                ),
             ),
         )
-
-        assertEquals(3, groups.sumOf { it.rows.size })
-        val workspaceGroup = groups.single { it.label == "/w" }
-        assertEquals(listOf("from-the-future", "tmux-one"), workspaceGroup.rows.map { it.name })
+        assertEquals(3, roots.sumOf { it.sessionCount })
+        val workspaceFolder = roots.single { it.headerLabel == "~/git" }.folders.single()
+        assertEquals(listOf("tmux-one", "from-the-future"), workspaceFolder.rows.map { it.name })
         assertEquals(
             listOf("no-workspace-future"),
-            groups.single { it.label == OTHER_WORKSPACE_LABEL }.rows.map { it.name },
+            roots.single { it.other }.folders.single().rows.map { it.name },
         )
         assertTrue(
             "an unrecognised manager must survive as UNKNOWN",
-            workspaceGroup.rows.any { it.backend == Backend.UNKNOWN },
+            workspaceFolder.rows.any { it.backend == Backend.UNKNOWN },
         )
     }
 
     @Test
     fun `every input row survives grouping, tmux and aplexer alike`() {
         val input = listOf(
-            row("t1", workspace = "/a", activity = 1, backend = Backend.TMUX),
-            row("t2", workspace = null, activity = null, backend = Backend.TMUX),
-            row("a1", workspace = "/b", activity = 3, backend = Backend.APLEXER),
-            row("a2", workspace = "/a", activity = 4, backend = Backend.APLEXER),
-            row("u1", workspace = "/b", activity = null, backend = Backend.UNKNOWN),
+            row("t1", workspace = "/home/x/git/a", activity = 1, backend = Backend.TMUX, created = 1),
+            row("t2", workspace = null, activity = null, backend = Backend.TMUX, created = 2),
+            row("a1", workspace = "/home/x/tmp/b", activity = 3, backend = Backend.APLEXER, created = 3),
+            row("a2", workspace = "/home/x/git/a", activity = 4, backend = Backend.APLEXER, created = 4),
+            row("u1", workspace = "/home/x/tmp/b", activity = null, backend = Backend.UNKNOWN, created = 5),
         )
 
-        val out = groupSessionsByWorkspace(input)
+        val out = groupSessionsIntoRoots(input)
 
         assertEquals(
             input.map { it.name }.toSet(),
-            out.flatMap { group -> group.rows.map { it.name } }.toSet(),
+            out.flatMap { root -> root.folders.flatMap { it.rows.map { row -> row.name } } }.toSet(),
         )
-        assertEquals(input.size, out.sumOf { it.rows.size })
+        assertEquals(input.size, out.sumOf { it.sessionCount })
     }
 
     @Test
-    fun `an empty listing produces no groups`() {
-        assertEquals(emptyList<WorkspaceGroup>(), groupSessionsByWorkspace(emptyList()))
+    fun `an empty listing produces no roots`() {
+        assertEquals(emptyList<SessionRoot>(), groupSessionsIntoRoots(emptyList()))
     }
 
     @Test
-    fun `latestActivityEpoch is the newest member, ignoring nulls`() {
-        val group = groupSessionsByWorkspace(
+    fun `rows with the same created epoch are ordered by name, so the output is deterministic`() {
+        val forward = groupSessionsIntoRoots(
             listOf(
-                row("a", workspace = "/w", activity = null),
-                row("b", workspace = "/w", activity = 5),
-                row("c", workspace = "/w", activity = 77),
+                row("beta", workspace = "/home/x/git/w", activity = 42, created = 7),
+                row("alpha", workspace = "/home/x/git/w", activity = 42, created = 7),
             ),
-        ).single()
-
-        assertEquals(77L, group.latestActivityEpoch)
+        )
+        val reversed = groupSessionsIntoRoots(
+            listOf(
+                row("alpha", workspace = "/home/x/git/w", activity = 42, created = 7),
+                row("beta", workspace = "/home/x/git/w", activity = 42, created = 7),
+            ),
+        )
+        assertEquals(listOf("alpha", "beta"), forward.single().folders.single().rows.map { it.name })
+        assertEquals(
+            forward.single().folders.single().rows.map { it.name },
+            reversed.single().folders.single().rows.map { it.name },
+        )
     }
 
     // --- relativeActivityLabel -------------------------------------------
@@ -249,57 +346,53 @@ class TreeGroupingTest {
      * `fixtures/sessions-list-devbox.json`.
      *
      * Hand-written rows exercise the rules; this exercises the SHAPE — 13
-     * sessions over 9 workspaces from BOTH managers, three of them sharing one
-     * workspace, several aplexer rows carrying `workspace:tag` names. It runs
-     * through the real `SessionsJson` parser, so a change to either side that
-     * only breaks on real data breaks here.
+     * sessions over `$HOME/git/…` plus `/tmp/aplexer-follow` from BOTH managers.
+     * It runs through the real `SessionsJson` parser, so a change to either side
+     * that only breaks on real data breaks here.
      */
     @Test
-    fun `a real dev-box listing groups into its workspaces with both managers`() {
+    fun `a real dev-box listing groups into git and other with both managers`() {
         val listing = SessionsJson.parseSessionsList(readFixture("sessions-list-devbox.json"))
             .getOrThrow()
 
         assertTrue("the capture must carry backend errors as an empty list", listing.errors.isEmpty())
-        val groups = groupSessionsByWorkspace(listing.sessions)
+        val roots = groupSessionsIntoRoots(listing.sessions)
 
-        // Nothing is lost and nothing is invented.
-        assertEquals(listing.sessions.size, groups.sumOf { it.rows.size })
+        assertEquals(listing.sessions.size, roots.sumOf { it.sessionCount })
         assertEquals(
-            listing.sessions.map { it.workspace }.toSet(),
-            groups.map { it.workspace }.toSet(),
+            listing.sessions.map { it.name }.toSet(),
+            roots.flatMap { it.folders.flatMap { folder -> folder.rows.map { it.name } } }.toSet(),
         )
 
-        // BOTH managers really are represented — a tmux-only regression here
-        // would be invisible to every hand-written case above.
         val backends = listing.sessions.map { it.backend }.toSet()
         assertTrue("expected tmux rows", Backend.TMUX in backends)
         assertTrue("expected aplexer rows", Backend.APLEXER in backends)
 
-        // The workspace with three sessions is one group, not three.
-        val busiest = groups.maxBy { it.rows.size }
-        assertTrue("expected a workspace holding several sessions", busiest.rows.size >= 3)
-
-        // Ordering holds on real data: every group's own rows are non-increasing
-        // in activity, and the groups themselves are too.
-        groups.forEach { group ->
-            assertEquals(
-                "rows in ${group.label} must be newest-first",
-                group.rows.sortedWith(
-                    compareBy<SessionRow> { it.activityEpoch == null }
-                        .thenByDescending { it.activityEpoch ?: Long.MIN_VALUE },
-                ).map { it.name },
-                group.rows.map { it.name },
-            )
+        assertEquals(listOf("~/git", OTHER_ROOT_LABEL), roots.map { it.headerLabel })
+        val git = roots.single { it.headerLabel == "~/git" }
+        assertTrue("git must hold more than one folder", git.folders.size > 1)
+        git.folders.forEach { folder ->
+            assertFalse("a reported cwd must keep its folder row", folder.untracked)
+            assertTrue(folder.rows.isNotEmpty())
         }
-        val groupActivity = groups.map { it.latestActivityEpoch }
-        assertEquals(
-            "groups must be newest-first",
-            groupActivity.sortedWith(
-                compareBy<Long?> { it == null }.thenByDescending { it ?: Long.MIN_VALUE },
-            ),
-            groupActivity,
-        )
+        val busiest = git.folders.maxBy { it.rows.size }
+        assertTrue("expected a folder holding several sessions", busiest.rows.size >= 3)
+
+        // Creation order: never activity. An activity bump is not in this
+        // fixture, but the order of each folder's rows must match createdEpoch.
+        roots.forEach { root ->
+            root.folders.forEach { folder ->
+                val names = folder.rows.map { it.name }
+                val expected = folder.rows.sortedWith(
+                    compareBy<SessionRow> { it.createdEpoch ?: 0L }.thenBy { it.name },
+                ).map { it.name }
+                assertEquals("rows in ${folder.label} must be oldest-created first", expected, names)
+            }
+        }
     }
+
+    private fun leafNames(roots: List<SessionRoot>): List<String> =
+        roots.flatMap { root -> root.folders.flatMap { it.rows.map { row -> row.name } } }
 
     private fun readFixture(name: String): String =
         requireNotNull(javaClass.classLoader?.getResourceAsStream("fixtures/$name")) {
@@ -311,6 +404,7 @@ class TreeGroupingTest {
         workspace: String?,
         activity: Long?,
         backend: Backend = Backend.TMUX,
+        created: Long? = null,
     ): SessionRow = SessionRow(
         name = name,
         backend = backend,
@@ -322,7 +416,7 @@ class TreeGroupingTest {
         agentState = null as AgentState?,
         agentStateSource = null as AgentStateSource?,
         attached = false,
-        createdEpoch = null,
+        createdEpoch = created,
         activityEpoch = activity,
     )
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,11 +207,18 @@ the tree renders that as a "some sessions may be missing" banner.
 ### Session tree
 
 `app2/tree/` — `SessionTreeViewModel` lists on enter, on `ON_START` and on
-pull-to-refresh; `TreeGrouping` buckets rows by the host's `workspace` string,
-compared exactly. Nothing parses a session name, strips a prefix or splits an
-aplexer `workspace:tag`: the host already knows the structure, so the phone
-buckets rather than deduces. Null/blank workspace lands in an `other` bucket.
-Both levels sort most-recently-active first.
+pull-to-refresh; `TreeGrouping.groupSessionsIntoRoots` projects rows into the
+desktop-style `root → folder → session` tree. The host's `workspace` string is
+the cwd (same as desktop `path`). Registered Settings workspace roots are the
+top level when any exist; otherwise roots are synthesised from `$HOME`'s
+children (`~/git`, `~/tmp`, …). Null/blank workspace, `$HOME` itself, and
+paths matching no root land in `other`, pinned last. Folder label is the cwd
+basename (parent segment on collision). A 1-session folder still has a folder
+row — collapsing it is the "grouping doesn't work" failure. Order is creation
+(`createdEpoch` oldest first, name tiebreak); `activityEpoch` is display-only
+and never a sort key. Nothing parses a session name, strips a prefix or splits
+an aplexer `workspace:tag`. The tree shows no engine/agent chrome (U-9 stays
+cut): attached is a green status dot, the row title is the session name.
 
 `SessionTreeUiState` keeps `groups` and `failure` simultaneously, so a failed
 refresh leaves the last known list on screen under an error banner instead of
@@ -344,7 +351,7 @@ graph, where a credential-carrying destination was the norm.
 | Route | Screen | Purpose |
 |---|---|---|
 | `hosts` | `HostListScreen` (+ `ConnectGate`) | Saved hosts; tap connects |
-| `tree/{hostId}` | `SessionTreeScreen` | Sessions grouped by workspace; create sheet |
+| `tree/{hostId}` | `SessionTreeScreen` | Sessions as root → folder → session; create sheet |
 | `session/{hostId}/{sessionName}` | `SessionScreen` | The attached terminal, key bar, composer |
 | `files/{hostId}?path=` | `FileExplorerScreen` | SFTP browser |
 | `file/{hostId}?path=` | `ViewerScreen` | File viewer/editor (text, markdown, image, binary) |
@@ -387,25 +394,23 @@ tree/env/repo helpers. Install and troubleshooting: [server-setup.md](server-set
 The client uses a subset. `jobs`, `env`, `cards` and `repos` exist server-side
 but have **no app2 UI** — those ports were cut from the rewrite's scope.
 
-Agent identity/state belongs to the host for both backends, and app2 only
-renders what the host reports. The wire path is live end to end:
-`session_enum.aplexer_agent_state` derives `(agent_state, agent_state_source)`
-for each aplexer row (a fresh `reported_state` push wins; otherwise a
-PTY-recency heuristic picks `working`/`waiting`), `core-hostapi` parses it into
-`AgentState?`, and `SessionTreeScreen` maps that to the ui-kit
-`AgentStateChip` — a tinted hourglass/spinner/check in every session row's
-trailing slot, beside the `AgentKindBadge` monogram. The chip draws **nothing**
-for the unknown state, so a row with no host opinion is absent, never wrong.
+Agent identity/state belongs to the host for both backends. The wire path is
+live end to end: `session_enum.aplexer_agent_state` derives
+`(agent_state, agent_state_source)` for each aplexer row (a fresh
+`reported_state` push wins; otherwise a PTY-recency heuristic picks
+`working`/`waiting`) and `core-hostapi` parses it into `AgentState?`. The
+session tree does **not** render that as UI — rewrite U-9 (agent-state chips /
+engine badges on the list) stays cut, so a row is a name, an optional relative
+time, and a green attached dot. The parsed fields remain on `SessionRow` for
+the terminal screen and for anything U-9 later grows.
 
-Two things are absent, and they are not the chip:
+Two things are absent, and they are not a chip:
 
 - **tmux-backed rows have no state to show.** They carry an explicit
   `agent_state: null` until the cross-repo `APX-ADOPT` capability lets aplexer
-  adopt a foreign tmux session, so on a tmux-only host the chip is wired but
-  invisible everywhere.
+  adopt a foreign tmux session.
 - **There is no conversation/transcript view and no client-side detection.**
-  Parsing agent output on the phone was cut with the rest of control mode; the
-  chip is the entire agent-awareness surface.
+  Parsing agent output on the phone was cut with the rest of control mode.
 
 A host CLI older than schema 2 is rejected with a typed `HostCliError.TooOld`
 rather than a parse error.

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/DesignRenders.kt
@@ -104,6 +104,17 @@ import org.robolectric.annotation.GraphicsMode
 @Config(qualifiers = "w412dp-h915dp-night-xxhdpi")
 class DesignRenders {
 
+    /**
+     * Issue #2530: desktop-style session tree — `~/git` / `other` roots, folder
+     * rows even at 1:1, session leaves with a status dot and no agent badge.
+     * `SessionTreeScreen` is app-module private, so this mirrors the primitives
+     * it composes; the emulator journey is the acceptance.
+     */
+    @Test
+    fun sessionTree() = render("session-tree") {
+        SessionTreeDesktopStyleRender()
+    }
+
     /** Issue #2521: closed-session compact launcher (Prompt Composer + ⌨). */
     @Test
     fun sessionCompactLauncherBar() = render("session-compact-launcher-bar") {

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/SessionTreeRenderFixtures.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/render/SessionTreeRenderFixtures.kt
@@ -1,0 +1,68 @@
+package com.pocketshell.uikit.render
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.pocketshell.uikit.components.ListRow
+import com.pocketshell.uikit.components.ScreenHeader
+import com.pocketshell.uikit.components.SectionHeader
+import com.pocketshell.uikit.components.StatusDot
+import com.pocketshell.uikit.model.ConnectionStatus
+import com.pocketshell.uikit.theme.PocketShellDensity
+
+/**
+ * Issue #2530: the phone session tree as `root → folder → session`, no
+ * engine/agent chrome. `SessionTreeScreen` is app-module private, so this
+ * mirrors it with the shared ui-kit primitives the screen composes
+ * ([ScreenHeader], [SectionHeader], [ListRow], [StatusDot]). Fast first
+ * visual check; the emulator journey is the acceptance.
+ */
+@Composable
+internal fun SessionTreeDesktopStyleRender() {
+    Column {
+        ScreenHeader(
+            title = "Sessions",
+            subtitle = "4 sessions · 2 roots",
+        )
+        SectionHeader(label = "~/git", count = 3)
+        SectionHeader(
+            label = "pocketshell",
+            count = 2,
+            modifier = Modifier.padding(start = PocketShellDensity.treeIndent),
+        )
+        ListRow(
+            title = "git-pocketshell",
+            subtitle = "2m ago",
+            leading = { StatusDot(status = ConnectionStatus.Connected) },
+            onClick = {},
+            modifier = Modifier.padding(start = PocketShellDensity.treeIndent * 2),
+        )
+        ListRow(
+            title = "git-pocketshell-2",
+            subtitle = "1h ago",
+            leading = { StatusDot(status = ConnectionStatus.Idle) },
+            onClick = {},
+            modifier = Modifier.padding(start = PocketShellDensity.treeIndent * 2),
+        )
+        SectionHeader(
+            label = "aplexer",
+            modifier = Modifier.padding(start = PocketShellDensity.treeIndent),
+        )
+        ListRow(
+            title = "git-aplexer",
+            subtitle = "3h ago",
+            leading = { StatusDot(status = ConnectionStatus.Idle) },
+            onClick = {},
+            modifier = Modifier.padding(start = PocketShellDensity.treeIndent * 2),
+        )
+        SectionHeader(label = "other", count = 1)
+        ListRow(
+            title = "stray",
+            subtitle = "2d ago",
+            leading = { StatusDot(status = ConnectionStatus.Idle) },
+            onClick = {},
+            modifier = Modifier.padding(start = PocketShellDensity.treeIndent),
+        )
+    }
+}


### PR DESCRIPTION
Closes #2530.

Session list follows the desktop panel: `~/git` / `other` roots, folders under them, session rows. Creation order. No agent badges.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2530#issuecomment-5554065055