### PR TITLE
fix: keep the terminal fixed under the keyboard

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/Issue887TerminalFixedUnderImeProofTest.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/Issue887TerminalFixedUnderImeProofTest.kt
@@ -1,0 +1,413 @@
+package com.pocketshell.next.terminal
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.next.composer.ComposerUiState
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #2533 (D31 reopen of #887) — terminal stays FIXED when the soft
+ * keyboard shows: NEITHER resized NOR panned. The keyboard simply OVERLAYS
+ * the bottom rows of the terminal, and the composer (when open) floats above
+ * the keyboard.
+ *
+ * ## What this proves (and the maintainer's reported bug)
+ *
+ * The rewrite put [Modifier.imePadding] back on [SessionScreen]'s session
+ * column, so raising the keyboard shrinks the column, [onResized] fires, and
+ * tmux reflows. After the keyboard hides, the view can be left with a large
+ * empty void (the 2026-09-05 screenshot). #887 already forbade that: the
+ * window is `SOFT_INPUT_ADJUST_NOTHING` and the session column is a plain
+ * `Modifier.fillMaxSize()`.
+ *
+ * ## The load-bearing assertion (terminal bounds UNCHANGED)
+ *
+ * [terminalDoesNotMoveOrResizeWhenImeUp] composes the PRODUCTION
+ * [SessionScreen] (Connecting — the terminal slot is the weight(1f) box,
+ * no native `TerminalSession` required), captures the slot's `boundsInRoot`
+ * keyboard-DOWN, dispatches a SYNTHETIC `ime()` inset (the #780 model —
+ * environment-independent, HARD-asserted to apply, never an `assumeTrue`
+ * skip), and asserts those bounds are IDENTICAL keyboard-UP. It also
+ * asserts a composer stand-in that DOES apply `.imePadding()` sits fully
+ * above the synthetic keyboard.
+ *
+ * This is the reproduce-first proof: on the unfixed `imePadding()` column
+ * the height shrinks (RED); after the #887 flags the height is unchanged
+ * (GREEN).
+ *
+ * ## Red→green guard (the assertion is load-bearing, not vacuous)
+ *
+ * [imePaddingOnTheColumnWouldShrinkTheTerminal_provesAssertionIsLoadBearing]
+ * composes the CURRENT (buggy) column shape — `fillMaxSize().imePadding()` —
+ * under the SAME synthetic inset and asserts the terminal slot DID shrink.
+ * Together the two cases are the red→green proof for #2533/#887.
+ */
+@RunWith(AndroidJUnit4::class)
+class Issue887TerminalFixedUnderImeProofTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    // Compose-observed insets (px), captured from INSIDE the composition so the
+    // measured keyboard height is exactly what the laid-out screen reacted to.
+    private val observedImeBottomPx = mutableStateOf(0)
+    private val observedNavBottomPx = mutableStateOf(0)
+
+    @Test
+    fun terminalDoesNotMoveOrResizeWhenImeUp() {
+        setUpEdgeToEdge()
+        compose.setContent {
+            PocketShellTheme {
+                ObserveInsets()
+                ProductionSessionColumn()
+            }
+        }
+        compose.waitForIdle()
+
+        val terminalDown = boundsOf(SESSION_CONNECTING_TAG)
+        val columnDown = boundsOf(SESSION_SCREEN_TAG)
+
+        applySyntheticInsets(
+            imeBottomPx = (IME_HEIGHT_DP * density()).toInt(),
+            navBarBottomPx = (NAV_BAR_DP * density()).toInt(),
+        )
+        compose.waitForIdle()
+
+        // HARD-assert the synthetic inset actually reached Compose — otherwise we
+        // would be measuring a keyboard-DOWN layout and the bounds-unchanged check
+        // would pass vacuously. Never an assumeTrue skip (#780/#657 F3).
+        val imeBottomPx = observedImeBottomPx.value
+        assertTrue(
+            "Synthetic ime() inset did not reach Compose; cannot validate the " +
+                "#887 terminal-fixed-under-keyboard geometry. observedImeBottomPx=" +
+                "$imeBottomPx (expected > 0).",
+            imeBottomPx > 0,
+        )
+
+        val terminalUp = boundsOf(SESSION_CONNECTING_TAG)
+        val columnUp = boundsOf(SESSION_SCREEN_TAG)
+
+        println(
+            "ISSUE887_TERMINAL terminalDown=$terminalDown terminalUp=$terminalUp " +
+                "columnDown=$columnDown columnUp=$columnUp " +
+                "imeBottomPx=$imeBottomPx navBottomPx=${observedNavBottomPx.value}",
+        )
+
+        // LOAD-BEARING: the terminal slot's boundsInRoot must be IDENTICAL with
+        // vs without the keyboard — same top (no pan up) AND same size (no
+        // resize / reflow). This is the exact #887/#2533 acceptance criterion.
+        assertUnchanged("Terminal", terminalDown, terminalUp)
+        assertUnchanged("Session column", columnDown, columnUp)
+
+        // The composer (which DOES apply `.imePadding()`) must sit fully above
+        // the synthetic keyboard — independent of the fixed terminal. The
+        // keyboard top in root coords is decorHeight - (ime - navBars).
+        val rootBottom = boundsOf(ROOT_TAG).bottom
+        val keyboardIntrusionPx = (imeBottomPx - observedNavBottomPx.value).coerceAtLeast(0)
+        val keyboardTopPx = rootBottom - keyboardIntrusionPx
+        assertNodeFullyAboveKeyboard(
+            tag = COMPOSER_TAG,
+            keyboardTopPx = keyboardTopPx,
+        )
+    }
+
+    @Test
+    fun imePaddingOnTheColumnWouldShrinkTheTerminal_provesAssertionIsLoadBearing() {
+        setUpEdgeToEdge()
+        compose.setContent {
+            PocketShellTheme {
+                ObserveInsets()
+                LegacyImePaddedTerminalColumn()
+            }
+        }
+        compose.waitForIdle()
+
+        val terminalDown = boundsOf(TERMINAL_TAG)
+
+        applySyntheticInsets(
+            imeBottomPx = (IME_HEIGHT_DP * density()).toInt(),
+            navBarBottomPx = (NAV_BAR_DP * density()).toInt(),
+        )
+        compose.waitForIdle()
+
+        val imeBottomPx = observedImeBottomPx.value
+        assertTrue(
+            "Synthetic ime() inset did not reach Compose. observedImeBottomPx=$imeBottomPx.",
+            imeBottomPx > 0,
+        )
+
+        val terminalUp = boundsOf(TERMINAL_TAG)
+        println(
+            "ISSUE887_IME_PADDING terminalDown=$terminalDown terminalUp=$terminalUp " +
+                "imeBottomPx=$imeBottomPx navBottomPx=${observedNavBottomPx.value}",
+        )
+
+        // The rewrite's session-column `imePadding()` DID shrink the terminal
+        // (height drops by the IME inset). This is the bug the production fix
+        // removes; asserting the height moved here proves the bounds-UNCHANGED
+        // assertion in the production test is load-bearing (it can tell
+        // padded from fixed) — the red the fix turns green.
+        assertTrue(
+            "imePadding on the session column was expected to shrink the terminal " +
+                "when the keyboard showed, but its height did not change — the " +
+                "red→green guard for #2533/#887 is no longer meaningful. " +
+                "down=$terminalDown up=$terminalUp",
+            terminalUp.height < terminalDown.height - BOUNDS_SLOP_PX,
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Harness composables — production SessionScreen vs the deleted
+    // imePadding column shape.
+    // ------------------------------------------------------------------
+
+    /**
+     * The PRODUCTION screen. Connecting is enough: the terminal slot is the
+     * weight(1f) box whose size change is what [SessionScreen] reports through
+     * `onResized`, and that is the quantity `imePadding` on the column used
+     * to steal. A composer stand-in with `.imePadding()` is overlaid so AC2
+     * (Send/mic above the IME) is proven independently of the sheet window.
+     *
+     * The stand-in is F2-justified the same way #887's was: the real
+     * [com.pocketshell.next.composer.PromptComposerSheet] is a separate
+     * `ModalBottomSheet` dialog window with its own inset handling; this
+     * proof's concern is that `.imePadding()` still lifts content above a
+     * dispatched `ime()` inset under `ADJUST_NOTHING`.
+     */
+    @Composable
+    private fun ProductionSessionColumn() {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(ROOT_TAG)
+                .background(PocketShellColors.Background),
+        ) {
+            SessionScreen(
+                state = SessionUiState.Connecting,
+                composerState = ComposerUiState(),
+                sessionName = SESSION,
+                onBack = {},
+                onResized = { _, _ -> },
+                onRetry = {},
+                onHotkeySend = {},
+                onDraftChange = {},
+                onSend = {},
+                onInsert = {},
+                onAttach = {},
+                onMicTap = {},
+                onCancelRecording = {},
+                onToggleHistory = {},
+                onTogglePreview = {},
+                onRemoveAttachment = {},
+                onDismissNotice = {},
+                onDiscardDraft = {},
+                onUseHistoryEntry = {},
+            )
+            ComposerStandIn(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .imePadding(),
+            )
+        }
+    }
+
+    /**
+     * The rewrite's buggy column shape, kept ONLY in this test as the red
+     * baseline: `fillMaxSize().imePadding()` on the session column. Production
+     * no longer has this; it exists here so the bounds-unchanged assertion
+     * above is provably load-bearing (red→green).
+     */
+    @Composable
+    private fun LegacyImePaddedTerminalColumn() {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(ROOT_TAG)
+                .background(PocketShellColors.Background),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .imePadding(),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .testTag(TERMINAL_TAG)
+                        .background(PocketShellColors.Background),
+                ) {
+                    Text(
+                        text = "alex@pocketshell:~$ tail -f deploy.log",
+                        color = PocketShellColors.Text,
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun ComposerStandIn(modifier: Modifier = Modifier) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(COMPOSER_HEIGHT_DP.dp)
+                .testTag(COMPOSER_TAG)
+                .background(PocketShellColors.Surface),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(text = "Send  |  attach  |  mic", color = PocketShellColors.Text)
+        }
+    }
+
+    @Composable
+    private fun ObserveInsets() {
+        val d = LocalDensity.current
+        observedImeBottomPx.value = WindowInsets.ime.getBottom(d)
+        observedNavBottomPx.value = WindowInsets.navigationBars.getBottom(d)
+    }
+
+    // ------------------------------------------------------------------
+    // Test plumbing (synthetic-inset model, #780).
+    // ------------------------------------------------------------------
+
+    private fun setUpEdgeToEdge() {
+        compose.activityRule.scenario.onActivity { activity ->
+            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
+        }
+    }
+
+    private fun applySyntheticInsets(imeBottomPx: Int, navBarBottomPx: Int) {
+        compose.activityRule.scenario.onActivity { activity ->
+            val decor = activity.window.decorView
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottomPx))
+                .setInsets(
+                    WindowInsetsCompat.Type.navigationBars(),
+                    Insets.of(0, 0, 0, navBarBottomPx),
+                )
+                .setInsets(
+                    WindowInsetsCompat.Type.systemBars(),
+                    Insets.of(0, 0, 0, navBarBottomPx),
+                )
+                .build()
+            ViewCompat.dispatchApplyWindowInsets(decor, insets)
+        }
+    }
+
+    private data class Bounds(
+        val left: Float,
+        val top: Float,
+        val width: Float,
+        val height: Float,
+        val bottom: Float,
+    ) {
+        override fun toString() =
+            "Bounds(left=$left top=$top width=$width height=$height bottom=$bottom)"
+    }
+
+    private fun boundsOf(tag: String): Bounds {
+        val r = compose.onNodeWithTag(tag, useUnmergedTree = true)
+            .fetchSemanticsNode()
+            .boundsInRoot
+        return Bounds(
+            left = r.left,
+            top = r.top,
+            width = r.width,
+            height = r.height,
+            bottom = r.bottom,
+        )
+    }
+
+    private fun assertUnchanged(what: String, down: Bounds, up: Bounds) {
+        assertEquals(
+            "$what TOP moved when the keyboard showed (#887: must NOT pan up). " +
+                "down=$down up=$up",
+            down.top,
+            up.top,
+            BOUNDS_SLOP_PX,
+        )
+        assertEquals(
+            "$what HEIGHT changed when the keyboard showed (#457/#887: must NOT " +
+                "resize/reflow). down=$down up=$up",
+            down.height,
+            up.height,
+            BOUNDS_SLOP_PX,
+        )
+        assertEquals(
+            "$what LEFT moved when the keyboard showed. down=$down up=$up",
+            down.left,
+            up.left,
+            BOUNDS_SLOP_PX,
+        )
+        assertEquals(
+            "$what WIDTH changed when the keyboard showed. down=$down up=$up",
+            down.width,
+            up.width,
+            BOUNDS_SLOP_PX,
+        )
+    }
+
+    private fun assertNodeFullyAboveKeyboard(tag: String, keyboardTopPx: Float) {
+        val density = compose.density.density
+        val slopPx = CONTAINMENT_SLOP_DP * density
+        val bounds = boundsOf(tag)
+        assertTrue(
+            "Node '$tag' is not fully above the keyboard (Send/mic must stay " +
+                "reachable). nodeBounds=$bounds keyboardTopPx=$keyboardTopPx " +
+                "slopPx=$slopPx.",
+            bounds.bottom <= keyboardTopPx + slopPx,
+        )
+    }
+
+    private fun density(): Float =
+        InstrumentationRegistry.getInstrumentation()
+            .targetContext.resources.displayMetrics.density
+
+    private companion object {
+        const val ROOT_TAG = "issue887-root"
+        const val TERMINAL_TAG = "issue887-terminal"
+        const val COMPOSER_TAG = "issue887-composer"
+        const val SESSION = "issue887-shell"
+
+        const val IME_HEIGHT_DP = 300f
+        const val NAV_BAR_DP = 24f
+        const val COMPOSER_HEIGHT_DP = 56f
+
+        // Density-scaled slop so sub-pixel rounding never flips the bounds-equal
+        // assertion. 1.5px is well below the ~750px shrink a 300dp keyboard produces.
+        const val BOUNDS_SLOP_PX = 1.5f
+        const val CONTAINMENT_SLOP_DP = 1f
+    }
+}

