### PR TITLE
feat: restore GitHub Releases update check

### DIFF
--- a/app2/src/main/java/com/pocketshell/next/App.kt
+++ b/app2/src/main/java/com/pocketshell/next/App.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import com.pocketshell.next.crash.CrashReporter
 import com.pocketshell.next.diagnostics.DiagnosticEvents
 import com.pocketshell.next.diagnostics.DiagnosticRecorder
+import com.pocketshell.next.release.UpdateCheckScheduler
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -12,12 +13,12 @@ import javax.inject.Inject
  * app2's Application.
  *
  * Beyond the Hilt entry point (plan §M-1 non-goal: "no DI beyond
- * `@HiltAndroidApp`"), `onCreate` does exactly two things (task P-10):
- * installs the generic diagnostics event sink and installs the crash
- * reporter's uncaught-exception handler, so an uncaught exception anywhere
- * in the app actually gets recorded to `filesDir/crash-reports` from process
- * start. No other eager initialisation, no process-wide schedulers, no
- * background work — D21 stands in the rewrite.
+ * `@HiltAndroidApp`"), `onCreate` does three things: installs the generic
+ * diagnostics event sink, installs the crash reporter's uncaught-exception
+ * handler, and attaches the foreground-only GitHub-Releases update check
+ * (issue #2531) to [androidx.lifecycle.ProcessLifecycleOwner]. The check is
+ * not background work — D21: it only fires on `ON_START`, throttled, one
+ * HTTP round-trip. No WorkManager, no AlarmManager.
  *
  * ## The Robolectric guard
  *
@@ -44,12 +45,19 @@ class App : Application() {
     @Inject
     lateinit var diagnosticRecorder: DiagnosticRecorder
 
+    @Inject
+    lateinit var updateCheckScheduler: UpdateCheckScheduler
+
     override fun onCreate() {
         super.onCreate()
         if (isRunningUnderRobolectric()) return
         DiagnosticEvents.install(diagnosticRecorder)
         DiagnosticEvents.record("app", "created")
         CrashReporter.install(this)
+        // Foreground-only (D21 / #698): ON_START of ProcessLifecycleOwner.
+        // Skipped under Robolectric so JVM unit tests never poll GitHub or
+        // attach a process-lifecycle observer that would leak across tests.
+        updateCheckScheduler.observeProcessLifecycle()
     }
 
     private fun isRunningUnderRobolectric(): Boolean = Build.FINGERPRINT == "robolectric"

--- a/app2/src/main/java/com/pocketshell/next/MainActivity.kt
+++ b/app2/src/main/java/com/pocketshell/next/MainActivity.kt
@@ -28,7 +28,6 @@ import com.pocketshell.next.files.FileExplorerRoute
 import com.pocketshell.next.files.ViewerRoute
 import com.pocketshell.next.hosts.AddEditHostRoute
 import com.pocketshell.next.hosts.HostListRoute
-
 import com.pocketshell.next.hosts.QrScannerRoute
 import com.pocketshell.next.hosts.SshKeysRoute
 import com.pocketshell.next.nav.Destination
@@ -150,6 +149,7 @@ fun AppNavHost(
             onEditHost = actions.onEditHost,
             onScanQr = actions.onScanQr,
             onOpenSettings = actions.onOpenSettings,
+            updateCheckViewModel = hiltViewModel(),
         )
     },
     connectViewModel: @Composable () -> ConnectViewModel = { hiltViewModel() },
@@ -207,6 +207,7 @@ fun AppNavHost(
             onBack = onBack,
             onOpenWorkspaceRoots = onOpenWorkspaceRoots,
             onOpenCrashReports = onOpenCrashReports,
+            updateCheckViewModel = hiltViewModel(),
         )
     },
     workspaceRootsScreen: @Composable (hostId: Long, onBack: () -> Unit) -> Unit =

--- a/app2/src/main/java/com/pocketshell/next/di/AppModule.kt
+++ b/app2/src/main/java/com/pocketshell/next/di/AppModule.kt
@@ -25,6 +25,7 @@ import com.pocketshell.next.hostcli.HostCliClientFactory
 import com.pocketshell.next.hostcli.asRemoteExec
 import com.pocketshell.next.hosts.HostImporter
 import com.pocketshell.next.hosts.SshKeyStore
+import com.pocketshell.next.release.ReleaseChecker
 import com.pocketshell.next.settings.SettingsRepository
 import com.pocketshell.next.terminal.AndroidGraceServiceControl
 import com.pocketshell.next.terminal.ForegroundSignal
@@ -322,4 +323,14 @@ object AppModule {
     @Singleton
     fun provideDiagnosticRecorder(@ApplicationContext context: Context): DiagnosticRecorder =
         DiagnosticRecorder(context)
+
+    // -------------------------------------------------------------------------
+    // GitHub Releases update check (issue #2531). Provided rather than
+    // `@Inject`-constructor-annotated because [ReleaseChecker] takes defaulted
+    // test seams (URL, backoff, HTTP client, zone) that Hilt would try to
+    // bind as missing types.
+
+    @Provides
+    @Singleton
+    fun provideReleaseChecker(): ReleaseChecker = ReleaseChecker()
 }

--- a/app2/src/main/java/com/pocketshell/next/hosts/HostListScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/hosts/HostListScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -13,9 +15,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.pocketshell.next.release.UpdateCheckViewModel
+import com.pocketshell.next.release.launchUpdateUrl
+import com.pocketshell.next.release.updateAvailableBannerText
+import com.pocketshell.uikit.components.Banner
+import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ConfirmDialog
 import com.pocketshell.uikit.components.EmptyState
@@ -26,6 +35,8 @@ import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.theme.PocketShellSpacing
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Stable test tags. The list container plus one tag per row, keyed by host id,
@@ -35,6 +46,12 @@ const val HOST_LIST_TAG: String = "host-list"
 const val HOST_LIST_ADD_TAG: String = "host-list-add"
 const val HOST_LIST_SCAN_TAG: String = "host-list-scan"
 const val HOST_LIST_SETTINGS_TAG: String = "host-list-settings"
+const val HOST_LIST_UPDATE_BANNER_TAG: String = "host-list-update-banner"
+const val HOST_LIST_UPDATE_DOWNLOAD_TAG: String = "host-list-update-download"
+const val HOST_LIST_UPDATE_NOTES_TAG: String = "host-list-update-notes"
+const val HOST_LIST_UPDATE_DISMISS_TAG: String = "host-list-update-dismiss"
+const val HOST_LIST_UPDATE_RETRY_TAG: String = "host-list-update-retry"
+const val HOST_LIST_UPDATE_FAILURE_TAG: String = "host-list-update-failure"
 
 fun hostRowTag(hostId: Long): String = "host-row-$hostId"
 
@@ -57,8 +74,26 @@ fun HostListRoute(
     onOpenSettings: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: HostListViewModel = hiltViewModel(),
+    updateCheckViewModel: UpdateCheckViewModel? = null,
 ) {
     val state by viewModel.state.collectAsState()
+    val available by collectOrNull(updateCheckViewModel?.available)
+    val failed by collectOrNull(updateCheckViewModel?.failed)
+    val context = LocalContext.current
+    val info = available
+    val failure = failed
+    val notice = when {
+        info != null -> HostListUpdateNotice.Available(
+            text = updateAvailableBannerText(
+                info,
+                updateCheckViewModel?.installedVersionLabel() ?: "",
+            ),
+            apkUrl = info.apkUrl,
+            htmlUrl = info.htmlUrl,
+        )
+        failure != null -> HostListUpdateNotice.Failed(failure)
+        else -> null
+    }
     HostListScreen(
         state = state,
         onOpenHost = onOpenHost,
@@ -68,7 +103,29 @@ fun HostListRoute(
         onOpenSettings = onOpenSettings,
         onDeleteHost = viewModel::delete,
         modifier = modifier,
+        updateNotice = notice,
+        onDownloadUpdate = { url -> launchUpdateUrl(context, url) },
+        onOpenReleaseNotes = { url -> launchUpdateUrl(context, url) },
+        onDismissUpdate = { updateCheckViewModel?.dismissUpdate() },
+        onRetryUpdateCheck = { updateCheckViewModel?.refreshNow() },
+        onDismissUpdateFailure = { updateCheckViewModel?.dismissFailure() },
     )
+}
+
+@Composable
+private fun <T> collectOrNull(flow: StateFlow<T?>?): androidx.compose.runtime.State<T?> {
+    val fallback = remember { MutableStateFlow(null as T?) }
+    return (flow ?: fallback).collectAsState()
+}
+
+/** In-app update surface on the host list (issue #2531). */
+sealed interface HostListUpdateNotice {
+    data class Available(
+        val text: String,
+        val apkUrl: String,
+        val htmlUrl: String,
+    ) : HostListUpdateNotice
+    data class Failed(val reason: String) : HostListUpdateNotice
 }
 
 /**
@@ -99,6 +156,12 @@ fun HostListScreen(
     onOpenSettings: () -> Unit,
     onDeleteHost: (Long) -> Unit,
     modifier: Modifier = Modifier,
+    updateNotice: HostListUpdateNotice? = null,
+    onDownloadUpdate: (apkUrl: String) -> Unit = {},
+    onOpenReleaseNotes: (htmlUrl: String) -> Unit = {},
+    onDismissUpdate: () -> Unit = {},
+    onRetryUpdateCheck: () -> Unit = {},
+    onDismissUpdateFailure: () -> Unit = {},
 ) {
     var pendingDelete by remember { mutableStateOf<HostRow?>(null) }
 
@@ -137,6 +200,21 @@ fun HostListScreen(
                 }
             },
         )
+
+        when (val notice = updateNotice) {
+            is HostListUpdateNotice.Available -> UpdateAvailableBanner(
+                notice = notice,
+                onDownload = { onDownloadUpdate(notice.apkUrl) },
+                onNotes = { onOpenReleaseNotes(notice.htmlUrl) },
+                onDismiss = onDismissUpdate,
+            )
+            is HostListUpdateNotice.Failed -> UpdateCheckFailedBanner(
+                reason = notice.reason,
+                onRetry = onRetryUpdateCheck,
+                onDismiss = onDismissUpdateFailure,
+            )
+            null -> Unit
+        }
 
         when {
             // Nothing painted until Room's first emission: showing the empty
@@ -202,5 +280,93 @@ fun HostListScreen(
             },
             onDismiss = { pendingDelete = null },
         )
+    }
+}
+
+@Composable
+private fun UpdateAvailableBanner(
+    notice: HostListUpdateNotice.Available,
+    onDownload: () -> Unit,
+    onNotes: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = PocketShellSpacing.md, vertical = PocketShellSpacing.sm)
+            .testTag(HOST_LIST_UPDATE_BANNER_TAG),
+    ) {
+        Banner(
+            text = notice.text,
+            role = BannerRole.Info,
+            maxLines = 3,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            PocketShellButton(
+                text = "Download",
+                onClick = onDownload,
+                variant = ButtonVariant.Text,
+                compact = true,
+                modifier = Modifier.testTag(HOST_LIST_UPDATE_DOWNLOAD_TAG),
+            )
+            PocketShellButton(
+                text = "Notes",
+                onClick = onNotes,
+                variant = ButtonVariant.Text,
+                compact = true,
+                modifier = Modifier.testTag(HOST_LIST_UPDATE_NOTES_TAG),
+            )
+            PocketShellButton(
+                text = "Dismiss",
+                onClick = onDismiss,
+                variant = ButtonVariant.Text,
+                compact = true,
+                modifier = Modifier.testTag(HOST_LIST_UPDATE_DISMISS_TAG),
+            )
+        }
+    }
+}
+
+@Composable
+private fun UpdateCheckFailedBanner(
+    reason: String,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = PocketShellSpacing.md, vertical = PocketShellSpacing.sm)
+            .testTag(HOST_LIST_UPDATE_FAILURE_TAG),
+    ) {
+        Banner(
+            text = "Couldn't check for updates ($reason)",
+            role = BannerRole.Error,
+            maxLines = 3,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            PocketShellButton(
+                text = "Retry",
+                onClick = onRetry,
+                variant = ButtonVariant.Text,
+                compact = true,
+                modifier = Modifier.testTag(HOST_LIST_UPDATE_RETRY_TAG),
+            )
+            PocketShellButton(
+                text = "Dismiss",
+                onClick = onDismiss,
+                variant = ButtonVariant.Text,
+                compact = true,
+                modifier = Modifier.testTag(HOST_LIST_UPDATE_DISMISS_TAG),
+            )
+        }
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/release/ReleaseChecker.kt
+++ b/app2/src/main/java/com/pocketshell/next/release/ReleaseChecker.kt
@@ -1,0 +1,305 @@
+package com.pocketshell.next.release
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import org.json.JSONException
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.net.URL
+import java.net.UnknownHostException
+import java.security.GeneralSecurityException
+import java.time.DateTimeException
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import javax.net.ssl.SSLException
+
+/**
+ * Metadata about a GitHub Release PocketShell can offer as a download.
+ *
+ * [publishedDateLabel] is a local calendar date only (`d MMM yyyy`) — never a
+ * clock time. Empty when GitHub omitted `published_at` or it could not be
+ * parsed; the rest of the offer still stands.
+ */
+data class ReleaseInfo(
+    val tagName: String,
+    val htmlUrl: String,
+    val apkUrl: String,
+    val publishedDateLabel: String = "",
+)
+
+/**
+ * Outcome of one GitHub-Releases poll (issue #515).
+ *
+ * "No newer release" and "the check itself failed" must never collapse into
+ * the same silence: a rate-limit or network blip is not "up to date".
+ */
+sealed interface ReleaseCheckResult {
+    data class UpdateAvailable(val info: ReleaseInfo) : ReleaseCheckResult
+    data object UpToDate : ReleaseCheckResult
+    data class Failed(val reason: String) : ReleaseCheckResult
+
+    fun infoOrNull(): ReleaseInfo? = (this as? UpdateAvailable)?.info
+}
+
+/** One GET against the latest-release URL. Throws on transport/TLS failure. */
+fun interface ReleaseHttpClient {
+    fun get(url: String): ReleaseHttpResponse
+}
+
+data class ReleaseHttpResponse(val code: Int, val body: String)
+
+/**
+ * Hits the GitHub Releases API and classifies the outcome against the
+ * installed [android.content.pm.PackageInfo.versionName].
+ *
+ * `HttpURLConnection` + `org.json` — no OkHttp for this one-shot call. The
+ * [http] client is injectable so JVM tests never touch live GitHub.
+ *
+ * One auto-retry on a transient TLS/network blip; a GitHub 403 (rate-limit)
+ * is a returned [ReleaseCheckResult.Failed] and is NOT retried (#1456).
+ */
+open class ReleaseChecker(
+    private val latestReleaseUrl: String = API_URL,
+    private val retryBackoffMs: Long = RETRY_BACKOFF_MS,
+    private val http: ReleaseHttpClient = HttpUrlConnectionReleaseClient(),
+    private val zoneId: ZoneId = ZoneId.systemDefault(),
+) {
+    companion object {
+        private const val REPO = "alexeygrigorev/pocketshell"
+        internal const val API_URL = "https://api.github.com/repos/$REPO/releases/latest"
+        private const val USER_AGENT = "pocketshell"
+        private const val TIMEOUT_MS = 10_000
+        private const val RETRY_BACKOFF_MS = 400L
+        private const val TAG = "PsReleaseCheck"
+    }
+
+    open suspend fun checkForUpdate(currentVersion: String): ReleaseCheckResult =
+        withContext(Dispatchers.IO) {
+            try {
+                fetchRelease(currentVersion)
+            } catch (e: Exception) {
+                val failure = classifyFailure(e)
+                Log.w(
+                    TAG,
+                    "release check failed: ${e.javaClass.simpleName}: ${e.message ?: "no message"} " +
+                        "-> \"${failure.message}\" (transient=${failure.transient}, current=$currentVersion)",
+                    e,
+                )
+                if (failure.transient) {
+                    delay(retryBackoffMs)
+                    try {
+                        fetchRelease(currentVersion)
+                    } catch (retry: Exception) {
+                        val retryFailure = classifyFailure(retry)
+                        Log.w(
+                            TAG,
+                            "release check retry failed: ${retry.javaClass.simpleName}: " +
+                                "${retry.message ?: "no message"} -> \"${retryFailure.message}\" " +
+                                "(current=$currentVersion)",
+                            retry,
+                        )
+                        ReleaseCheckResult.Failed(retryFailure.message)
+                    }
+                } else {
+                    ReleaseCheckResult.Failed(failure.message)
+                }
+            }
+        }
+
+    internal fun fetchRelease(currentVersion: String): ReleaseCheckResult {
+        val response = http.get(latestReleaseUrl)
+        if (response.code != 200) {
+            val userReason = if (response.code == HttpURLConnection.HTTP_FORBIDDEN) {
+                "rate-limited, try again later"
+            } else {
+                "server error (HTTP ${response.code})"
+            }
+            Log.w(TAG, "release check failed: GitHub returned HTTP ${response.code} (current=$currentVersion)")
+            return ReleaseCheckResult.Failed(userReason)
+        }
+        return when (val outcome = parseReleaseOutcome(response.body, currentVersion)) {
+            is ParsedReleaseOutcome.UpdateAvailable ->
+                ReleaseCheckResult.UpdateAvailable(outcome.info)
+            ParsedReleaseOutcome.UpToDate ->
+                ReleaseCheckResult.UpToDate
+            is ParsedReleaseOutcome.Failed -> {
+                Log.w(TAG, "release check failed: ${outcome.reason} (current=$currentVersion)")
+                ReleaseCheckResult.Failed(outcome.reason)
+            }
+        }
+    }
+
+    internal fun classifyFailure(e: Throwable): FailureClassification {
+        var cause: Throwable? = e
+        val seen = HashSet<Throwable>()
+        while (cause != null && seen.add(cause)) {
+            when (cause) {
+                is SocketTimeoutException ->
+                    return FailureClassification("timed out", transient = true)
+                is UnknownHostException ->
+                    return FailureClassification("no network connection", transient = false)
+                is SSLException, is GeneralSecurityException ->
+                    return FailureClassification("connection problem", transient = true)
+                is SocketException ->
+                    return FailureClassification("connection problem", transient = true)
+            }
+            val message = cause.message ?: ""
+            if (message.contains("DefaultSSLContextImpl") || message.contains("NoSuchAlgorithmException")) {
+                return FailureClassification("connection problem", transient = true)
+            }
+            cause = cause.cause
+        }
+        return FailureClassification("connection problem", transient = false)
+    }
+
+    internal data class FailureClassification(
+        val message: String,
+        val transient: Boolean,
+    )
+
+    internal fun isNewer(current: String, remote: String): Boolean {
+        val currentVersion = ParsedVersion.from(current) ?: return false
+        val remoteVersion = ParsedVersion.from(remote) ?: return false
+        return remoteVersion.compareTo(currentVersion) > 0
+    }
+
+    internal fun renderDottedVersionLabel(versionName: String): String {
+        val parsed = ParsedVersion.from(versionName)
+        return "v${parsed?.toDottedString() ?: versionName.trim().removePrefix("v")}"
+    }
+
+    private fun parseReleaseOutcome(body: String, currentVersion: String): ParsedReleaseOutcome {
+        val json = try {
+            JSONObject(body)
+        } catch (_: JSONException) {
+            return ParsedReleaseOutcome.Failed("unparseable release body")
+        }
+        val tagName = json.optString("tag_name").takeIf { it.isNotBlank() }
+            ?: return ParsedReleaseOutcome.Failed("Latest release has no tag_name")
+        ParsedVersion.from(tagName)
+            ?: return ParsedReleaseOutcome.Failed("Latest release tag is not parseable: $tagName")
+
+        if (!isNewer(currentVersion, tagName)) return ParsedReleaseOutcome.UpToDate
+
+        val htmlUrl = json.optString("html_url").takeIf { it.isNotBlank() }
+            ?: return ParsedReleaseOutcome.Failed("Release $tagName has no html_url")
+        val assets = json.optJSONArray("assets")
+            ?: return ParsedReleaseOutcome.Failed("Release $tagName has no downloadable APK assets")
+        val apkUrl = pickApkUrl(assets)
+            ?: return ParsedReleaseOutcome.Failed("Release $tagName has no downloadable APK assets")
+        val publishedDateLabel = formatPublishedDate(json.optString("published_at"), zoneId)
+        return ParsedReleaseOutcome.UpdateAvailable(
+            ReleaseInfo(
+                tagName = tagName,
+                htmlUrl = htmlUrl,
+                apkUrl = apkUrl,
+                publishedDateLabel = publishedDateLabel,
+            ),
+        )
+    }
+
+    /**
+     * Prefer the historical `pocketshell-<ver>-debug.apk` name when it is
+     * present, otherwise the first `.apk` asset. Release asset names have
+     * drifted; a tagged release with *any* APK is still an offer.
+     */
+    private fun pickApkUrl(assets: org.json.JSONArray): String? {
+        var firstApk: String? = null
+        for (i in 0 until assets.length()) {
+            val asset = assets.optJSONObject(i) ?: continue
+            val name = asset.optString("name")
+            val url = asset.optString("browser_download_url")
+            if (!name.endsWith(".apk", ignoreCase = true) || url.isBlank()) continue
+            if (name.contains("pocketshell", ignoreCase = true) && name.contains("-debug.apk")) {
+                return url
+            }
+            if (firstApk == null) firstApk = url
+        }
+        return firstApk
+    }
+
+    private data class ParsedVersion(
+        val major: Int,
+        val minor: Int,
+        val patch: Int,
+    ) : Comparable<ParsedVersion> {
+        override fun compareTo(other: ParsedVersion): Int =
+            compareValuesBy(this, other, ParsedVersion::major, ParsedVersion::minor, ParsedVersion::patch)
+
+        fun toDottedString(): String = "$major.$minor.$patch"
+
+        companion object {
+            private val VERSION_PATTERN = Regex("""^[vV]?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[-+].*)?$""")
+
+            fun from(raw: String): ParsedVersion? {
+                val match = VERSION_PATTERN.matchEntire(raw.trim()) ?: return null
+                return ParsedVersion(
+                    major = match.groupValues[1].toIntOrNull() ?: return null,
+                    minor = match.groupValues[2].takeIf { it.isNotEmpty() }?.toIntOrNull() ?: 0,
+                    patch = match.groupValues[3].takeIf { it.isNotEmpty() }?.toIntOrNull() ?: 0,
+                )
+            }
+        }
+    }
+
+    private sealed interface ParsedReleaseOutcome {
+        data class UpdateAvailable(val info: ReleaseInfo) : ParsedReleaseOutcome
+        data object UpToDate : ParsedReleaseOutcome
+        data class Failed(val reason: String) : ParsedReleaseOutcome
+    }
+
+    /**
+     * Production GET: always `disconnect()`, drain the error stream on a
+     * non-200 so a GitHub 403 does not leak the keep-alive socket.
+     */
+    private class HttpUrlConnectionReleaseClient : ReleaseHttpClient {
+        override fun get(url: String): ReleaseHttpResponse {
+            val conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                connectTimeout = TIMEOUT_MS
+                readTimeout = TIMEOUT_MS
+                setRequestProperty("Accept", "application/vnd.github+json")
+                setRequestProperty("User-Agent", USER_AGENT)
+            }
+            return try {
+                val code = conn.responseCode
+                val stream = if (code == 200) conn.inputStream else conn.errorStream
+                val body = stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+                ReleaseHttpResponse(code, body)
+            } finally {
+                conn.disconnect()
+            }
+        }
+    }
+}
+
+private val PUBLISHED_DATE: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("d MMM yyyy", Locale.US)
+
+/**
+ * GitHub `published_at` → local calendar date. Never includes a clock time
+ * (`HH:mm` / a `:`). Unparseable or blank input yields an empty string.
+ */
+internal fun formatPublishedDate(publishedAt: String, zoneId: ZoneId): String {
+    val raw = publishedAt.trim()
+    if (raw.isEmpty()) return ""
+    val instant = try {
+        Instant.parse(raw)
+    } catch (_: DateTimeException) {
+        return raw.takeWhile { it != 'T' }
+            .takeIf { it.matches(Regex("""\d{4}-\d{2}-\d{2}""")) }
+            .orEmpty()
+    }
+    return instant.atZone(zoneId).toLocalDate().format(PUBLISHED_DATE)
+}
+
+/** Host-list banner copy: `v0.5.1 is available — you are on v0.5.0 · 5 Sep 2026`. */
+internal fun updateAvailableBannerText(info: ReleaseInfo, currentVersionLabel: String): String {
+    val head = "${info.tagName} is available — you are on $currentVersionLabel"
+    return if (info.publishedDateLabel.isBlank()) head else "$head · ${info.publishedDateLabel}"
+}

--- a/app2/src/main/java/com/pocketshell/next/release/UpdateCheckScheduler.kt
+++ b/app2/src/main/java/com/pocketshell/next/release/UpdateCheckScheduler.kt
@@ -1,0 +1,195 @@
+package com.pocketshell.next.release
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * Foreground-only GitHub-Releases poll (D21 / issue #698).
+ *
+ * Hooks [ProcessLifecycleOwner] `ON_START` and fires a throttled check so a
+ * user who never opens the host list still hears about a newer APK. Settings
+ * "Check for updates" calls [refreshNow] and bypasses the throttle.
+ *
+ * No WorkManager, no AlarmManager, no repeating timer. Each trigger launches
+ * one HTTP round-trip and completes.
+ */
+@Singleton
+class UpdateCheckScheduler @Inject constructor(
+    @ApplicationContext private val applicationContext: Context,
+    private val releaseChecker: ReleaseChecker,
+    private val store: UpdateCheckStore,
+) {
+
+    internal var throttleWindowMillis: Long = DEFAULT_THROTTLE_WINDOW_MILLIS
+    internal var nowMillis: () -> Long = { System.currentTimeMillis() }
+    internal var currentVersionProvider: () -> String? = ::readInstalledVersionName
+    internal var scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val mutex = Mutex()
+
+    private val _updateAvailable = MutableStateFlow<ReleaseInfo?>(null)
+    val updateAvailable: StateFlow<ReleaseInfo?> = _updateAvailable.asStateFlow()
+
+    private val _updateCheckFailed = MutableStateFlow<String?>(null)
+    val updateCheckFailed: StateFlow<String?> = _updateCheckFailed.asStateFlow()
+
+    private val _lastResult = MutableStateFlow<ReleaseCheckResult?>(null)
+    val lastResult: StateFlow<ReleaseCheckResult?> = _lastResult.asStateFlow()
+
+    private val _checking = MutableStateFlow(false)
+    val checking: StateFlow<Boolean> = _checking.asStateFlow()
+
+    fun dismissUpdateCheckFailure() {
+        _updateCheckFailed.value = null
+        if (_lastResult.value is ReleaseCheckResult.Failed) {
+            _lastResult.value = null
+        }
+    }
+
+    /** Hide the host-list banner for this tag until a newer tag appears. */
+    fun dismissCurrentUpdate() {
+        val tag = _updateAvailable.value?.tagName ?: return
+        store.markDismissed(tag)
+        _updateAvailable.value = null
+    }
+
+    fun installedVersionLabel(): String {
+        val raw = currentVersionProvider() ?: return "unknown"
+        return releaseChecker.renderDottedVersionLabel(raw)
+    }
+
+    private val _checkCount = AtomicLong(0L)
+    val checkCount: Long
+        get() = _checkCount.get()
+
+    private val processLifecycleObserver = LifecycleEventObserver { _: LifecycleOwner, event ->
+        if (event == Lifecycle.Event.ON_START) {
+            requestCheck(TRIGGER_FOREGROUND)
+        }
+    }
+
+    private var lifecycleAttached: Boolean = false
+    private val _lifecycleObserverAttached = AtomicBoolean(false)
+    internal val lifecycleObserverAttached: Boolean
+        get() = _lifecycleObserverAttached.get()
+
+    /**
+     * Attach [ProcessLifecycleOwner] (or any [LifecycleOwner]) so a throttled
+     * check fires on every `ON_START`. Subsequent calls are no-ops. Seeds an
+     * immediate check when the owner is already `STARTED` (cold launch).
+     */
+    fun observeProcessLifecycle(owner: LifecycleOwner = ProcessLifecycleOwner.get()) {
+        synchronized(this) {
+            if (lifecycleAttached) return
+            lifecycleAttached = true
+        }
+        scope.launch {
+            val alreadyStarted = withContext(Dispatchers.Main) {
+                owner.lifecycle.addObserver(processLifecycleObserver)
+                _lifecycleObserverAttached.set(true)
+                owner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+            }
+            if (alreadyStarted) requestCheck(TRIGGER_FOREGROUND)
+        }
+    }
+
+    internal fun stopObservingProcessLifecycleForTest(owner: LifecycleOwner) {
+        owner.lifecycle.removeObserver(processLifecycleObserver)
+        _lifecycleObserverAttached.set(false)
+        synchronized(this) {
+            lifecycleAttached = false
+        }
+    }
+
+    /** Settings "Check for updates": run immediately, ignore the throttle. */
+    fun refreshNow() {
+        scope.launch { runCheck(TRIGGER_MANUAL, force = true) }
+    }
+
+    private fun requestCheck(trigger: String) {
+        scope.launch { runCheck(trigger, force = false) }
+    }
+
+    private suspend fun runCheck(trigger: String, force: Boolean) {
+        mutex.withLock {
+            val now = nowMillis()
+            val priorCheckedAt = store.lastCheckedAtMillis()
+            if (!force) {
+                if (priorCheckedAt != 0L && now - priorCheckedAt < throttleWindowMillis) {
+                    return
+                }
+            }
+            val currentVersion = currentVersionProvider()
+            if (currentVersion == null) return
+            _checkCount.incrementAndGet()
+            store.markCheckedAt(now)
+            _checking.value = true
+            try {
+                when (val result = releaseChecker.checkForUpdate(currentVersion)) {
+                    is ReleaseCheckResult.UpdateAvailable -> {
+                        _lastResult.value = result
+                        _updateCheckFailed.value = null
+                        _updateAvailable.value =
+                            if (store.dismissedTag() == result.info.tagName) null else result.info
+                    }
+
+                    ReleaseCheckResult.UpToDate -> {
+                        _lastResult.value = result
+                        _updateAvailable.value = null
+                        _updateCheckFailed.value = null
+                    }
+
+                    is ReleaseCheckResult.Failed -> {
+                        // Keep any previously-found update visible. Do not burn
+                        // the throttle window, so the next resume retries.
+                        _lastResult.value = result
+                        _updateCheckFailed.value = result.reason
+                        store.markCheckedAt(priorCheckedAt)
+                        Log.w(TAG, "update check failed (trigger=$trigger): ${result.reason}")
+                    }
+                }
+            } finally {
+                _checking.value = false
+            }
+        }
+    }
+
+    private fun readInstalledVersionName(): String? = try {
+        applicationContext.packageManager
+            .getPackageInfo(applicationContext.packageName, 0)
+            .versionName
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+    } catch (_: PackageManager.NameNotFoundException) {
+        null
+    } catch (_: Exception) {
+        null
+    }
+
+    companion object {
+        const val DEFAULT_THROTTLE_WINDOW_MILLIS: Long = 6L * 60L * 60L * 1000L
+        private const val TRIGGER_FOREGROUND = "foreground_resume"
+        private const val TRIGGER_MANUAL = "manual"
+        private const val TAG = "PsUpdateCheckSched"
+    }
+}

--- a/app2/src/main/java/com/pocketshell/next/release/UpdateCheckStore.kt
+++ b/app2/src/main/java/com/pocketshell/next/release/UpdateCheckStore.kt
@@ -1,0 +1,46 @@
+package com.pocketshell.next.release
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Tiny ledger for the foreground update check: last-poll time (6h throttle)
+ * and the release tag the user dismissed, so that tag is not re-nagged.
+ *
+ * SharedPreferences, like the rest of app2's small stores. Bookkeeping, not a
+ * user-facing preference. `by lazy` keeps the first-touch disk read off
+ * [com.pocketshell.next.App.onCreate] Hilt injection.
+ */
+@Singleton
+class UpdateCheckStore @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val appContext: Context = context.applicationContext
+
+    private val prefs: SharedPreferences by lazy {
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    fun lastCheckedAtMillis(): Long =
+        runCatching { prefs.getLong(KEY_LAST_CHECKED_AT, 0L) }.getOrDefault(0L)
+
+    fun markCheckedAt(nowMillis: Long) {
+        prefs.edit().putLong(KEY_LAST_CHECKED_AT, nowMillis).apply()
+    }
+
+    fun dismissedTag(): String? =
+        runCatching { prefs.getString(KEY_DISMISSED_TAG, null) }.getOrNull()
+
+    fun markDismissed(tagName: String) {
+        prefs.edit().putString(KEY_DISMISSED_TAG, tagName).apply()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "update_check"
+        const val KEY_LAST_CHECKED_AT = "last_checked_at_millis"
+        const val KEY_DISMISSED_TAG = "dismissed_tag"
+    }
+}

--- a/app2/src/main/java/com/pocketshell/next/release/UpdateCheckViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/release/UpdateCheckViewModel.kt
@@ -1,0 +1,30 @@
+package com.pocketshell.next.release
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Thin screen wrapper over the process-wide [UpdateCheckScheduler]. Host list
+ * and Settings share the same singleton so a poll from either surface is the
+ * result both see.
+ */
+@HiltViewModel
+class UpdateCheckViewModel @Inject constructor(
+    private val scheduler: UpdateCheckScheduler,
+) : ViewModel() {
+
+    val available: StateFlow<ReleaseInfo?> = scheduler.updateAvailable
+    val failed: StateFlow<String?> = scheduler.updateCheckFailed
+    val lastResult: StateFlow<ReleaseCheckResult?> = scheduler.lastResult
+    val checking: StateFlow<Boolean> = scheduler.checking
+
+    fun refreshNow() = scheduler.refreshNow()
+
+    fun dismissUpdate() = scheduler.dismissCurrentUpdate()
+
+    fun dismissFailure() = scheduler.dismissUpdateCheckFailure()
+
+    fun installedVersionLabel(): String = scheduler.installedVersionLabel()
+}

--- a/app2/src/main/java/com/pocketshell/next/release/UpdateDownloadLauncher.kt
+++ b/app2/src/main/java/com/pocketshell/next/release/UpdateDownloadLauncher.kt
@@ -1,0 +1,25 @@
+package com.pocketshell.next.release
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+
+/**
+ * Opens [url] with `ACTION_VIEW` so the system browser / download manager
+ * handles the sideload. No in-app install, no `REQUEST_INSTALL_PACKAGES`.
+ *
+ * [Intent.FLAG_ACTIVITY_NEW_TASK] so this works from an Activity or a
+ * non-Activity context (issue #515).
+ */
+internal fun launchUpdateUrl(context: Context, url: String) {
+    try {
+        context.startActivity(viewIntent(url))
+    } catch (_: ActivityNotFoundException) {
+    } catch (_: SecurityException) {
+    } catch (_: RuntimeException) {
+    }
+}
+
+internal fun viewIntent(url: String): Intent =
+    Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app2/src/main/java/com/pocketshell/next/settings/SettingsScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/SettingsScreen.kt
@@ -3,6 +3,7 @@ package com.pocketshell.next.settings
 import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,9 +30,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.pocketshell.next.release.ReleaseCheckResult
+import com.pocketshell.next.release.ReleaseInfo
+import com.pocketshell.next.release.UpdateCheckViewModel
+import com.pocketshell.next.release.launchUpdateUrl
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.NavigationChevron
@@ -56,6 +62,9 @@ const val SETTINGS_AGENT_SUBMIT_DELAY_VALUE_TAG: String = "settings-agent-submit
 const val SETTINGS_WORKSPACE_EMPTY_TAG: String = "settings-workspace-empty"
 const val SETTINGS_CRASH_REPORTS_TAG: String = "settings-crash-reports"
 const val SETTINGS_VERSION_TAG: String = "settings-version"
+const val SETTINGS_UPDATE_CHECK_TAG: String = "settings-update-check"
+const val SETTINGS_UPDATE_CHECK_LABEL_TAG: String = "settings-update-check-label"
+const val SETTINGS_UPDATE_CHECK_DETAIL_TAG: String = "settings-update-check-detail"
 
 fun backgroundGraceOptionTag(millis: Long): String = "settings-grace-$millis"
 
@@ -82,11 +91,15 @@ fun SettingsRoute(
     onOpenCrashReports: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel(),
+    updateCheckViewModel: UpdateCheckViewModel? = null,
 ) {
     val settings by viewModel.state.collectAsState()
     val hosts by viewModel.hosts.collectAsState()
     val context = LocalContext.current
     val buildInfo = remember(context) { readBuildInfo(context) }
+    val checking by (updateCheckViewModel?.checking ?: rememberIdleFalse()).collectAsState()
+    val lastResult by (updateCheckViewModel?.lastResult ?: rememberIdleResult()).collectAsState()
+    val updateCheckState = settingsUpdateCheckState(checking, lastResult)
 
     SettingsScreen(
         settings = settings,
@@ -101,7 +114,38 @@ fun SettingsRoute(
         onOpenWorkspaceRoots = onOpenWorkspaceRoots,
         onOpenCrashReports = onOpenCrashReports,
         modifier = modifier,
+        updateCheckState = updateCheckState,
+        onCheckForUpdates = { updateCheckViewModel?.refreshNow() },
+        onDownloadUpdate = { info -> launchUpdateUrl(context, info.apkUrl) },
     )
+}
+
+@Composable
+private fun rememberIdleFalse(): kotlinx.coroutines.flow.StateFlow<Boolean> =
+    remember { kotlinx.coroutines.flow.MutableStateFlow(false) }
+
+@Composable
+private fun rememberIdleResult(): kotlinx.coroutines.flow.StateFlow<ReleaseCheckResult?> =
+    remember { kotlinx.coroutines.flow.MutableStateFlow(null) }
+
+internal fun settingsUpdateCheckState(
+    checking: Boolean,
+    lastResult: ReleaseCheckResult?,
+): SettingsUpdateCheckState = when {
+    checking -> SettingsUpdateCheckState.Checking
+    lastResult is ReleaseCheckResult.UpdateAvailable ->
+        SettingsUpdateCheckState.UpdateAvailable(lastResult.info)
+    lastResult is ReleaseCheckResult.UpToDate -> SettingsUpdateCheckState.UpToDate
+    lastResult is ReleaseCheckResult.Failed -> SettingsUpdateCheckState.Failed(lastResult.reason)
+    else -> SettingsUpdateCheckState.Idle
+}
+
+sealed interface SettingsUpdateCheckState {
+    data object Idle : SettingsUpdateCheckState
+    data object Checking : SettingsUpdateCheckState
+    data object UpToDate : SettingsUpdateCheckState
+    data class UpdateAvailable(val info: ReleaseInfo) : SettingsUpdateCheckState
+    data class Failed(val reason: String) : SettingsUpdateCheckState
 }
 
 /**
@@ -121,7 +165,8 @@ fun SettingsRoute(
  *  5. **Diagnostics** — the local crash-report browser (issue #2476). It sits
  *     next to About because both answer "what build am I on and what went
  *     wrong with it", which is the question a user has when reporting a bug.
- *  6. **About** — the installed build, as a footer.
+ *  6. **About** — the installed build, plus **Check for updates** (issue
+ *     #2531): Up to date / Available+date / Failed+Retry.
  *
  * Stateless: every value comes in, every change goes out. See [AppSettings] for
  * the table of ported-away fields, and [SettingsRepository] for which of the
@@ -141,6 +186,9 @@ fun SettingsScreen(
     onOpenWorkspaceRoots: (Long) -> Unit,
     onOpenCrashReports: () -> Unit,
     modifier: Modifier = Modifier,
+    updateCheckState: SettingsUpdateCheckState = SettingsUpdateCheckState.Idle,
+    onCheckForUpdates: () -> Unit = {},
+    onDownloadUpdate: (ReleaseInfo) -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -292,7 +340,14 @@ fun SettingsScreen(
                 }
             }
 
-            item { AboutFooter(buildInfo) }
+            item {
+                AboutFooter(
+                    buildInfo = buildInfo,
+                    updateCheckState = updateCheckState,
+                    onCheckForUpdates = onCheckForUpdates,
+                    onDownloadUpdate = onDownloadUpdate,
+                )
+            }
         }
     }
 }
@@ -427,15 +482,17 @@ private fun RadioMark(selected: Boolean) {
 }
 
 /**
- * The installed build, at the bottom.
- *
- * A footer, not a section, and deliberately without the old client's
- * check-for-updates row: that row drove the self-distribution update notifier
- * the scope amendment cut, and it is the only part of About that needed the
- * network.
+ * The installed build, at the bottom, plus the Check for updates row
+ * (issue #2531). The row is the Settings-side of the same GitHub poll the
+ * host-list banner uses — tapping it bypasses the 6h throttle.
  */
 @Composable
-private fun AboutFooter(buildInfo: AppBuildInfo) {
+private fun AboutFooter(
+    buildInfo: AppBuildInfo,
+    updateCheckState: SettingsUpdateCheckState,
+    onCheckForUpdates: () -> Unit,
+    onDownloadUpdate: (ReleaseInfo) -> Unit,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -454,6 +511,79 @@ private fun AboutFooter(buildInfo: AppBuildInfo) {
             style = PocketShellType.labelMono,
             modifier = Modifier.testTag(SETTINGS_VERSION_TAG),
         )
+        Spacer(modifier = Modifier.height(PocketShellSpacing.sm))
+        SettingsUpdateCheckRow(
+            state = updateCheckState,
+            onCheckForUpdates = onCheckForUpdates,
+            onDownloadUpdate = onDownloadUpdate,
+        )
+    }
+}
+
+@Composable
+private fun SettingsUpdateCheckRow(
+    state: SettingsUpdateCheckState,
+    onCheckForUpdates: () -> Unit,
+    onDownloadUpdate: (ReleaseInfo) -> Unit,
+) {
+    val (label, detail) = when (state) {
+        SettingsUpdateCheckState.Idle ->
+            "Check for updates" to "Ask GitHub for the latest APK."
+        SettingsUpdateCheckState.Checking ->
+            "Checking..." to "Contacting GitHub releases."
+        SettingsUpdateCheckState.UpToDate ->
+            "Up to date" to "This APK is the latest release."
+        is SettingsUpdateCheckState.UpdateAvailable -> {
+            val date = state.info.publishedDateLabel
+            val detail = if (date.isBlank()) {
+                "New APK available."
+            } else {
+                "Published $date"
+            }
+            "Download ${state.info.tagName}" to detail
+        }
+        is SettingsUpdateCheckState.Failed ->
+            "Retry update check" to "Couldn't check for updates: ${state.reason}"
+    }
+    val enabled = state != SettingsUpdateCheckState.Checking
+    val click = {
+        when (state) {
+            is SettingsUpdateCheckState.UpdateAvailable -> onDownloadUpdate(state.info)
+            SettingsUpdateCheckState.Checking -> Unit
+            else -> onCheckForUpdates()
+        }
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = PocketShellSpacing.md)
+            .then(
+                if (enabled) {
+                    Modifier.clickable(role = Role.Button, onClick = click)
+                } else {
+                    Modifier
+                },
+            )
+            .testTag(SETTINGS_UPDATE_CHECK_TAG)
+            .padding(vertical = PocketShellSpacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.Start) {
+            Text(
+                text = label,
+                color = if (enabled) PocketShellColors.Accent else PocketShellColors.TextSecondary,
+                style = PocketShellType.bodyDense,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.testTag(SETTINGS_UPDATE_CHECK_LABEL_TAG),
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = detail,
+                color = PocketShellColors.TextMuted,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.testTag(SETTINGS_UPDATE_CHECK_DETAIL_TAG),
+            )
+        }
     }
 }
 

--- a/app2/src/test/java/com/pocketshell/next/AppRobolectricSideEffectGuardTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/AppRobolectricSideEffectGuardTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.next
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.robolectric.annotation.Config
@@ -63,5 +64,18 @@ class AppRobolectricSideEffectGuardTest {
         // Restore whatever was installed before this test touched the Application,
         // so a sibling test in the same JVM worker never observes this test's state.
         Thread.setDefaultUncaughtExceptionHandler(previous)
+    }
+
+    @Test
+    fun `App onCreate does not attach the update-check lifecycle observer under Robolectric`() {
+        val app = ApplicationProvider.getApplicationContext<App>()
+
+        assertFalse(
+            "App.onCreate() must not observe ProcessLifecycleOwner under Robolectric — " +
+                "that would fire a GitHub poll from every JVM unit test and leak a " +
+                "process-lifecycle observer across the suite",
+            app.updateCheckScheduler.lifecycleObserverAttached,
+        )
+        assertEquals(0L, app.updateCheckScheduler.checkCount)
     }
 }

--- a/app2/src/test/java/com/pocketshell/next/hosts/HostListUpdateBannerTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/hosts/HostListUpdateBannerTest.kt
@@ -1,0 +1,148 @@
+package com.pocketshell.next.hosts
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Host-list update banner (issue #2531): visible on UpdateAvailable, gone
+ * after dismiss of that tag's notice, and a failure is not painted as
+ * "Up to date".
+ */
+@RunWith(RobolectricTestRunner::class)
+class HostListUpdateBannerTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val available = HostListUpdateNotice.Available(
+        text = "v0.5.1 is available — you are on v0.5.0 · 5 Sep 2026",
+        apkUrl = "https://example.com/pocketshell-0.5.1.apk",
+        htmlUrl = "https://github.com/alexeygrigorev/pocketshell/releases/tag/v0.5.1",
+    )
+
+    @Test
+    fun bannerNamesNewTagCurrentVersionAndDateWithoutTime() {
+        setContent(notice = available)
+
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_BANNER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText(available.text, substring = true).assertIsDisplayed()
+        assertFalse(available.text.contains(":"))
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_DOWNLOAD_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_NOTES_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_DISMISS_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("Up to date").assertDoesNotExist()
+    }
+
+    @Test
+    fun downloadAndNotesFireTheirUrls() {
+        var downloaded: String? = null
+        var notes: String? = null
+        setContent(
+            notice = available,
+            onDownloadUpdate = { downloaded = it },
+            onOpenReleaseNotes = { notes = it },
+        )
+
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_DOWNLOAD_TAG).performClick()
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_NOTES_TAG).performClick()
+
+        assertEquals(available.apkUrl, downloaded)
+        assertEquals(available.htmlUrl, notes)
+    }
+
+    @Test
+    fun dismissHidesTheBanner_andANewerTagShowsAgain() {
+        val notice = mutableStateOf<HostListUpdateNotice?>(available)
+        composeRule.setContent {
+            HostListScreen(
+                state = populatedState(),
+                onOpenHost = {},
+                onAddHost = {},
+                onEditHost = {},
+                onScanQr = {},
+                onOpenSettings = {},
+                onDeleteHost = {},
+                updateNotice = notice.value,
+                onDismissUpdate = { notice.value = null },
+            )
+        }
+
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_BANNER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_DISMISS_TAG).performClick()
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_BANNER_TAG).assertDoesNotExist()
+
+        composeRule.runOnIdle {
+            notice.value = HostListUpdateNotice.Available(
+                text = "v0.5.2 is available — you are on v0.5.0 · 6 Sep 2026",
+                apkUrl = "https://example.com/pocketshell-0.5.2.apk",
+                htmlUrl = "https://github.com/alexeygrigorev/pocketshell/releases/tag/v0.5.2",
+            )
+        }
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_BANNER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("v0.5.2 is available", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun failedBanner_isNotUpToDate_andRetryFires() {
+        var retries = 0
+        setContent(
+            notice = HostListUpdateNotice.Failed("rate-limited, try again later"),
+            onRetryUpdateCheck = { retries += 1 },
+        )
+
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_FAILURE_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("Couldn't check for updates", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText("Up to date").assertDoesNotExist()
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_RETRY_TAG).performClick()
+        assertEquals(1, retries)
+    }
+
+    @Test
+    fun noBannerWhenIdle() {
+        setContent(notice = null)
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_BANNER_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(HOST_LIST_UPDATE_FAILURE_TAG).assertDoesNotExist()
+    }
+
+    private fun setContent(
+        notice: HostListUpdateNotice?,
+        onDownloadUpdate: (String) -> Unit = {},
+        onOpenReleaseNotes: (String) -> Unit = {},
+        onDismissUpdate: () -> Unit = {},
+        onRetryUpdateCheck: () -> Unit = {},
+        onDismissUpdateFailure: () -> Unit = {},
+    ) {
+        composeRule.setContent {
+            HostListScreen(
+                state = populatedState(),
+                onOpenHost = {},
+                onAddHost = {},
+                onEditHost = {},
+                onScanQr = {},
+                onOpenSettings = {},
+                onDeleteHost = {},
+                updateNotice = notice,
+                onDownloadUpdate = onDownloadUpdate,
+                onOpenReleaseNotes = onOpenReleaseNotes,
+                onDismissUpdate = onDismissUpdate,
+                onRetryUpdateCheck = onRetryUpdateCheck,
+                onDismissUpdateFailure = onDismissUpdateFailure,
+            )
+        }
+    }
+
+    private fun populatedState() = HostListUiState(
+        loaded = true,
+        hosts = listOf(HostRow(1, "hetzner", "alexey@135.181.114.209")),
+    )
+}

--- a/app2/src/test/java/com/pocketshell/next/release/ReleaseCheckerTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/release/ReleaseCheckerTest.kt
@@ -1,0 +1,229 @@
+package com.pocketshell.next.release
+
+import java.net.SocketException
+import java.time.ZoneOffset
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * [ReleaseChecker] against an injected fetcher — no live GitHub.
+ *
+ * Pins compare, the three-way result, APK-asset picking (including drifted
+ * filenames), and `published_at` → date-only (no clock time).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ReleaseCheckerTest {
+
+    private val utcChecker = ReleaseChecker(zoneId = ZoneOffset.UTC)
+
+    @Test
+    fun isNewer_returnsTrue_forPatchBump() {
+        assertTrue(utcChecker.isNewer("v0.0.1", "v0.0.2"))
+    }
+
+    @Test
+    fun isNewer_returnsFalse_forEqualVersions() {
+        assertFalse(utcChecker.isNewer("v0.0.1", "v0.0.1"))
+        assertFalse(utcChecker.isNewer("0.5.0", "v0.5.0"))
+    }
+
+    @Test
+    fun isNewer_returnsFalse_forOlderRemote() {
+        assertFalse(utcChecker.isNewer("v0.1.0", "v0.0.9"))
+        assertFalse(utcChecker.isNewer("0.5.1", "v0.5.0"))
+    }
+
+    @Test
+    fun isNewer_toleratesMissingVPrefix_andDebugSuffix() {
+        assertTrue(utcChecker.isNewer("0.5.0-debug", "v0.5.1"))
+        assertTrue(utcChecker.isNewer("0.5.0", "v0.5.1"))
+    }
+
+    @Test
+    fun formatPublishedDate_isCalendarDate_withNoClockTime() {
+        val label = formatPublishedDate("2026-09-05T14:30:00Z", ZoneOffset.UTC)
+        assertEquals("5 Sep 2026", label)
+        assertFalse("date label leaked a clock time: $label", label.contains(":"))
+        assertFalse(
+            "date label looks like HH:mm: $label",
+            Regex("""\d{1,2}:\d{2}""").containsMatchIn(label),
+        )
+    }
+
+    @Test
+    fun formatPublishedDate_emptyOnBlank() {
+        assertEquals("", formatPublishedDate("", ZoneOffset.UTC))
+        assertEquals("", formatPublishedDate("   ", ZoneOffset.UTC))
+    }
+
+    @Test
+    fun newerTagWithApk_isUpdateAvailable_andDateHasNoTime() = runBlocking {
+        val checker = ReleaseChecker(
+            http = { ReleaseHttpResponse(200, releaseJson(tagName = "v0.5.1")) },
+            zoneId = ZoneOffset.UTC,
+        )
+        val result = checker.checkForUpdate("0.5.0")
+        assertTrue(result is ReleaseCheckResult.UpdateAvailable)
+        val info = (result as ReleaseCheckResult.UpdateAvailable).info
+        assertEquals("v0.5.1", info.tagName)
+        assertEquals("https://example.com/pocketshell-0.5.1.apk", info.apkUrl)
+        assertEquals("5 Sep 2026", info.publishedDateLabel)
+        assertFalse(info.publishedDateLabel.contains(":"))
+        assertEquals(
+            "v0.5.1 is available — you are on v0.5.0 · 5 Sep 2026",
+            updateAvailableBannerText(info, "v0.5.0"),
+        )
+    }
+
+    @Test
+    fun sameVersion_isUpToDate_notFailed() = runBlocking {
+        val checker = ReleaseChecker(
+            http = { ReleaseHttpResponse(200, releaseJson(tagName = "v0.5.0")) },
+            zoneId = ZoneOffset.UTC,
+        )
+        val result = checker.checkForUpdate("0.5.0")
+        assertEquals(ReleaseCheckResult.UpToDate, result)
+        assertFalse(result is ReleaseCheckResult.Failed)
+    }
+
+    @Test
+    fun olderTag_isUpToDate() = runBlocking {
+        val checker = ReleaseChecker(
+            http = { ReleaseHttpResponse(200, releaseJson(tagName = "v0.4.0")) },
+            zoneId = ZoneOffset.UTC,
+        )
+        assertEquals(ReleaseCheckResult.UpToDate, checker.checkForUpdate("0.5.0"))
+    }
+
+    @Test
+    fun non200_isFailed_notUpToDate() = runBlocking {
+        val checker = ReleaseChecker(
+            http = { ReleaseHttpResponse(500, """{"message":"oops"}""") },
+        )
+        val result = checker.checkForUpdate("0.5.0")
+        assertTrue(result is ReleaseCheckResult.Failed)
+        assertEquals("server error (HTTP 500)", (result as ReleaseCheckResult.Failed).reason)
+        assertFalse(result is ReleaseCheckResult.UpToDate)
+    }
+
+    @Test
+    fun github403_isFailed_andNotRetried() = runBlocking {
+        val calls = AtomicInteger(0)
+        val checker = ReleaseChecker(
+            retryBackoffMs = 0,
+            http = {
+                calls.incrementAndGet()
+                ReleaseHttpResponse(403, """{"message":"API rate limit exceeded"}""")
+            },
+        )
+        val result = checker.checkForUpdate("0.5.0")
+        assertTrue(result is ReleaseCheckResult.Failed)
+        assertEquals("rate-limited, try again later", (result as ReleaseCheckResult.Failed).reason)
+        assertEquals(1, calls.get())
+    }
+
+    @Test
+    fun missingApk_isFailed() = runBlocking {
+        val checker = ReleaseChecker(
+            http = {
+                ReleaseHttpResponse(
+                    200,
+                    releaseJson(
+                        tagName = "v0.5.1",
+                        assets = """{"name":"notes.txt","browser_download_url":"https://example.com/notes.txt"}""",
+                    ),
+                )
+            },
+        )
+        val result = checker.checkForUpdate("0.5.0")
+        assertTrue(result is ReleaseCheckResult.Failed)
+        assertTrue(
+            (result as ReleaseCheckResult.Failed).reason.contains("no downloadable APK"),
+        )
+    }
+
+    @Test
+    fun driftedApkFilename_isStillAnOffer() = runBlocking {
+        val checker = ReleaseChecker(
+            http = {
+                ReleaseHttpResponse(
+                    200,
+                    releaseJson(
+                        tagName = "v0.5.1",
+                        assets = """{"name":"PocketShell-0.5.1.apk","browser_download_url":"https://example.com/drifted.apk"}""",
+                    ),
+                )
+            },
+            zoneId = ZoneOffset.UTC,
+        )
+        val result = checker.checkForUpdate("0.5.0")
+        assertTrue(result is ReleaseCheckResult.UpdateAvailable)
+        assertEquals(
+            "https://example.com/drifted.apk",
+            (result as ReleaseCheckResult.UpdateAvailable).info.apkUrl,
+        )
+    }
+
+    @Test
+    fun transientFailure_retriesOnce_andSucceeds() = runBlocking {
+        val calls = AtomicInteger(0)
+        val checker = ReleaseChecker(
+            retryBackoffMs = 0,
+            http = {
+                if (calls.getAndIncrement() == 0) throw SocketException("connection reset")
+                ReleaseHttpResponse(200, releaseJson(tagName = "v0.5.0"))
+            },
+        )
+        assertEquals(ReleaseCheckResult.UpToDate, checker.checkForUpdate("0.5.0"))
+        assertEquals(2, calls.get())
+    }
+
+    @Test
+    fun unknownHost_isFailed_notRetried() = runBlocking {
+        val calls = AtomicInteger(0)
+        val checker = ReleaseChecker(
+            retryBackoffMs = 0,
+            http = {
+                calls.incrementAndGet()
+                throw java.net.UnknownHostException("api.github.com")
+            },
+        )
+        val result = checker.checkForUpdate("0.5.0")
+        assertEquals("no network connection", (result as ReleaseCheckResult.Failed).reason)
+        assertEquals(1, calls.get())
+    }
+
+    @Test
+    fun checkHitsTheGithubLatestEndpoint() = runBlocking {
+        var seenUrl: String? = null
+        val checker = ReleaseChecker(
+            http = { url ->
+                seenUrl = url
+                ReleaseHttpResponse(200, releaseJson(tagName = "v0.5.0"))
+            },
+        )
+        checker.checkForUpdate("0.5.0")
+        assertEquals(ReleaseChecker.API_URL, seenUrl)
+    }
+
+    private fun releaseJson(
+        tagName: String,
+        assets: String = """{"name":"pocketshell-0.5.1-debug.apk","browser_download_url":"https://example.com/pocketshell-0.5.1.apk"}""",
+        publishedAt: String = "2026-09-05T14:30:00Z",
+    ): String = """
+        {
+          "tag_name": "$tagName",
+          "html_url": "https://github.com/alexeygrigorev/pocketshell/releases/tag/$tagName",
+          "published_at": "$publishedAt",
+          "assets": [ $assets ]
+        }
+    """.trimIndent()
+}