--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/J03AttachAndTypeJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/J03AttachAndTypeJourney.kt
@@ -291,16 +291,16 @@ class J03AttachAndTypeJourney {
      * a resize that never crossed the wire.
      *
      * Two viewport changes, the two the maintainer actually does: raising the
-     * keyboard (which must take rows and leave columns alone) and rotating
-     * (which swaps them). Both must also come BACK — a resize path that only
-     * ever shrinks leaves the session unusable after the keyboard closes.
+     * keyboard (which must NOT change rows or columns — #887/#2533: the
+     * keyboard overlays the terminal, it does not shrink it) and rotating
+     * (which swaps them). Rotation must also come BACK — a resize path that
+     * only ever shrinks leaves the session unusable after a rotate.
      *
      * Then the awkward one: a viewport change that lands in the MIDDLE of a
-     * measurement. Each of those gestures is a stream of sizes (an IME inset
-     * animation reports a new one per frame), and the app must end up telling
-     * the remote the size it settled at — not one from the middle of the
-     * animation, which leaves the pane wrapping at a width the screen does not
-     * have and no further layout change to correct it.
+     * measurement. Rotation is a stream of sizes (an inset animation reports
+     * a new one per frame), and the app must end up telling the remote the
+     * size it settled at. A keyboard arriving mid-measurement must not change
+     * the size at all (#887/#2533).
      */
     @Test
     fun theRemoteTerminalSizeTracksTheKeyboardAndRotation() {
@@ -313,20 +313,18 @@ class J03AttachAndTypeJourney {
         showKeyboard()
         val opened = remoteSize("keyboard up", keyboardUp = true)
         JourneyScreenshots.capture("05-keyboard-up", JOURNEY)
-        assertTrue(
-            "the keyboard must cost the remote rows: closed=$closed opened=$opened",
-            opened.rows < closed.rows,
-        )
         assertEquals(
-            "the keyboard takes height, not width: closed=$closed opened=$opened",
-            closed.cols,
-            opened.cols,
+            "the keyboard must not change the remote size (#887/#2533): " +
+                "closed=$closed opened=$opened",
+            closed,
+            opened,
         )
 
         hideKeyboard()
         val reclosed = remoteSize("keyboard down again", keyboardUp = false)
         assertEquals(
-            "closing the keyboard must give the rows back: was $closed, now $reclosed",
+            "closing the keyboard must leave the remote size unchanged: " +
+                "was $closed, now $reclosed",
             closed,
             reclosed,
         )
@@ -351,13 +349,11 @@ class J03AttachAndTypeJourney {
             backToPortrait,
         )
 
-        // A viewport change can land in the MIDDLE of a command, and on a
-        // device with no hardware keyboard the framework raises the IME by
-        // itself when the terminal takes focus — so this is not a contrived
-        // race, it is the one that left the CI run of this journey waiting a
-        // full minute for a `stty size` reply describing a size the remote no
-        // longer had. Both ends must converge afterwards, on the size the
-        // layout settled at.
+        // A keyboard can land in the MIDDLE of a command — on a device with
+        // no hardware keyboard the framework raises the IME by itself when
+        // the terminal takes focus. That used to resize the pane mid-
+        // measurement (#887 recurrence). Both ends must still agree, on the
+        // same size the keyboard-down reading had.
         val afterMidFlightKeyboard =
             remoteSize("a keyboard arriving mid-measurement", keyboardUp = false) {
                 showKeyboard()
@@ -878,10 +874,11 @@ class J03AttachAndTypeJourney {
     /**
      * Waits for the framework's own IME inset to reach the expected state.
      *
-     * The inset — not a screenshot, not `isActive()` — because it is the exact
-     * quantity `Modifier.imePadding()` consumes, so it is the thing that must
-     * change for the terminal to shrink. If it never does, the test says so
-     * instead of quietly asserting a resize that had no cause.
+     * The inset — not a screenshot, not `isActive()` — because it is the
+     * quantity that would have shrunk the terminal when the session column
+     * still had `imePadding()`. If it never appears, asserting "rows
+     * unchanged with the keyboard up" (#887/#2533) would be vacuous. If it
+     * never does, the test says so instead of quietly asserting a no-op.
      */
     /** The framework's own IME inset, in pixels. 0 when the keyboard is down. */
     private fun imeInsetBottom(): Int {

--- a/app2/src/main/java/com/pocketshell/next/MainActivity.kt
+++ b/app2/src/main/java/com/pocketshell/next/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.pocketshell.next
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.systemBars
@@ -74,19 +76,31 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         grace.register(application)
+        // #887/#2533: after edge-to-edge, SOFT_INPUT_ADJUST_NOTHING so the OS
+        // neither resizes nor pans the window when the keyboard shows.
+        // enableEdgeToEdge already sets setDecorFitsSystemWindows(false), which
+        // left the default ADJUST_UNSPECIFIED resolving to PAN — the black-top
+        // / empty-void screenshot. ADJUST_NOTHING keeps the window FIXED: the
+        // keyboard overlays the terminal. Because decorFitsSystemWindows is
+        // still false, the IME inset is STILL dispatched to Compose as
+        // WindowInsets.ime, so sheets/forms that opt into imePadding keep
+        // working. The session column must not consume those insets.
+        enableEdgeToEdge()
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
         setContent {
             PocketShellTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
-                    // The window draws edge to edge (targetSdk 35 makes that
-                    // non-optional), so content must be inset out from under
-                    // the status/navigation bars or the first row of any
-                    // screen renders under the clock — which is exactly what
-                    // the placeholder scaffold hid by centring its one label.
-                    // IME insets stay a screen concern (task U-5 owns the
-                    // terminal's keyboard behaviour); this is bars only.
+                    // The window draws edge to edge (enableEdgeToEdge above;
+                    // targetSdk 35 also makes that non-optional), so content
+                    // must be inset out from under the status/navigation bars
+                    // or the first row of any screen renders under the clock.
+                    // IME insets are deliberately NOT consumed here: the
+                    // session column stays full-bleed under the keyboard
+                    // (#887/#2533); sheets and forms that need lifting apply
+                    // their own imePadding.
                     //
                     // Task P-6: the settings snapshot is collected ONCE here and
                     // provided through `LocalAppSettings` (see that file's class

--- a/app2/src/main/java/com/pocketshell/next/terminal/SessionScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/SessionScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
@@ -139,14 +138,15 @@ fun SessionRoute(
  * launcher bar. Prompt Composer and the hotkeys panel open as floating
  * overlays (#2521) and do not sit in this column.
  *
- * ## The keyboard shrinks the terminal, the overlays do not
+ * ## The keyboard overlays the terminal; it must not resize it (#887/#2533)
  *
- * [imePadding] on the column is what makes `stty size` on the remote track
- * the system keyboard: the column shrinks, so the terminal slot shrinks, so
- * the vendored view reports a new cell count through [onResized]. The
- * composer and hotkeys sheets are [androidx.compose.material3.ModalBottomSheet]s
- * — they float over the viewport and must not change that cell count, so
- * imePadding is skipped while either overlay is open.
+ * The session column is a plain [Modifier.fillMaxSize] — no `imePadding`, no
+ * pan. The window is `SOFT_INPUT_ADJUST_NOTHING` (see [com.pocketshell.next.MainActivity]),
+ * so the OS neither resizes nor pans when the keyboard shows. The grid stays
+ * put; [onResized] does not fire; tmux does not reflow. The composer and
+ * hotkeys sheets are [androidx.compose.material3.ModalBottomSheet]s with their
+ * own IME policy, so Send/mic stay above the keyboard independently of this
+ * column.
  *
  * @param onResized the terminal's size in character cells.
  * @param onHotkeySend raw bytes for the remote from the hotkeys panel.
@@ -185,12 +185,10 @@ fun SessionScreen(
 ) {
     var composerOpen by remember { mutableStateOf(initiallyShowComposer) }
     var hotkeysOpen by remember { mutableStateOf(initiallyShowHotkeys) }
-    val overlayOpen = composerOpen || hotkeysOpen
 
     Column(
         modifier = modifier
             .fillMaxSize()
-            .then(if (overlayOpen) Modifier else Modifier.imePadding())
             .testTag(SESSION_SCREEN_TAG),
     ) {
         ScreenHeader(


### PR DESCRIPTION
Closes #2533.

D31 reopen of #887: the window neither pans nor resizes when the IME shows. Composer/hotkeys sheets still sit above the keyboard.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2533#issuecomment-5554090839