--- a/app2/src/test/java/com/pocketshell/next/release/UpdateCheckSchedulerTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/release/UpdateCheckSchedulerTest.kt
@@ -1,0 +1,203 @@
+package com.pocketshell.next.release
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class UpdateCheckSchedulerTest {
+
+    private lateinit var context: Context
+    private val dispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+
+    private fun release(tag: String, date: String = "5 Sep 2026") = ReleaseInfo(
+        tagName = tag,
+        htmlUrl = "https://github.com/alexeygrigorev/pocketshell/releases/tag/$tag",
+        apkUrl = "https://example.com/${tag}.apk",
+        publishedDateLabel = date,
+    )
+
+    private class ScriptedReleaseChecker(
+        private val results: MutableList<ReleaseCheckResult>,
+    ) : ReleaseChecker() {
+        var calls = 0
+            private set
+
+        override suspend fun checkForUpdate(currentVersion: String): ReleaseCheckResult {
+            calls += 1
+            return if (results.isEmpty()) ReleaseCheckResult.UpToDate else results.removeAt(0)
+        }
+    }
+
+    private fun scheduler(
+        checker: ReleaseChecker,
+        now: () -> Long = { 1_000_000L },
+    ): UpdateCheckScheduler {
+        val s = UpdateCheckScheduler(
+            applicationContext = context,
+            releaseChecker = checker,
+            store = UpdateCheckStore(context),
+        )
+        s.scope = CoroutineScope(SupervisorJob() + dispatcher)
+        s.nowMillis = now
+        s.currentVersionProvider = { "0.5.0" }
+        return s
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("update_check", Context.MODE_PRIVATE).edit().clear().commit()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun foregroundResume_firesCheck_viaLifecycleObserver() = runTest(dispatcher) {
+        val info = release("v0.5.1")
+        val checker = ScriptedReleaseChecker(mutableListOf(ReleaseCheckResult.UpdateAvailable(info)))
+        val s = scheduler(checker)
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.CREATED
+
+        s.observeProcessLifecycle(owner)
+        advanceUntilIdle()
+        assertEquals(0, checker.calls)
+
+        owner.registry.currentState = Lifecycle.State.STARTED
+        advanceUntilIdle()
+
+        assertEquals(1, checker.calls)
+        assertEquals(info, s.updateAvailable.value)
+    }
+
+    @Test
+    fun onStartInsideThrottle_doesNotFetch() = runTest(dispatcher) {
+        val checker = ScriptedReleaseChecker(
+            mutableListOf(ReleaseCheckResult.UpToDate, ReleaseCheckResult.UpToDate),
+        )
+        var clock = 1_000_000L
+        val s = scheduler(checker, now = { clock })
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.STARTED
+
+        s.observeProcessLifecycle(owner)
+        advanceUntilIdle()
+        assertEquals(1, checker.calls)
+
+        owner.registry.currentState = Lifecycle.State.CREATED
+        advanceUntilIdle()
+        owner.registry.currentState = Lifecycle.State.STARTED
+        advanceUntilIdle()
+        assertEquals(1, checker.calls)
+
+        clock += UpdateCheckScheduler.DEFAULT_THROTTLE_WINDOW_MILLIS + 1
+        owner.registry.currentState = Lifecycle.State.CREATED
+        advanceUntilIdle()
+        owner.registry.currentState = Lifecycle.State.STARTED
+        advanceUntilIdle()
+        assertEquals(2, checker.calls)
+    }
+
+    @Test
+    fun refreshNow_bypassesThrottle() = runTest(dispatcher) {
+        val checker = ScriptedReleaseChecker(
+            mutableListOf(ReleaseCheckResult.UpToDate, ReleaseCheckResult.UpToDate),
+        )
+        val s = scheduler(checker)
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.STARTED
+        s.observeProcessLifecycle(owner)
+        advanceUntilIdle()
+        assertEquals(1, checker.calls)
+
+        s.refreshNow()
+        advanceUntilIdle()
+        assertEquals(2, checker.calls)
+    }
+
+    @Test
+    fun failedCheck_doesNotLookLikeUpToDate_andDoesNotBurnThrottle() = runTest(dispatcher) {
+        var clock = 1_000_000L
+        val checker = ScriptedReleaseChecker(
+            mutableListOf(
+                ReleaseCheckResult.Failed("rate-limited, try again later"),
+                ReleaseCheckResult.UpToDate,
+            ),
+        )
+        val s = scheduler(checker, now = { clock })
+        s.refreshNow()
+        advanceUntilIdle()
+        assertEquals("rate-limited, try again later", s.updateCheckFailed.value)
+        assertTrue(s.lastResult.value is ReleaseCheckResult.Failed)
+        assertNull(s.updateAvailable.value)
+
+        clock += 1
+        s.refreshNow()
+        advanceUntilIdle()
+        assertEquals(ReleaseCheckResult.UpToDate, s.lastResult.value)
+        assertNull(s.updateCheckFailed.value)
+    }
+
+    @Test
+    fun dismissHidesTag_untilANewerTagAppears() = runTest(dispatcher) {
+        val v51 = release("v0.5.1")
+        val v52 = release("v0.5.2")
+        val checker = ScriptedReleaseChecker(
+            mutableListOf(
+                ReleaseCheckResult.UpdateAvailable(v51),
+                ReleaseCheckResult.UpdateAvailable(v51),
+                ReleaseCheckResult.UpdateAvailable(v52),
+            ),
+        )
+        val s = scheduler(checker)
+
+        s.refreshNow()
+        advanceUntilIdle()
+        assertEquals(v51, s.updateAvailable.value)
+
+        s.dismissCurrentUpdate()
+        assertNull(s.updateAvailable.value)
+        assertTrue(s.lastResult.value is ReleaseCheckResult.UpdateAvailable)
+
+        s.refreshNow()
+        advanceUntilIdle()
+        assertNull("dismissed tag must not re-nag", s.updateAvailable.value)
+
+        s.refreshNow()
+        advanceUntilIdle()
+        assertEquals(v52, s.updateAvailable.value)
+    }
+
+    private class FakeLifecycleOwner : LifecycleOwner {
+        val registry = LifecycleRegistry.createUnsafe(this)
+        override val lifecycle: Lifecycle get() = registry
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/release/UpdateDownloadLauncherTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/release/UpdateDownloadLauncherTest.kt
@@ -1,0 +1,31 @@
+package com.pocketshell.next.release
+
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class UpdateDownloadLauncherTest {
+
+    @Test
+    fun viewIntent_isActionView_withNewTask_againstTheUrl() {
+        val apk = "https://github.com/alexeygrigorev/pocketshell/releases/download/v0.5.1/app.apk"
+        val intent = viewIntent(apk)
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals(apk, intent.data.toString())
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    fun notesIntent_isActionView_againstHtmlUrl() {
+        val html = "https://github.com/alexeygrigorev/pocketshell/releases/tag/v0.5.1"
+        val intent = viewIntent(html)
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals(html, intent.data.toString())
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/render/HostScreenRenders.kt
+++ b/app2/src/test/java/com/pocketshell/next/render/HostScreenRenders.kt
@@ -11,6 +11,7 @@ import com.pocketshell.next.hosts.HostFormErrors
 import com.pocketshell.next.hosts.HostFormState
 import com.pocketshell.next.hosts.HostListScreen
 import com.pocketshell.next.hosts.HostListUiState
+import com.pocketshell.next.hosts.HostListUpdateNotice
 import com.pocketshell.next.hosts.HostRow
 import com.pocketshell.next.hosts.QrScannerViewModel
 import com.pocketshell.next.hosts.QrScannerScreen
@@ -59,6 +60,31 @@ class HostScreenRenders {
             onScanQr = {},
             onOpenSettings = {},
             onDeleteHost = {},
+        )
+    }
+
+    /** Issue #2531: the GitHub-Releases update banner on the host list. */
+    @Test
+    fun hostListUpdateBanner() = render("host-list-update-banner") {
+        HostListScreen(
+            state = HostListUiState(
+                loaded = true,
+                hosts = listOf(
+                    HostRow(1, "hetzner", "alexey@135.181.114.209"),
+                    HostRow(2, "builder", "root@10.0.0.7"),
+                ),
+            ),
+            onOpenHost = {},
+            onAddHost = {},
+            onEditHost = {},
+            onScanQr = {},
+            onOpenSettings = {},
+            onDeleteHost = {},
+            updateNotice = HostListUpdateNotice.Available(
+                text = "v0.5.1 is available — you are on v0.5.0 · 5 Sep 2026",
+                apkUrl = "https://example.com/pocketshell-0.5.1.apk",
+                htmlUrl = "https://github.com/alexeygrigorev/pocketshell/releases/tag/v0.5.1",
+            ),
         )
     }
 

--- a/app2/src/test/java/com/pocketshell/next/settings/SettingsScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/settings/SettingsScreenTest.kt
@@ -6,7 +6,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.next.release.ReleaseCheckResult
+import com.pocketshell.next.release.ReleaseInfo
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -133,6 +137,84 @@ class SettingsScreenTest {
         assertEquals(1, backCount)
     }
 
+    @Test
+    fun `idle check-for-updates row runs immediately when tapped`() {
+        var checks = 0
+        setContent(onCheckForUpdates = { checks++ })
+
+        composeRule.onNodeWithText("Ask GitHub for the latest APK.").assertIsDisplayed()
+        composeRule.onNodeWithText("Ask GitHub for the latest APK.").performClick()
+        assertEquals(1, checks)
+    }
+
+    @Test
+    fun `up-to-date state is distinct from failed`() {
+        setContent(updateCheckState = SettingsUpdateCheckState.UpToDate)
+
+        composeRule.onNodeWithText("Up to date").assertIsDisplayed()
+        composeRule.onNodeWithText("Retry update check").assertDoesNotExist()
+        composeRule.onNodeWithText("Couldn't check for updates", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `available state shows tag and date without a clock time`() {
+        val info = ReleaseInfo(
+            tagName = "v0.5.1",
+            htmlUrl = "https://github.com/alexeygrigorev/pocketshell/releases/tag/v0.5.1",
+            apkUrl = "https://example.com/pocketshell-0.5.1.apk",
+            publishedDateLabel = "5 Sep 2026",
+        )
+        var downloaded: ReleaseInfo? = null
+        setContent(
+            updateCheckState = SettingsUpdateCheckState.UpdateAvailable(info),
+            onDownloadUpdate = { downloaded = it },
+        )
+
+        composeRule.onNodeWithText("Download v0.5.1").assertIsDisplayed()
+        composeRule.onNodeWithText("Published 5 Sep 2026").assertIsDisplayed()
+        assertFalse("date leaked a clock time", info.publishedDateLabel.contains(":"))
+        composeRule.onNodeWithTag(SETTINGS_UPDATE_CHECK_TAG).performClick()
+        assertEquals(info, downloaded)
+    }
+
+    @Test
+    fun `failed state is not up to date and retries`() {
+        var checks = 0
+        setContent(
+            updateCheckState = SettingsUpdateCheckState.Failed("rate-limited, try again later"),
+            onCheckForUpdates = { checks++ },
+        )
+
+        composeRule.onNodeWithText("Retry update check").assertIsDisplayed()
+        composeRule.onNodeWithText("Couldn't check for updates: rate-limited, try again later")
+            .assertIsDisplayed()
+        composeRule.onNodeWithText("Up to date").assertDoesNotExist()
+        composeRule.onNodeWithTag(SETTINGS_UPDATE_CHECK_TAG).performClick()
+        assertEquals(1, checks)
+    }
+
+    @Test
+    fun settingsUpdateCheckState_mapsTheThreeWayResult() {
+        assertEquals(
+            SettingsUpdateCheckState.Idle,
+            settingsUpdateCheckState(checking = false, lastResult = null),
+        )
+        assertEquals(
+            SettingsUpdateCheckState.Checking,
+            settingsUpdateCheckState(checking = true, lastResult = null),
+        )
+        assertEquals(
+            SettingsUpdateCheckState.UpToDate,
+            settingsUpdateCheckState(checking = false, lastResult = ReleaseCheckResult.UpToDate),
+        )
+        val failed = settingsUpdateCheckState(
+            checking = false,
+            lastResult = ReleaseCheckResult.Failed("no network connection"),
+        )
+        assertTrue(failed is SettingsUpdateCheckState.Failed)
+        assertFalse(failed is SettingsUpdateCheckState.UpToDate)
+    }
+
     private fun setContent(
         settings: AppSettings = AppSettings(),
         hosts: List<SettingsHostRow> = emptyList(),
@@ -145,6 +227,9 @@ class SettingsScreenTest {
         onAgentSubmitEnterDelayChange: (Int) -> Unit = {},
         onOpenWorkspaceRoots: (Long) -> Unit = {},
         onOpenCrashReports: () -> Unit = {},
+        updateCheckState: SettingsUpdateCheckState = SettingsUpdateCheckState.Idle,
+        onCheckForUpdates: () -> Unit = {},
+        onDownloadUpdate: (ReleaseInfo) -> Unit = {},
     ) {
         composeRule.setContent {
             SettingsScreen(
@@ -159,6 +244,9 @@ class SettingsScreenTest {
                 onAgentSubmitEnterDelayChange = onAgentSubmitEnterDelayChange,
                 onOpenWorkspaceRoots = onOpenWorkspaceRoots,
                 onOpenCrashReports = onOpenCrashReports,
+                updateCheckState = updateCheckState,
+                onCheckForUpdates = onCheckForUpdates,
+                onDownloadUpdate = onDownloadUpdate,
             )
         }
     }

--- a/scripts/test-areas.txt
+++ b/scripts/test-areas.txt
@@ -298,6 +298,7 @@ src    app2/src/main/java/com/pocketshell/next/ports/*        portfwd           
 src    app2/src/main/java/com/pocketshell/next/files/*        files                full
 src    app2/src/main/java/com/pocketshell/next/hosts/*        hosts-settings       full
 src    app2/src/main/java/com/pocketshell/next/settings/*     hosts-settings       full
+src    app2/src/main/java/com/pocketshell/next/release/*      hosts-settings       full
 src    app2/src/main/java/com/pocketshell/next/share/*        share                full
 src    app2/src/main/java/com/pocketshell/next/usage/*        usage-costs          full
 src    app2/src/main/java/com/pocketshell/next/hostcli/*      bootstrap            full
@@ -348,6 +349,7 @@ test   app2/src/*/java/com/pocketshell/next/ports/*        portfwd              
 test   app2/src/*/java/com/pocketshell/next/files/*        files                full
 test   app2/src/*/java/com/pocketshell/next/hosts/*        hosts-settings       full
 test   app2/src/*/java/com/pocketshell/next/settings/*     hosts-settings       full
+test   app2/src/*/java/com/pocketshell/next/release/*      hosts-settings       full
 test   app2/src/*/java/com/pocketshell/next/share/*        share                full
 test   app2/src/*/java/com/pocketshell/next/usage/*        usage-costs          full
 test   app2/src/*/java/com/pocketshell/next/diagnostics/*  diagnostics-crash    full


### PR DESCRIPTION
Closes #2531.

Foreground-only GitHub Releases check. Banner names the new tag, current version, and published date (no clock time). Settings can check immediately.

Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2531#issuecomment-5554105344