### PR TITLE
feat: ship aplexer with the CLI instead of a separate install

### DIFF
--- a/docs/aplexer-integration.md
+++ b/docs/aplexer-integration.md
@@ -30,6 +30,124 @@ inherits Phase A the same day the helper does.
 
 ---
 
+## Shipping: aplexer is part of the pocketshell CLI (#2543)
+
+aplexer is **not installed separately**. `tools/pocketshell/pyproject.toml`
+carries a pinned, Linux-marked hard dependency:
+
+```toml
+"aplexer==0.1.2; sys_platform == 'linux'"
+```
+
+so the documented host install — `uv tool install pocketshell` — also delivers
+the `a` CLI **and** the `aplexer` worker binary as console-scripts in the same
+`bin` directory as the pocketshell interpreter. There is no separate build, no
+copy step, and no PATH surgery. The published wheels bundle both native
+binaries (x86_64 + aarch64); the `sys_platform == 'linux'` marker is
+load-bearing because aplexer publishes no sdist and no macOS/Windows wheels,
+so an unmarked hard dependency would make `pip install pocketshell`
+unresolvable off Linux.
+
+**glibc floor (flagged, not solved).** aplexer 0.1.1 shipped `manylinux_2_17`
+wheels; 0.1.2 ships `manylinux_2_28`, raising the minimum glibc from 2.17 to
+2.28. Now that aplexer is a *hard* dependency, that floor applies to
+`pip install pocketshell` / `uv tool install pocketshell` as a whole, not just
+to the aplexer backend: a Linux host older than glibc 2.28 (CentOS 7,
+Ubuntu 18.04, Debian 9) can no longer install the CLI at all. Combined with
+the existing wheel-only, glibc-only surface, the install matrix is now
+"glibc >= 2.28, x86_64 or aarch64" — musl/Alpine and 32-bit Linux were already
+out (PEP 508 has no libc marker to express that). Every current PocketShell
+host is well past 2.28 (the maintainer's box is 2.39), so nothing is broken
+today; widening the matrix would mean an aplexer-side manylinux target change
+or making the dependency optional again, both out of scope for #2543.
+
+### Binary resolution (`pocketshell/aplexer.py::resolve_a`)
+
+Exactly two candidates, highest first:
+
+1. `APLEXER_BIN` — the single explicit override. A debug/test knob (the unit
+   suite points it at stub `a` scripts), not an install path.
+2. The **bundled** copy next to `sys.executable` — the interpreter's own `bin`
+   dir first, then the resolved dir, mirroring
+   `usage.py::_resolve_quse_binary` for the pinned `quse`. Console-scripts sit
+   next to the *unresolved* `sys.executable`, because a venv / `uv tool`
+   `bin/python` is a symlink into a shared interpreter dir that holds no
+   console-scripts.
+
+There is **no `PATH` lookup**. `shutil.which("a")` was deleted (D22 hard cut,
+not put behind a condition): a host-level or locally-built `a` must not shadow
+the pinned copy, and "a binary that only exists on `PATH`" is exactly the
+separate-install mode this change removes. An unresolvable `a` is a
+packaging-integrity error that fails loud — `sessions.py::_create_on_aplexer`
+names every candidate it tried and points at
+`uv tool install --force pocketshell`, instead of the old message that claimed
+aplexer "is not installed on this host" while it was in fact installed and
+merely off the app's non-interactive SSH `PATH`.
+
+Every call site uses the RESOLVED path. `sessions attach` and `sessions kill`
+used to `execvp` / `subprocess.run` a bare `"a"` — a PATH lookup by another
+name, and a way to run a different copy than the availability check just
+approved; they now exec `resolution.path` (#2543).
+
+The worker matters as much as the CLI: `aplexer/src/lib.rs::worker_executable`
+resolves the `aplexer` worker as a sibling of `current_exe`, so a hand-copied
+`a` with no sibling worker finds the CLI and still cannot start a session. The
+wheel always ships both into the same dir, and `AplexerResolution.worker`
+reports the sibling that was found.
+
+### Version coupling, and why the version string is not the contract
+
+The pin is enforced by the exact `==` specifier, the committed
+`tools/pocketshell/uv.lock`, and `tools/pocketshell/tests/test_aplexer_contract.py`.
+It deliberately does **not** get a release-time guard:
+`scripts/check-pypi-version.sh` couples pocketshell's own package version to
+the release tag and says nothing about `quse` or `tmuxctl` either.
+
+The version string alone is **not** sufficient, and #2543 is the proof. The
+first attempt pinned `aplexer==0.1.1`, the newest published wheel at the time.
+aplexer's `main` was 143 commits past the `v0.1.1` tag and *still* reported
+`a --version` as `0.1.1`, so the published wheel and the build every host
+actually ran were indistinguishable by version. Under the hard cut above the
+bundled wheel is the ONLY `a` the CLI can run, so that pin would have silently
+downgraded every host past two fixes the real create-agent path depends on:
+
+| aplexer commit | What 0.1.1 does instead |
+| --- | --- |
+| `ee4b957` — profile `executable` override (argv[0]) | Accepts the key, ignores it. `[profiles.zcodex] engine="codex", executable="zcodex"` resolves argv[0] to `codex`, so `sessions create --backend aplexer --engine codex --profile zcodex` dies with `a: command is not executable or was not found in PATH: codex`. |
+| `d13ecb2` — preserve provider env for `shell` launches | Unsets 71 provider vars for every plain shell session. |
+
+Hence `test_aplexer_contract.py`: it drives the **bundled** binary (never a
+host copy, never PATH) against its own throwaway `APLEXER_CONFIG` fixture — so
+it is not hostage to the maintainer's personal profiles — and asserts the
+BEHAVIOUR the CLI depends on:
+
+- a profile `executable` override reaches argv[0], in `a --json launch-spec`
+  **and** in a real `a start` whose fixture engine command deliberately does
+  not exist (the reported symptom, reproduced);
+- `a --json profiles` exposes the `executable` field;
+- `launch-spec --engine shell` strips nothing, while an agent engine still
+  strips the provider keys;
+- every subcommand + flag this CLI passes (`start --workspace/--tag/--engine/
+  --profile`, `snapshot`, `list`, `engines`, `profiles`,
+  `launch-spec --engine/--cwd/--profile/--no-skip-permissions`,
+  `attach`, `kill`) exists in the bundled build.
+
+Those assertions were verified to fail against published 0.1.1 and pass
+against 0.1.2. **Re-run that file whenever the pin moves** — it is what a bump
+has to re-verify, in place of a version check that cannot see the difference.
+
+### Lock cutoff
+
+`[tool.uv] exclude-newer` in `tools/pocketshell/pyproject.toml` (mirrored in
+`uv.lock`'s `[options]`) is a project-local reproducibility cutoff, and a
+package uploaded *after* it is simply invisible to `uv lock` — which looks
+like a broken index rather than a stale cutoff. So it moves in lock-step with
+every new pin: past quse 0.0.15 (#2293), now past aplexer 0.1.2's
+2026-09-05T22:38:08Z upload (its `aplexer-client` runtime dependency landed at
+22:38:04Z). Bump both places together, or `uv lock --check` fails.
+
+---
+
 ## Readiness (fair assessment, 2026-08-26)
 
 | Phase | Ready? | Meaning |
@@ -79,8 +197,9 @@ names, `@ps_*` options stay.
 
 Issue: #2341.
 
-In `profiles.py`, probe `a profiles --json` when `a` is on PATH (or
-`$APLEXER_BIN`). Map entries onto `Profile` objects. Log divergence
+In `profiles.py`, probe `a profiles --json` when `a` resolves (the bundled
+copy shipped with the CLI, or `$APLEXER_BIN` — never PATH, see "Shipping"
+above). Map entries onto `Profile` objects. Log divergence
 against native discovery. **Prefer mapped siblings**; keep native
 `Claude`/`Codex` defaults. Native discovery is the fallback. Kill
 switches: `POCKETSHELL_APLEXER=0` / `POCKETSHELL_APLEXER_PROFILES=0`.

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -82,6 +82,62 @@ dependencies = [
     # per-session-server migration so every caller resolves sessions the same
     # way.
     "tmuxctl>=0.3.5",
+    # aplexer ships WITH the pocketshell CLI (issue #2543). `pocketshell
+    # sessions create --backend aplexer` needs BOTH the `a` CLI and its
+    # `aplexer` worker binary (aplexer/src/lib.rs::worker_executable resolves
+    # the worker as a sibling of current_exe); the published wheel bundles
+    # both native binaries and exposes them as the `a` / `aplexer`
+    # console-scripts, so `uv tool install pocketshell` delivers a complete,
+    # working aplexer with no separate build/copy/PATH step. That closes the
+    # reported failure where a hand-installed `~/bin/a` was invisible to the
+    # app's NON-INTERACTIVE SSH PATH and half-installed (no sibling worker).
+    #
+    # Pinned exactly, like `quse`: pocketshell speaks a specific `a --json`
+    # contract (`start`/`snapshot`/`list`/`launch-spec`/`engines`/`profiles`),
+    # and `pocketshell/aplexer.py` resolves the BUNDLED copy INSTEAD of PATH,
+    # so the pinned wheel is the ONLY aplexer this CLI can run. Bumping the
+    # pin is a deliberate, reviewed change.
+    #
+    # 0.1.2 (not 0.1.1) is required, and the version string alone cannot tell
+    # you why: aplexer HEAD sat 143 commits past the v0.1.1 tag while STILL
+    # self-reporting `a --version` as 0.1.1, so the published 0.1.1 wheel and
+    # the build every PocketShell host actually ran were indistinguishable by
+    # version. Pinning 0.1.1 under the hard cut would have silently DOWNGRADED
+    # every host to a build missing two fixes the real create-agent path needs:
+    #   * aplexer ee4b957 — profile `executable` override (argv[0]) for Codex
+    #     variants. Without it, `[profiles.zcodex] engine="codex",
+    #     executable="zcodex"` resolves argv[0] to `codex`, and `pocketshell
+    #     sessions create --backend aplexer --engine codex --profile zcodex`
+    #     dies with "a: command is not executable or was not found in PATH:
+    #     codex".
+    #   * aplexer d13ecb2 — preserve the provider environment for plain
+    #     `shell` launches (0.1.1 stripped 71 provider vars from every shell
+    #     session).
+    # tests/test_aplexer_contract.py pins BOTH behaviours against the BUNDLED
+    # binary, because `a --version` demonstrably cannot: a future pin that
+    # regresses to a build without them fails that test loudly instead of
+    # shipping a silent downgrade. Re-run it whenever this pin moves.
+    #
+    # There is no separate release-time guard for the aplexer version itself
+    # (scripts/check-pypi-version.sh only couples pocketshell's OWN version to
+    # the release tag and says nothing about quse or tmuxctl either), so the
+    # exact pin + the committed uv.lock + that contract test are the
+    # enforcement.
+    #
+    # The `sys_platform == 'linux'` marker is load-bearing: aplexer publishes
+    # manylinux wheels only (x86_64 + aarch64) and NO sdist, so an unmarked
+    # hard dependency would make `pip install pocketshell` unresolvable on
+    # macOS/Windows. PocketShell hosts are Linux; a non-Linux host simply gets
+    # no bundled aplexer at all, so `sessions create --backend aplexer` there
+    # fails loud (there is no PATH fallback — D22) while tmux, the default
+    # backend, keeps working.
+    #
+    # Install-surface note (0.1.2): the wheels moved from manylinux_2_17 to
+    # manylinux_2_28, raising the minimum glibc from 2.17 to 2.28. Linux hosts
+    # older than that (CentOS 7, Ubuntu 18.04) can no longer install
+    # pocketshell at all now that aplexer is a hard dependency. Flagged, not
+    # solved here — see docs/aplexer-integration.md.
+    "aplexer==0.1.2; sys_platform == 'linux'",
 ]
 
 [project.scripts]
@@ -137,8 +193,13 @@ required-version = "==0.10.11"
 # a rolling global `exclude-newer` policy that predates deliberately pinned
 # releases (quse 0.0.15 and tmuxctl 0.3.5); this exact value is also the
 # `uv.lock` options cutoff and must be used when checking this lock. Moved
-# past quse 0.0.15's 2026-08-28T12:09:07Z PyPI upload for issue #2293.
-exclude-newer = "2026-08-28T22:00:00Z"
+# past quse 0.0.15's 2026-08-28T12:09:07Z PyPI upload for issue #2293, then
+# past aplexer 0.1.2's 2026-09-05T22:38:08Z PyPI upload (its `aplexer-client`
+# runtime dep landed at 22:38:04Z) for issue #2543. A package uploaded after
+# the cutoff is simply invisible to `uv lock`, which reads like a broken index
+# rather than a stale cutoff, so this value moves in lock-step with every new
+# pin — and the `uv.lock` options cutoff must be moved to match.
+exclude-newer = "2026-09-05T23:00:00Z"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tools/pocketshell/src/pocketshell/aplexer.py
+++ b/tools/pocketshell/src/pocketshell/aplexer.py
@@ -12,16 +12,48 @@ Kill switches (any one is enough to skip):
 - ``POCKETSHELL_APLEXER_LAUNCH=0``
 - ``POCKETSHELL_APLEXER_SESSIONS=0``
 
-``APLEXER_BIN`` overrides ``PATH`` lookup of ``a``.
+Binary resolution (issue #2543)
+-------------------------------
+
+aplexer ships WITH this CLI: PyPI ``aplexer`` is a pinned, Linux-marked hard
+dependency (``pyproject.toml``), so ``uv tool install pocketshell`` drops the
+``a`` and ``aplexer`` console-scripts into the SAME ``bin`` directory as the
+interpreter running pocketshell. There is no separate aplexer install step and
+no PATH surgery. Resolution order, highest first:
+
+1. ``APLEXER_BIN`` — the one explicit override (a debug/test knob, not an
+   install path).
+2. The **bundled** copy next to ``sys.executable`` — the pinned wheel, the
+   same anchor ``usage.py::_resolve_quse_binary`` uses for the pinned ``quse``.
+
+There is no third step: the ``PATH`` lookup is HARD-CUT (D22 — no fallback
+branch; the superseded code is deleted, not conditioned). This mirrors
+``quse`` exactly. A host-level or locally-built ``a`` on ``PATH`` must NOT
+shadow the pinned copy, and an absent bundled copy is a packaging-integrity
+error that fails loud — not a "please install aplexer" nag. aplexer is a
+dependency of this CLI; it is never installed separately.
+
+The original bug this fixes: ``which_a`` used to be a bare
+``shutil.which("a", path=env["PATH"])``, and the app drives the host CLI over
+a NON-INTERACTIVE SSH command whose PATH is
+``~/.local/bin:/usr/local/sbin:…`` — a correctly installed ``a`` outside those
+dirs (e.g. ``~/bin/a``) was invisible, and the error said "not installed".
+
+``a`` needs a sibling ``aplexer`` worker binary (``aplexer/src/lib.rs``
+``worker_executable`` resolves it next to ``current_exe``, else bare
+``aplexer`` on PATH). The pinned wheel always ships both into the same dir, so
+:class:`AplexerResolution` reports the worker it found next to ``a``.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import shutil
 import signal
 import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Mapping, Optional
 
 JSON_TIMEOUT_S = 2.0
@@ -57,12 +89,87 @@ def enabled(feature: str, env: Optional[Mapping[str, str]] = None) -> bool:
     return True
 
 
-def which_a(env: Optional[Mapping[str, str]] = None) -> Optional[str]:
+@dataclass(frozen=True)
+class AplexerResolution:
+    """Outcome of resolving the ``a`` CLI, including what was tried.
+
+    ``tried`` is human-readable and exists so a failure can NAME the candidate
+    paths instead of claiming aplexer "is not installed" (issue #2543).
+    """
+
+    path: Optional[str] = None
+    source: Optional[str] = None
+    worker: Optional[str] = None
+    tried: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _bundled_bin_dirs() -> list[Path]:
+    """Directories that can hold the pinned aplexer console-scripts.
+
+    Console-scripts live next to the UNRESOLVED ``sys.executable``: in a venv
+    (or a ``uv tool`` install) ``bin/python`` is a symlink to the underlying
+    interpreter, so ``Path(sys.executable).resolve()`` points at the shared
+    interpreter dir where ``a`` is NOT installed. Check the interpreter's own
+    ``bin`` dir first and only fall through to the resolved dir for layouts
+    where the two coincide. Both candidates are anchored to ``sys.executable``
+    — this is NOT a PATH search. Same trap, same handling, as
+    ``usage.py::_resolve_quse_binary``.
+    """
+    exe_dir = Path(sys.executable).parent
+    dirs = [exe_dir]
+    resolved_dir = Path(sys.executable).resolve().parent
+    if resolved_dir != exe_dir:
+        dirs.append(resolved_dir)
+    return dirs
+
+
+def _sibling_worker(cli_path: str) -> Optional[str]:
+    """The ``aplexer`` worker binary shipped next to ``cli_path``, if any."""
+    worker = Path(cli_path).parent / "aplexer"
+    return str(worker) if worker.exists() else None
+
+
+def resolve_a(env: Optional[Mapping[str, str]] = None) -> AplexerResolution:
+    """Resolve the ``a`` CLI: ``APLEXER_BIN``, else the BUNDLED copy. No PATH.
+
+    See the module docstring: ``PATH`` is deliberately not consulted at all,
+    so a separately-installed ``a`` can never be load-bearing. Never raises —
+    an unresolvable ``a`` comes back as a report whose ``path`` is ``None``
+    and whose ``tried`` lists every candidate, for the caller's error message.
+    """
     source = env_map(env)
+    tried: list[str] = []
+
     explicit = source.get(BIN_ENV)
     if explicit:
-        return explicit
-    return shutil.which("a", path=source.get("PATH"))
+        return AplexerResolution(
+            path=explicit,
+            source=BIN_ENV,
+            worker=_sibling_worker(explicit),
+            tried=(f"{BIN_ENV}={explicit}",),
+        )
+    tried.append(f"{BIN_ENV} (unset)")
+
+    for bin_dir in _bundled_bin_dirs():
+        candidate = bin_dir / "a"
+        if candidate.exists():
+            return AplexerResolution(
+                path=str(candidate),
+                source="bundled",
+                worker=_sibling_worker(str(candidate)),
+                tried=tuple([*tried, f"{candidate} (bundled, found)"]),
+            )
+        tried.append(f"{candidate} (bundled, missing)")
+
+    # No PATH lookup by design (D22 hard cut, issue #2543): resolution ends
+    # here. An `a` that exists only on PATH is a SEPARATE install, which is the
+    # mode this change removes — it must not be picked up silently.
+    return AplexerResolution(tried=tuple(tried))
+
+
+def which_a(env: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    """Path to the ``a`` CLI, or ``None``. Thin wrapper over :func:`resolve_a`."""
+    return resolve_a(env).path
 
 
 def run_json(

--- a/tools/pocketshell/src/pocketshell/sessions.py
+++ b/tools/pocketshell/src/pocketshell/sessions.py
@@ -810,12 +810,24 @@ def _create_on_aplexer(
     ``session_enum.aplexer_display_name``) so it round-trips with what
     `sessions list --json` shows.
     """
-    aplexer_path = _aplexer.which_a()
+    resolution = _aplexer.resolve_a()
+    aplexer_path = resolution.path
     if aplexer_path is None:
+        # #2543: this used to say "is not installed", which was actively
+        # misleading — the real cause was a RESOLUTION failure (a correctly
+        # installed `a` outside the app's non-interactive SSH PATH). aplexer
+        # now ships WITH this CLI as a pinned dependency, so an unresolvable
+        # `a` is a packaging-integrity problem, and the message names every
+        # candidate that was checked.
         raise _CreateError(
-            "pocketshell: `a` (aplexer) is not installed on this host, but "
-            "the backend routing selected it. Install aplexer or set "
-            "[backends] in ~/.config/pocketshell/config.toml back to tmux.",
+            _aplexer_unresolved_message(
+                resolution,
+                action=(
+                    "the backend routing selected it, so `sessions create` "
+                    "cannot run (or set [backends] in "
+                    "~/.config/pocketshell/config.toml back to tmux)"
+                ),
+            ),
             exit_code=127,
         )
     workspace = cwd or os.getcwd()
@@ -1040,15 +1052,37 @@ TMUX_PROBE_TIMEOUT_S = 2.0
 TMUX_SOCKET_SWEEP_BUDGET_S = 5.0
 
 
-def _resolve_aplexer_binary() -> Optional[str]:
-    """Locate the ``a`` (aplexer) CLI, honouring ``APLEXER_BIN``.
+def _resolve_aplexer() -> "_aplexer.AplexerResolution":
+    """Resolve the ``a`` CLI for attach/kill: ``APLEXER_BIN``, else bundled.
 
-    Wrapped rather than calling :func:`pocketshell.aplexer.which_a` inline so
+    Wrapped rather than calling :func:`pocketshell.aplexer.resolve_a` inline so
     the attach-time availability check has its own monkeypatch seam: patching
-    ``which_a`` itself would also silence the enumeration probe that produced
-    the aplexer rows in the first place.
+    ``resolve_a`` itself would also silence the enumeration probe that produced
+    the aplexer rows in the first place. Returns the full report, because the
+    failure message names every candidate it tried (#2543), and the callers
+    exec/run the RESOLVED path — never a bare ``a`` that execvp would look up
+    on PATH.
     """
-    return _aplexer.which_a()
+    return _aplexer.resolve_a()
+
+
+def _aplexer_unresolved_message(
+    resolution: "_aplexer.AplexerResolution", *, action: str
+) -> str:
+    """Explain an unresolvable ``a`` by NAMING the candidates (issue #2543).
+
+    The old wording — "`a` (aplexer) is not installed on this host" — was the
+    inverse of the truth in the reported failure: aplexer WAS installed, just
+    not where a bare PATH lookup could see it. aplexer now ships WITH this CLI
+    as a pinned dependency, so an unresolvable `a` is a packaging-integrity
+    problem with a concrete fix, and the message says which paths were checked.
+    """
+    return (
+        "pocketshell: could not resolve the `a` (aplexer) binary; "
+        f"{action}. aplexer ships with the pocketshell CLI, so reinstalling "
+        "normally fixes this (`uv tool install --force pocketshell`); "
+        "otherwise set APLEXER_BIN. Tried: " + "; ".join(resolution.tried)
+    )
 
 
 def _exec(argv: list[str]) -> None:
@@ -1231,15 +1265,21 @@ def sessions_attach(ctx: click.Context, name: str, hide_status: bool) -> None:
 
     row = matches[0]
     if row.manager == _session_enum.MANAGER_APLEXER:
-        if _resolve_aplexer_binary() is None:
+        # Resolve ONCE and exec that exact path (#2543). A bare "a" here would
+        # be an execvp PATH lookup — the separate-install mode this CLI no
+        # longer supports, and a way to run a different copy than the one the
+        # availability check just approved.
+        resolution = _resolve_aplexer()
+        if resolution.path is None:
             click.echo(
-                "pocketshell: `a` (aplexer) is not installed on this host; "
-                f"cannot attach to {row.name!r}.",
+                _aplexer_unresolved_message(
+                    resolution, action=f"cannot attach to {row.name!r}"
+                ),
                 err=True,
             )
             ctx.exit(ATTACH_EXIT_NO_BINARY)
             return
-        _exec(["a", "attach", str(row.aplexer_id)])
+        _exec([resolution.path, "attach", str(row.aplexer_id)])
         return
 
     if shutil.which("tmux") is None:
@@ -1398,11 +1438,13 @@ def sessions_kill(ctx: click.Context, name: str, as_json: bool) -> None:
 
     row = matches[0]
     if row.manager == _session_enum.MANAGER_APLEXER:
-        if _resolve_aplexer_binary() is None:
+        resolution = _resolve_aplexer()
+        if resolution.path is None:
             _emit_kill_failure(
                 ctx,
-                "pocketshell: `a` (aplexer) is not installed on this host; "
-                f"cannot kill {row.name!r}.",
+                _aplexer_unresolved_message(
+                    resolution, action=f"cannot kill {row.name!r}"
+                ),
                 exit_code=ATTACH_EXIT_NO_BINARY,
                 as_json=as_json,
             )
@@ -1416,7 +1458,8 @@ def sessions_kill(ctx: click.Context, name: str, as_json: bool) -> None:
                 as_json=as_json,
             )
             return
-        argv = ["a", "kill", str(aplexer_id)]
+        # The resolved path, not a bare "a" on PATH (#2543).
+        argv = [resolution.path, "kill", str(aplexer_id)]
         try:
             completed = _run_session_kill(argv)
         except subprocess.TimeoutExpired:
@@ -1430,7 +1473,7 @@ def sessions_kill(ctx: click.Context, name: str, as_json: bool) -> None:
         except OSError as exc:
             _emit_kill_failure(
                 ctx,
-                "pocketshell: `a` (aplexer) is not installed on this host; "
+                f"pocketshell: `{resolution.path} kill` could not run; "
                 f"cannot kill {row.name!r}: {exc}",
                 exit_code=ATTACH_EXIT_NO_BINARY,
                 as_json=as_json,

--- a/tools/pocketshell/tests/test_aplexer_contract.py
+++ b/tools/pocketshell/tests/test_aplexer_contract.py
@@ -1,0 +1,400 @@
+"""Behavioural contract of the BUNDLED aplexer binary (issue #2543).
+
+``test_aplexer_resolution.py`` proves *which* ``a`` we run. This file proves
+*what that ``a`` does* — and it exists because the version string provably
+cannot answer that question.
+
+Why a version check is not enough
+---------------------------------
+
+While #2543 was in review, aplexer's ``main`` sat 143 commits past the
+``v0.1.1`` tag while STILL self-reporting ``a --version`` -> ``0.1.1``. The
+published 0.1.1 wheel and the build every PocketShell host actually ran were
+therefore indistinguishable by version, and pinning 0.1.1 under the D22 hard
+cut (the bundled copy is the ONLY copy) would have silently DOWNGRADED every
+host. Two post-0.1.1 fixes the real create-agent path depends on were missing:
+
+* ``ee4b957`` — profile ``executable`` override (argv[0]) for Codex variants.
+  0.1.1 accepts the key and then IGNORES it, so
+  ``[profiles.zcodex] engine="codex", executable="zcodex"`` resolved argv[0]
+  to ``codex`` and ``pocketshell sessions create --backend aplexer --engine
+  codex --profile zcodex`` died with
+  ``a: command is not executable or was not found in PATH: codex``.
+* ``d13ecb2`` — preserve the provider environment for plain ``shell``
+  launches. 0.1.1 stripped 71 provider vars from every shell session.
+
+So these tests pin BEHAVIOUR, against the real bundled binary, with their own
+config fixture (``APLEXER_CONFIG``) — never the maintainer's personal
+``~/.config/aplexer/config.toml``, which would make them pass on exactly one
+machine. Every assertion here was verified to fail on published aplexer 0.1.1
+and pass on 0.1.2; a future pin that regresses fails loudly instead of
+shipping a silent downgrade.
+
+They run in the ``Python utility tests`` job (``tests.yml``), on Linux, with
+no Docker service or fixture port — the same gate the rest of this suite uses.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import tomllib
+import uuid
+from pathlib import Path
+from typing import Any, Sequence
+
+import pytest
+
+from pocketshell import aplexer as _aplexer
+
+PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="aplexer publishes Linux wheels only; the pin is marked sys_platform=='linux'",
+)
+
+# Exactly the `a` surface pocketshell drives, read off the call sites:
+#   sessions.aplexer_start_argv / _create_on_aplexer  -> start
+#   sessions._aplexer_snapshot / session_enum         -> snapshot, list
+#   engines.py / profiles.py                          -> engines, profiles
+#   agents.py::launch_agent shim                      -> launch-spec
+#   sessions.py attach / kill                         -> attach, kill
+# A future pin that drops any of these (or renames a flag) breaks the CLI at
+# runtime with no compile-time signal, so assert the surface exists.
+REQUIRED_SURFACE: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("start", ("--workspace", "--tag", "--engine", "--profile")),
+    ("snapshot", ()),
+    ("list", ()),
+    ("engines", ()),
+    ("profiles", ()),
+    ("launch-spec", ("--engine", "--cwd", "--profile", "--no-skip-permissions")),
+    ("attach", ("--workspace", "--tag")),
+    ("kill", ("--workspace", "--tag")),
+)
+
+
+def bundled_a() -> str:
+    """The pinned, bundled ``a`` — never a host copy, never PATH.
+
+    Fails (does not skip) when it is missing: on Linux an absent bundled
+    console-script is a packaging-integrity error, which is exactly the class
+    of problem #2543 is about.
+    """
+    report = _aplexer.resolve_a({"PATH": ""})
+    if report.path is None:
+        pytest.fail(
+            "no bundled aplexer console-script next to the interpreter; "
+            f"tried {report.tried}"
+        )
+    expected = str(Path(sys.executable).parent / "a")
+    assert report.path == expected, (
+        "the binary under contract test must be the BUNDLED one "
+        f"({expected}), got {report.path} via {report.source}"
+    )
+    return report.path
+
+
+def _pinned_version() -> str:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    reqs = [
+        r
+        for r in data["project"]["dependencies"]
+        if r.split(";")[0].strip().startswith("aplexer")
+    ]
+    assert len(reqs) == 1, f"expected exactly one aplexer requirement, got {reqs}"
+    return reqs[0].split(";")[0].strip().split("==", 1)[1]
+
+
+@pytest.fixture
+def aplexer_fixture(tmp_path: Path):
+    """A throwaway aplexer config + a minimal env that runs against it.
+
+    ``APLEXER_CONFIG`` is aplexer's own explicit config override
+    (``aplexer/src/lib.rs``), so the contract is asserted against OUR fixture
+    profiles, not whatever the developer has in ``~/.config/aplexer``.
+
+    ``PATH`` holds the system dirs only — no ``a``, no ``aplexer`` — so a host
+    copy cannot answer for the bundled one, and ``XDG_RUNTIME_DIR`` is
+    deliberately absent: the autouse conftest fixture points it deep under the
+    pytest tmp root, and aplexer's ``$XDG_RUNTIME_DIR/aplexer/sessions/<uuid>/
+    control.sock`` then exceeds the 108-byte AF_UNIX limit, killing the worker
+    for reasons unrelated to this contract.
+    """
+
+    class Fixture:
+        def __init__(self) -> None:
+            self.binary = bundled_a()
+            self.config = tmp_path / "aplexer-config.toml"
+            self.home = tmp_path / "aplexer-home"
+            self.workspace = tmp_path / "ws"
+            for directory in (self.home, self.workspace):
+                directory.mkdir(exist_ok=True)
+            self.env = {
+                "PATH": "/usr/bin:/bin",
+                "HOME": str(self.home),
+                "TERM": "dumb",
+                "APLEXER_CONFIG": str(self.config),
+            }
+
+        def write_config(self, body: str) -> None:
+            self.config.write_text(body, encoding="utf-8")
+
+        def run(self, args: Sequence[str], *, timeout: float = 60) -> Any:
+            if not self.config.exists():
+                self.write_config("version = 1\n")
+            return subprocess.run(
+                [self.binary, *args],
+                capture_output=True,
+                text=True,
+                env=dict(self.env),
+                cwd=str(self.workspace),
+                timeout=timeout,
+            )
+
+        def json(self, args: Sequence[str], *, timeout: float = 60) -> Any:
+            completed = self.run(["--json", *args], timeout=timeout)
+            assert completed.returncode == 0, (
+                f"`a --json {' '.join(args)}` exited {completed.returncode}: "
+                f"{completed.stderr or completed.stdout}"
+            )
+            return json.loads(completed.stdout)
+
+    return Fixture()
+
+
+# ---------------------------------------------------------------------------
+# ee4b957 — the profile `executable` override (the reviewer's blocker)
+# ---------------------------------------------------------------------------
+
+
+def test_bundled_aplexer_honours_the_profile_executable_override(aplexer_fixture) -> None:
+    """argv[0] comes from the profile's ``executable``, engine args survive.
+
+    Fixture shape of the maintainer's real ``[profiles.zcodex]``: the builtin
+    ``codex`` engine plus an ``executable`` override. Published 0.1.1 resolves
+    argv[0] to ``codex`` here (verified); 0.1.2 resolves the override.
+    """
+    aplexer_fixture.write_config(
+        "version = 1\n"
+        "[profiles.ps2543codex]\n"
+        'engine = "codex"\n'
+        'executable = "ps2543-codex-variant"\n'
+    )
+
+    spec = aplexer_fixture.json(
+        ["launch-spec", "--engine", "codex", "--profile", "ps2543codex"]
+    )
+
+    argv = spec["argv"]
+    assert argv[0] == "ps2543-codex-variant", (
+        "the bundled aplexer ignored the profile `executable` override — this "
+        "is aplexer ee4b957, missing from published 0.1.1, and it breaks "
+        "`sessions create --engine codex --profile <codex-variant>` with "
+        "\"command is not executable or was not found in PATH: codex\". "
+        f"Full argv: {argv}"
+    )
+    assert "-c" in argv and "check_for_update_on_startup=false" in argv, (
+        "`executable` overrides ONLY argv[0]; the engine's own default "
+        f"arguments must survive. Full argv: {argv}"
+    )
+    assert "--dangerously-bypass-approvals-and-sandbox" in argv, (
+        "the engine's skip-permissions argv must still be appended by default"
+    )
+
+
+def test_bundled_aplexer_profiles_json_exposes_the_executable_field(
+    aplexer_fixture,
+) -> None:
+    """``a --json profiles`` reports ``executable``, so the field is real.
+
+    Published 0.1.1 omits the key entirely from every profile record, which is
+    what made the downgrade invisible: the config parses, the profile lists,
+    and only the resolved argv is wrong.
+    """
+    aplexer_fixture.write_config(
+        "version = 1\n"
+        "[profiles.ps2543codex]\n"
+        'engine = "codex"\n'
+        'executable = "ps2543-codex-variant"\n'
+    )
+
+    profiles = aplexer_fixture.json(["profiles"])
+
+    assert "ps2543codex" in profiles, profiles
+    record = profiles["ps2543codex"]
+    assert "executable" in record, (
+        "`a --json profiles` does not expose `executable`; the bundled build "
+        f"predates aplexer ee4b957. Record: {record}"
+    )
+    assert record["executable"] == "ps2543-codex-variant"
+
+
+def test_bundled_aplexer_start_launches_the_profile_executable(aplexer_fixture) -> None:
+    """End-to-end: a real ``a start`` runs the OVERRIDE, not the engine default.
+
+    The reviewer's blocker manifested at ``a start``, not at ``launch-spec``,
+    so reproduce it there on the real binaries. The fixture engine's own
+    command is a binary that deliberately does not exist, so a build without
+    ee4b957 fails with the maintainer's exact error shape
+    (``a: command is not executable or was not found in PATH: …``) — verified
+    against published 0.1.1 — while a correct build runs the override and
+    leaves a marker file behind.
+    """
+    marker = aplexer_fixture.workspace.parent / "ps2543-executable-ran"
+    shim = aplexer_fixture.workspace.parent / "ps2543-shim"
+    shim.write_text(
+        "#!/bin/sh\n"
+        f'echo ran > "{marker}"\n'
+        "exec sleep 60\n",
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    aplexer_fixture.write_config(
+        "version = 1\n"
+        "[engines.ps2543engine]\n"
+        'command = ["ps2543-engine-default-absent"]\n'
+        "[profiles.ps2543profile]\n"
+        'engine = "ps2543engine"\n'
+        f'executable = "{shim}"\n'
+    )
+    tag = f"ps2543c-{uuid.uuid4().hex[:8]}"
+
+    started = aplexer_fixture.run(
+        [
+            "--json", "start",
+            "--workspace", str(aplexer_fixture.workspace),
+            "--tag", tag,
+            "--engine", "ps2543engine",
+            "--profile", "ps2543profile",
+        ]
+    )
+    try:
+        assert started.returncode == 0, (
+            "`a start` refused the profile `executable` override: "
+            f"{started.stderr.strip() or started.stdout.strip()}"
+        )
+        record = json.loads(started.stdout)
+        assert record.get("command") == [str(shim)], (
+            "the started session's command must be the profile override, not "
+            f"the engine default: {record.get('command')}"
+        )
+        assert record.get("phase") == "running", (
+            f"the worker did not come up: {record.get('phase')} / {record.get('error')}"
+        )
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline and not marker.exists():
+            time.sleep(0.1)
+        assert marker.exists(), (
+            "the overridden executable never ran — `a start` reported success "
+            "without launching the profile's binary"
+        )
+    finally:
+        aplexer_fixture.run(
+            ["kill", "--workspace", str(aplexer_fixture.workspace), "--tag", tag]
+        )
+
+
+# ---------------------------------------------------------------------------
+# d13ecb2 — provider environment preserved for plain shell launches
+# ---------------------------------------------------------------------------
+
+
+def test_bundled_aplexer_preserves_provider_env_for_shell_launches(
+    aplexer_fixture,
+) -> None:
+    """A plain ``shell`` session keeps its ambient/provider environment.
+
+    Published 0.1.1 unset 71 provider vars for the literal ``shell`` engine
+    (verified), so every non-agent session created through a 0.1.1 bundle
+    would silently lose them.
+    """
+    spec = aplexer_fixture.json(["launch-spec", "--engine", "shell"])
+
+    assert spec["env_unset"] == [], (
+        "the bundled aplexer strips the provider environment from plain "
+        "`shell` launches; this is aplexer d13ecb2, missing from published "
+        f"0.1.1. Stripped: {spec['env_unset']}"
+    )
+
+
+def test_bundled_aplexer_still_strips_provider_env_for_agent_engines(
+    aplexer_fixture,
+) -> None:
+    """…and the strip policy still applies to agent engines (no over-correction)."""
+    spec = aplexer_fixture.json(["launch-spec", "--engine", "codex"])
+
+    unset = set(spec["env_unset"])
+    assert {"OPENAI_API_KEY", "ANTHROPIC_API_KEY"} <= unset, (
+        "agent engines must still drop provider API keys so subscription auth "
+        f"is used; unset only {sorted(unset)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The `a` surface pocketshell actually drives
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("subcommand,flags", REQUIRED_SURFACE)
+def test_bundled_aplexer_exposes_the_surface_pocketshell_drives(
+    aplexer_fixture, subcommand: str, flags: tuple[str, ...]
+) -> None:
+    """Every subcommand + flag the CLI invokes exists in the bundled build.
+
+    ``launch-spec`` is hidden from ``a --help`` (it is aplexer's integration
+    point for this CLI), so probe each subcommand directly rather than
+    scraping the top-level command list.
+    """
+    completed = aplexer_fixture.run([subcommand, "--help"])
+
+    assert completed.returncode == 0, (
+        f"the bundled aplexer has no `a {subcommand}`; pocketshell calls it. "
+        f"{completed.stderr or completed.stdout}"
+    )
+    help_text = completed.stdout
+    missing = [flag for flag in flags if flag not in help_text]
+    assert not missing, (
+        f"`a {subcommand}` no longer accepts {missing}; pocketshell passes "
+        f"them. Help:\n{help_text}"
+    )
+
+
+def test_bundled_aplexer_reports_the_pinned_version(aplexer_fixture) -> None:
+    """Sanity only: the bundled binary IS the pinned wheel.
+
+    Deliberately last and deliberately weak — the whole reason this file
+    exists is that this assertion passed for a build missing the two fixes
+    above. It guards "did the wheel install at all", nothing more; the
+    behavioural tests are the contract.
+    """
+    completed = aplexer_fixture.run(["--version"])
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.split() == ["a", _pinned_version()], (
+        f"bundled `a --version` is {completed.stdout.strip()!r}, pyproject "
+        f"pins {_pinned_version()}"
+    )
+
+
+def test_contract_env_never_reads_the_developers_aplexer_config(
+    aplexer_fixture,
+) -> None:
+    """The fixture config is authoritative — not ``~/.config/aplexer``.
+
+    A contract test that silently fell back to the maintainer's own profiles
+    would pass on exactly one machine, which is what the reviewer warned
+    against.
+    """
+    aplexer_fixture.write_config("version = 1\n")
+
+    profiles = aplexer_fixture.json(["profiles"])
+
+    assert profiles == {}, (
+        "the bundled `a` read profiles from somewhere other than "
+        f"APLEXER_CONFIG: {profiles}"
+    )
+    assert aplexer_fixture.env["HOME"] != os.path.expanduser("~")

--- a/tools/pocketshell/tests/test_aplexer_resolution.py
+++ b/tools/pocketshell/tests/test_aplexer_resolution.py
@@ -1,0 +1,382 @@
+"""Resolution of the ``a`` (aplexer) binary shipped WITH the pocketshell CLI.
+
+Issue #2543. aplexer is now a pinned, Linux-marked hard dependency
+(``pyproject.toml``), so ``uv tool install pocketshell`` also delivers the
+``a`` and ``aplexer`` console-scripts into the SAME ``bin`` directory as the
+interpreter running pocketshell. These tests pin the resolution ORDER that
+makes that install usable from the app's non-interactive SSH command, where
+``~/bin`` is not on ``PATH``:
+
+    APLEXER_BIN  >  bundled copy next to sys.executable   (and NOTHING else)
+
+The ``PATH`` lookup is HARD-CUT (D22), exactly like the pinned ``quse``: a
+separately-installed ``a`` — host package, `cargo install`, `~/bin` copy —
+must never be load-bearing, so resolution fails loud instead of falling back
+to it.
+
+The reported failure (#2543) was a pure PATH problem: ``which_a`` only ever
+did ``shutil.which("a", path=env["PATH"])``, so a correctly installed aplexer
+that simply was not on the non-interactive PATH produced
+"`a` (aplexer) is not installed on this host".
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tomllib
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pocketshell import aplexer as _aplexer
+
+PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _fake_interpreter_dir(tmp_path: Path, *, with_a: bool) -> Path:
+    """A venv-shaped ``bin`` dir; optionally holding a bundled ``a``."""
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "python").write_text("#!/bin/sh\n")
+    if with_a:
+        for name in ("a", "aplexer"):
+            binary = bin_dir / name
+            binary.write_text("#!/bin/sh\n")
+            binary.chmod(0o755)
+    return bin_dir
+
+
+# ---------------------------------------------------------------------------
+# Reported defect (#2543): a bundled aplexer that is not on PATH
+# ---------------------------------------------------------------------------
+
+
+def test_bundled_a_resolves_when_path_has_no_aplexer(tmp_path: Path) -> None:
+    """RED before #2543: the app's non-interactive SSH PATH has no ``a``.
+
+    Reproduces the maintainer's report verbatim: aplexer IS installed (here,
+    next to the interpreter, exactly where the pinned dependency puts it) but
+    the process ``PATH`` — the app's non-interactive SSH PATH, which does not
+    contain the install dir — has no ``a`` anywhere on it. Resolution must
+    still find the bundled copy.
+    """
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=True)
+    empty_path_dir = tmp_path / "empty"
+    empty_path_dir.mkdir()
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        resolved = _aplexer.which_a({"PATH": str(empty_path_dir)})
+
+    assert resolved == str(bin_dir / "a"), (
+        "#2543 symptom: a bundled `a` that is not on the non-interactive PATH "
+        "must still resolve"
+    )
+
+
+def test_bundled_worker_ships_next_to_bundled_a(tmp_path: Path) -> None:
+    """The WORKER binary must resolve too, not just ``a`` (#2543 gap 2).
+
+    ``aplexer/src/lib.rs::worker_executable`` looks for the ``aplexer`` worker
+    as a sibling of ``current_exe`` (else bare ``aplexer`` on PATH), so a
+    resolved ``a`` with no sibling worker cannot start a session. The pinned
+    wheel ships both console-scripts into the same ``bin`` dir, so the sibling
+    always exists; assert the resolver reports it.
+    """
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=True)
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        report = _aplexer.resolve_a({"PATH": ""})
+
+    assert report.path == str(bin_dir / "a")
+    assert report.worker == str(bin_dir / "aplexer")
+
+
+def test_bundled_a_without_sibling_worker_is_reported(tmp_path: Path) -> None:
+    """A half-installed bundle (``a`` only) is resolvable but worker-less."""
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=True)
+    (bin_dir / "aplexer").unlink()
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        report = _aplexer.resolve_a({"PATH": ""})
+
+    assert report.path == str(bin_dir / "a")
+    assert report.worker is None
+
+
+# ---------------------------------------------------------------------------
+# Resolution order
+# ---------------------------------------------------------------------------
+
+
+def test_aplexer_bin_overrides_bundled_copy(tmp_path: Path) -> None:
+    """``APLEXER_BIN`` still wins over everything (#2543 AC)."""
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=True)
+    override = tmp_path / "custom-a"
+    override.write_text("#!/bin/sh\n")
+    override.chmod(0o755)
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        report = _aplexer.resolve_a({"APLEXER_BIN": str(override), "PATH": str(bin_dir)})
+
+    assert report.path == str(override)
+    assert report.source == "APLEXER_BIN"
+
+
+def test_bundled_copy_wins_over_path(tmp_path: Path) -> None:
+    """The pinned bundled copy beats a host-level ``a`` on PATH.
+
+    Same rule the pinned `quse` follows (`usage.py::_resolve_quse_binary`):
+    a host upgrade must not silently shadow the version pocketshell pinned.
+    """
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=True)
+    path_dir = tmp_path / "elsewhere"
+    path_dir.mkdir()
+    decoy = path_dir / "a"
+    decoy.write_text("#!/bin/sh\n")
+    decoy.chmod(0o755)
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        report = _aplexer.resolve_a({"PATH": str(path_dir)})
+
+    assert report.path == str(bin_dir / "a")
+    assert report.source == "bundled"
+
+
+def test_path_only_aplexer_is_never_used(tmp_path: Path) -> None:
+    """#2543 AC: an ``a`` present ONLY on PATH must NOT be used.
+
+    This is the "no separate install" property stated as an assertion. The
+    PATH lookup is hard-cut (D22): a separately-installed aplexer — host
+    package, ``cargo install``, ``~/bin`` copy — is never load-bearing, so a
+    missing bundled copy fails loud instead of silently using it.
+    """
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=False)
+    path_dir = tmp_path / "elsewhere"
+    path_dir.mkdir()
+    local_build = path_dir / "a"
+    local_build.write_text("#!/bin/sh\n")
+    local_build.chmod(0o755)
+    (path_dir / "aplexer").write_text("#!/bin/sh\n")
+    (path_dir / "aplexer").chmod(0o755)
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        # `which_a` first, deliberately: it is the pre-existing API, so this
+        # assertion is a behavioural red on the unfixed code (which returned
+        # the PATH copy), not an AttributeError on the new one.
+        resolved = _aplexer.which_a({"PATH": str(path_dir)})
+        assert resolved is None, (
+            "a separately-installed `a` on PATH must not be resolved — "
+            "aplexer ships WITH the CLI"
+        )
+        report = _aplexer.resolve_a({"PATH": str(path_dir)})
+
+    assert report.path is None
+    assert report.source is None
+
+
+def test_which_a_has_no_path_lookup_left(tmp_path: Path) -> None:
+    """D22 hard cut: ``shutil.which`` is GONE, not hidden behind a branch."""
+    source = Path(_aplexer.__file__).read_text(encoding="utf-8")
+    code = "\n".join(
+        line for line in source.splitlines() if not line.lstrip().startswith("#")
+    )
+    body = code.split('"""', 2)[-1]  # skip the module docstring, which cites it
+    assert "shutil" not in body, "the PATH lookup must be deleted, not conditioned"
+
+
+def test_unresolvable_reports_every_candidate_tried(tmp_path: Path) -> None:
+    """#2543 AC: the failure must name the candidate paths it tried."""
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=False)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        report = _aplexer.resolve_a({"PATH": str(empty)})
+
+    assert report.path is None
+    assert report.source is None
+    tried = " ".join(report.tried)
+    assert str(bin_dir / "a") in tried
+    assert "APLEXER_BIN" in tried
+    assert str(empty) not in tried, "PATH is not a candidate any more (D22 hard cut)"
+
+
+def test_resolved_dir_candidate_used_when_interpreter_is_a_symlink(
+    tmp_path: Path,
+) -> None:
+    """Console-scripts live next to the UNRESOLVED ``sys.executable``…
+
+    …but a layout where ``bin/python`` is a real file in the shared
+    interpreter dir must still be covered. Mirrors the second candidate
+    ``usage.py::_resolve_quse_binary`` keeps.
+    """
+    real_dir = tmp_path / "real" / "bin"
+    real_dir.mkdir(parents=True)
+    (real_dir / "python").write_text("#!/bin/sh\n")
+    for name in ("a", "aplexer"):
+        binary = real_dir / name
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+    link_dir = tmp_path / "link" / "bin"
+    link_dir.mkdir(parents=True)
+    (link_dir / "python").symlink_to(real_dir / "python")
+
+    with patch.object(sys, "executable", str(link_dir / "python")):
+        report = _aplexer.resolve_a({"PATH": ""})
+
+    assert report.path == str(real_dir / "a")
+
+
+# ---------------------------------------------------------------------------
+# Kill switches stay independent of resolution
+# ---------------------------------------------------------------------------
+
+
+def test_kill_switches_unaffected_by_bundled_resolution(tmp_path: Path) -> None:
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=True)
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        assert _aplexer.which_a({"PATH": ""}) is not None
+        assert _aplexer.enabled("sessions", {"POCKETSHELL_APLEXER": "0"}) is False
+        assert _aplexer.enabled("sessions", {"POCKETSHELL_APLEXER_SESSIONS": "0"}) is False
+        assert _aplexer.enabled("profiles", {"POCKETSHELL_APLEXER": "1"}) is True
+        # A master kill switch does NOT make the binary un-resolvable; the
+        # feature gate is what skips the probe (session_enum._probe_aplexer).
+        assert _aplexer.run_json(["snapshot"], env={"POCKETSHELL_APLEXER": "0"},
+                                 feature="sessions") is None
+
+
+# ---------------------------------------------------------------------------
+# Packaging: the pin, its marker, and the real installed console-scripts
+# ---------------------------------------------------------------------------
+
+
+def _aplexer_requirement() -> str:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    reqs = [r for r in data["project"]["dependencies"] if r.split(";")[0].strip().startswith("aplexer")]
+    assert len(reqs) == 1, f"expected exactly one aplexer requirement, got {reqs}"
+    return reqs[0]
+
+
+def test_aplexer_is_pinned_exactly() -> None:
+    """The pin is exact, like quse — a host upgrade must not reach us.
+
+    0.1.2, never 0.1.1: under the D22 hard cut the bundled wheel is the ONLY
+    aplexer this CLI can run, so pinning the older published wheel would
+    downgrade every host to a build missing the profile `executable` override
+    and the shell provider-env fix. ``test_aplexer_contract.py`` pins those
+    behaviours against the bundled binary, because `a --version` cannot
+    distinguish the two builds (both report 0.1.1).
+    """
+    requirement = _aplexer_requirement()
+    pin = requirement.split(";")[0].strip()
+    assert pin == "aplexer==0.1.2", pin
+
+
+def test_aplexer_dependency_marker_is_linux_only() -> None:
+    """#2543 AC: ``pip install pocketshell`` still resolves on macOS.
+
+    aplexer publishes manylinux wheels only (x86_64 + aarch64) and no sdist,
+    so an UNMARKED hard dependency would make the package uninstallable on
+    macOS/Windows. Marker check only — no macOS runner needed.
+    """
+    from packaging.markers import Marker
+
+    marker_text = _aplexer_requirement().split(";", 1)[1].strip()
+    marker = Marker(marker_text)
+
+    assert marker.evaluate({"sys_platform": "darwin", "platform_machine": "arm64"}) is False
+    assert marker.evaluate({"sys_platform": "win32", "platform_machine": "AMD64"}) is False
+    assert marker.evaluate({"sys_platform": "linux", "platform_machine": "x86_64"}) is True
+    assert marker.evaluate({"sys_platform": "linux", "platform_machine": "aarch64"}) is True
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="aplexer ships Linux wheels only")
+def test_pinned_aplexer_console_scripts_are_installed_next_to_interpreter() -> None:
+    """The pin really does land BOTH binaries in the interpreter's bin dir.
+
+    The analogue of ``test_usage.py``'s real-quse check: proves the packaging
+    claim against the actual installed environment, not a fake tmp layout.
+    """
+    report = _aplexer.resolve_a({"PATH": ""})
+    assert report.path is not None, (
+        "the pinned aplexer console-script must be installed next to the "
+        f"interpreter; tried {report.tried}"
+    )
+    assert report.source == "bundled"
+    assert report.worker is not None, "the `aplexer` worker must ship alongside `a`"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="aplexer ships Linux wheels only")
+def test_bundled_a_starts_a_session_with_no_aplexer_on_path(tmp_path: Path) -> None:
+    """End-to-end on the REAL bundled binaries with a stripped PATH.
+
+    This is the whole point of #2543: an environment whose PATH contains no
+    aplexer binary at all (the app's non-interactive SSH PATH) must still be
+    able to CREATE a session — which exercises the worker-binary sibling
+    lookup too, not merely "the CLI was found". The session is killed and its
+    whole registry (under a tmp HOME) is discarded with ``tmp_path``.
+    """
+    report = _aplexer.resolve_a({"PATH": ""})
+    if report.path is None:  # pragma: no cover - packaging integrity
+        pytest.fail(f"no bundled aplexer console-script; tried {report.tried}")
+    assert report.path == str(Path(sys.executable).parent / "a"), (
+        "the binary under test must be the BUNDLED one, not a host copy"
+    )
+
+    workspace = tmp_path / "ws"
+    home = tmp_path / "aplexer-home"
+    for directory in (workspace, home):
+        directory.mkdir()
+    tag = f"ps2543-{uuid.uuid4().hex[:8]}"
+    # A PATH with the standard system dirs ONLY — no `a`, no `aplexer` — and a
+    # throwaway HOME so the session registry dies with `tmp_path`.
+    #
+    # XDG_RUNTIME_DIR is deliberately NOT set (the autouse conftest fixture
+    # points it deep under the pytest tmp root): aplexer puts its control
+    # socket at $XDG_RUNTIME_DIR/aplexer/sessions/<uuid>/control.sock, and a
+    # long tmp prefix blows past the 108-byte AF_UNIX path limit, so the
+    # worker dies at startup for reasons that have nothing to do with #2543.
+    # Unset, aplexer picks its own short runtime dir.
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": str(home),
+        "TERM": "dumb",
+    }
+
+    started = subprocess.run(
+        [report.path, "--json", "start", "--workspace", str(workspace), "--tag", tag],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+    assert started.returncode == 0, (
+        "`a start` failed with a PATH holding no aplexer binaries: "
+        f"{started.stderr or started.stdout}"
+    )
+    record = json.loads(started.stdout)
+    session_id = str(record.get("id") or "")
+    assert session_id, f"no session id in {record}"
+    assert record.get("phase") == "running", (
+        f"the worker did not come up: {record.get('phase')} / {record.get('error')}"
+    )
+
+    try:
+        listed = subprocess.run(
+            [report.path, "--json", "list"],
+            capture_output=True, text=True, env=env, timeout=60,
+        )
+        assert listed.returncode == 0, listed.stderr
+        rows = json.loads(listed.stdout)
+        assert any(str(row.get("tag")) == tag for row in rows), (
+            f"session {tag} missing from `a list`"
+        )
+    finally:
+        subprocess.run(
+            [report.path, "kill", "--workspace", str(workspace), "--tag", tag],
+            capture_output=True, text=True, env=env, timeout=60,
+        )

--- a/tools/pocketshell/tests/test_profiles.py
+++ b/tools/pocketshell/tests/test_profiles.py
@@ -17,6 +17,7 @@ import logging
 import os
 import shlex
 import stat
+import sys
 import time
 
 import pytest
@@ -504,10 +505,8 @@ def test_probe_timeout_falls_back_to_native(fake_home, tmp_path, monkeypatch):
     assert {p.name for p in discovered} == {"Claude", "Claude (Z.AI)", "Codex"}
 
 
-def test_aplexer_profile_probe_uses_a_on_path(
-    fake_home, tmp_path, monkeypatch
-):
-    script = _install_fake_a(
+def _remote_laude_a(tmp_path, monkeypatch):
+    return _install_fake_a(
         tmp_path,
         monkeypatch,
         payload={
@@ -515,14 +514,56 @@ def test_aplexer_profile_probe_uses_a_on_path(
                 "engine": "claude",
                 "env": {"CLAUDE_CONFIG_DIR": "/srv/remote-laude"},
             }
-        }
+        },
     )
+
+
+def _interpreter_without_bundled_a(tmp_path, monkeypatch):
+    """Point ``sys.executable`` at a bin dir holding no bundled ``a``."""
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "python").write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "executable", str(bin_dir / "python"))
+    return bin_dir
+
+
+def test_aplexer_profile_probe_ignores_a_on_path(fake_home, tmp_path, monkeypatch):
+    """#2543 (D22 hard cut): a PATH-only ``a`` is NOT used any more.
+
+    This test used to assert the opposite (``…_uses_a_on_path``). aplexer now
+    ships WITH the pocketshell CLI as a pinned dependency, so a separately
+    installed ``a`` — the mode this change removes — must not be picked up:
+    with no bundled copy next to the interpreter, the probe is skipped and
+    native discovery stays authoritative.
+    """
+    script = _remote_laude_a(tmp_path, monkeypatch)
     monkeypatch.delenv("APLEXER_BIN", raising=False)
+    _interpreter_without_bundled_a(tmp_path, monkeypatch)
     environment = {
         "HOME": str(fake_home),
         "PATH": os.pathsep.join([str(script.parent), os.environ["PATH"]]),
         "POCKETSHELL_APLEXER_PROFILES": "1",
     }
+
+    assert profiles._aplexer_profiles(environment) is None
+
+
+def test_aplexer_profile_probe_uses_the_bundled_a(fake_home, tmp_path, monkeypatch):
+    """The bundled copy next to ``sys.executable`` IS what gets probed."""
+    script = _remote_laude_a(tmp_path, monkeypatch)
+    monkeypatch.delenv("APLEXER_BIN", raising=False)
+    bin_dir = _interpreter_without_bundled_a(tmp_path, monkeypatch)
+    bundled = bin_dir / "a"
+    bundled.write_text(script.read_text(encoding="utf-8"), encoding="utf-8")
+    bundled.chmod(bundled.stat().st_mode | stat.S_IEXEC)
+    environment = {
+        # No aplexer anywhere on PATH — only the system dirs the stub's own
+        # `/bin/sh` body needs. Resolution must come from the bundled copy.
+        "HOME": str(fake_home),
+        "PATH": "/usr/bin:/bin",
+        "POCKETSHELL_APLEXER_PROFILES": "1",
+    }
+
     mapped = profiles._aplexer_profiles(environment)
     assert mapped is not None
     assert [(item.name, item.config_dir) for item in mapped] == [

--- a/tools/pocketshell/tests/test_sessions_attach.py
+++ b/tools/pocketshell/tests/test_sessions_attach.py
@@ -28,6 +28,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+from pocketshell import aplexer as _aplexer
 from pocketshell.sessions import sessions_group
 
 FAKE_TMUXCTL = "/fake/tmuxctl"
@@ -139,7 +140,7 @@ def _invoke(
 
 
 def test_attach_aplexer_display_name_execs_a_attach(install_fake_a, socket_dir) -> None:
-    install_fake_a(
+    script = install_fake_a(
         snapshot=[
             {
                 "id": "sess-abc12345",
@@ -155,11 +156,12 @@ def test_attach_aplexer_display_name_execs_a_attach(install_fake_a, socket_dir) 
     result = _invoke(harness, ["attach", "toyaikit:codex"])
 
     assert result.exit_code == 0, result.output
-    assert harness.exec_calls == [["a", "attach", "sess-abc12345"]]
+    # #2543: the RESOLVED binary is exec'd, not a bare "a" from PATH.
+    assert harness.exec_calls == [[str(script), "attach", "sess-abc12345"]]
 
 
 def test_attach_aplexer_id_prefix_execs_a_attach(install_fake_a, socket_dir) -> None:
-    install_fake_a(
+    script = install_fake_a(
         snapshot=[
             {
                 "id": "abcdef0123456789",
@@ -173,7 +175,7 @@ def test_attach_aplexer_id_prefix_execs_a_attach(install_fake_a, socket_dir) -> 
     result = _invoke(harness, ["attach", "abcdef01"])
 
     assert result.exit_code == 0, result.output
-    assert harness.exec_calls == [["a", "attach", "abcdef0123456789"]]
+    assert harness.exec_calls == [[str(script), "attach", "abcdef0123456789"]]
 
 
 def test_attach_short_id_prefix_is_not_a_match(install_fake_a, socket_dir) -> None:
@@ -207,11 +209,15 @@ def test_attach_missing_a_binary_exits_127(install_fake_a, socket_dir) -> None:
     )
     harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
 
-    with patch("pocketshell.sessions._resolve_aplexer_binary", return_value=None):
+    unresolved = _aplexer.AplexerResolution(
+        tried=("APLEXER_BIN (unset)", "/opt/venv/bin/a (bundled, missing)")
+    )
+    with patch("pocketshell.sessions._resolve_aplexer", return_value=unresolved):
         result = _invoke(harness, ["attach", "toyaikit:codex"])
 
     assert result.exit_code == 127, result.output
-    assert "`a` (aplexer) is not installed" in result.output
+    assert "could not resolve the `a` (aplexer) binary" in result.output
+    assert "/opt/venv/bin/a (bundled, missing)" in result.output
     assert harness.exec_calls == []
 
 

--- a/tools/pocketshell/tests/test_sessions_create_routing.py
+++ b/tools/pocketshell/tests/test_sessions_create_routing.py
@@ -151,6 +151,13 @@ def use_aplexer_backend(
     start: AplexerStub,
     snapshot: Any = None,
 ) -> None:
+    monkeypatch.setattr(
+        sessions._aplexer,
+        "resolve_a",
+        lambda env=None: sessions._aplexer.AplexerResolution(
+            path="/fake/a", source="bundled", worker="/fake/aplexer"
+        ),
+    )
     monkeypatch.setattr(sessions._aplexer, "which_a", lambda env=None: "/fake/a")
     monkeypatch.setattr(sessions, "_aplexer_snapshot", lambda: snapshot)
     monkeypatch.setattr(sessions, "_run_aplexer", start)
@@ -563,10 +570,24 @@ def test_malformed_config_human_path_writes_stderr(
     assert "not valid TOML" in result.stderr
 
 
+def _unresolvable_aplexer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sessions._aplexer,
+        "resolve_a",
+        lambda env=None: sessions._aplexer.AplexerResolution(
+            tried=(
+                "APLEXER_BIN (unset)",
+                "/opt/venv/bin/a (bundled, missing)",
+                "PATH=/usr/bin:/bin (no `a`)",
+            )
+        ),
+    )
+
+
 def test_missing_aplexer_binary_json_error_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(sessions._aplexer, "which_a", lambda env=None: None)
+    _unresolvable_aplexer(monkeypatch)
 
     result = CliRunner().invoke(
         sessions_group, ["create", "work", "--backend", "aplexer", "--json"]
@@ -574,6 +595,29 @@ def test_missing_aplexer_binary_json_error_envelope(
 
     assert result.exit_code == 127
     assert "aplexer" in envelope(result)["error"]
+
+
+def test_unresolvable_aplexer_error_names_candidate_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2543 AC: the aplexer-missing error names the candidates it tried.
+
+    The old message claimed aplexer "is not installed on this host" even when
+    it WAS installed and merely off the non-interactive SSH PATH — the exact
+    inversion of the truth the maintainer hit. It must now report what was
+    checked, and must not assert a bare "not installed".
+    """
+    _unresolvable_aplexer(monkeypatch)
+
+    result = CliRunner().invoke(
+        sessions_group, ["create", "work", "--backend", "aplexer", "--json"]
+    )
+
+    message = envelope(result)["error"]
+    assert "is not installed on this host" not in message
+    assert "APLEXER_BIN (unset)" in message
+    assert "/opt/venv/bin/a (bundled, missing)" in message
+    assert "PATH=/usr/bin:/bin (no `a`)" in message
 
 
 # ----- aplexer arm ----------------------------------------------------

--- a/tools/pocketshell/tests/test_sessions_kill.py
+++ b/tools/pocketshell/tests/test_sessions_kill.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+from pocketshell import aplexer as _aplexer
 from pocketshell.sessions import sessions_group
 
 FAKE_TMUXCTL = "/fake/tmuxctl"
@@ -85,7 +86,9 @@ class Harness:
                     stderr=f"prefix match is not allowed: {target}\n",
                 )
             return _completed()
-        if args[0] == "a" and "kill" in args:
+        # #2543: argv[0] is the RESOLVED aplexer binary (the fixture's stub via
+        # APLEXER_BIN), never a bare "a" that execvp would find on PATH.
+        if Path(args[0]).name in {"a", "fake-a"} and "kill" in args:
             self.events.append(("a-kill", args))
             if self.a_kill_fails:
                 return _completed(returncode=1, stderr="no such session\n")
@@ -270,7 +273,7 @@ def test_kill_json_not_found_is_an_error_envelope(socket_dir) -> None:
 
 
 def test_kill_aplexer_display_name_runs_a_kill(install_fake_a, socket_dir) -> None:
-    install_fake_a(
+    script = install_fake_a(
         snapshot=[
             {
                 "id": "sess-abc12345",
@@ -286,12 +289,12 @@ def test_kill_aplexer_display_name_runs_a_kill(install_fake_a, socket_dir) -> No
     result = _invoke(harness, ["kill", "toyaikit:codex"])
 
     assert result.exit_code == 0, result.output
-    assert harness.a_kill_calls == [["a", "kill", "sess-abc12345"]]
+    assert harness.a_kill_calls == [[str(script), "kill", "sess-abc12345"]]
     assert harness.kill_calls == []
 
 
 def test_kill_aplexer_id_prefix_runs_a_kill(install_fake_a, socket_dir) -> None:
-    install_fake_a(
+    script = install_fake_a(
         snapshot=[
             {
                 "id": "abcdef0123456789",
@@ -305,7 +308,7 @@ def test_kill_aplexer_id_prefix_runs_a_kill(install_fake_a, socket_dir) -> None:
     result = _invoke(harness, ["kill", "abcdef01"])
 
     assert result.exit_code == 0, result.output
-    assert harness.a_kill_calls == [["a", "kill", "abcdef0123456789"]]
+    assert harness.a_kill_calls == [[str(script), "kill", "abcdef0123456789"]]
 
 
 def test_kill_missing_a_binary_exits_127(install_fake_a, socket_dir) -> None:
@@ -320,11 +323,15 @@ def test_kill_missing_a_binary_exits_127(install_fake_a, socket_dir) -> None:
     )
     harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
 
-    with patch("pocketshell.sessions._resolve_aplexer_binary", return_value=None):
+    unresolved = _aplexer.AplexerResolution(
+        tried=("APLEXER_BIN (unset)", "/opt/venv/bin/a (bundled, missing)")
+    )
+    with patch("pocketshell.sessions._resolve_aplexer", return_value=unresolved):
         result = _invoke(harness, ["kill", "toyaikit:codex"])
 
     assert result.exit_code == 127, result.output
-    assert "`a` (aplexer) is not installed" in result.output
+    assert "could not resolve the `a` (aplexer) binary" in result.output
+    assert "/opt/venv/bin/a (bundled, missing)" in result.output
     assert harness.a_kill_calls == []
 
 

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-08-28T22:00:00Z"
+exclude-newer = "2026-09-05T23:00:00Z"
 
 [[package]]
 name = "annotated-doc"
@@ -12,6 +12,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "aplexer"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aplexer-client" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/56/19d475730a654df90a2b18af5f1dd85070c087ebbb6a4c6ef8909775ddb7/aplexer-0.1.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:a4c153dcdbefe70ba1738c18e712e83ba06b408f0eabf7a4d21922fc85f4fd90", size = 2627286, upload-time = "2026-09-05T22:38:07.758Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1d/682bdf6071269466302e0d0b298b412521b5ad79c88d7eec985fb713d417/aplexer-0.1.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:bd19cde5608cb248a883326745484957fcbf3d79f58d66df4abeac237f270c6f", size = 2726923, upload-time = "2026-09-05T22:38:08.988Z" },
+]
+
+[[package]]
+name = "aplexer-client"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/33/03cb46de17f575648d7cc72ee9021b4199bb1f77c7eb1f10e3eb878b46a5/aplexer_client-0.1.2-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d4f0a217ddaf9f8df2157bc2538b98e5e5140207558493cffb02a221aeb5733f", size = 1172032, upload-time = "2026-09-05T22:38:02.78Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c9/88332107b9f4d303d1827749be93d7fea03df768fee7e3e64b4e5747b4b9/aplexer_client-0.1.2-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3280caf342618c8ceca3bc7e9788fbe29ae24ab4053cb3cc04e0ba151eccbb1b", size = 1202575, upload-time = "2026-09-05T22:38:04.362Z" },
 ]
 
 [[package]]
@@ -317,6 +338,7 @@ name = "pocketshell"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aplexer", marker = "sys_platform == 'linux'" },
     { name = "click" },
     { name = "google-auth" },
     { name = "pyyaml" },
@@ -341,6 +363,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aplexer", marker = "sys_platform == 'linux'", specifier = "==0.1.2" },
     { name = "click", specifier = ">=8.2.0" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },


### PR DESCRIPTION
Closes #2543.

## Why

Creating an Agent session from the phone failed with:

> pocketshell: `a` (aplexer) is not installed on this host, but the backend routing selected it.

aplexer **was** installed, at `~/bin/a`. Two independent gaps:

1. `which_a` did `shutil.which("a", path=env["PATH"])`, and the app drives the host CLI over a **non-interactive** SSH command whose PATH is `~/.local/bin:/usr/local/sbin:…`. A correctly installed `a` outside those dirs was invisible, and the error said the opposite of the truth.
2. Only `a` had been installed, not the sibling `aplexer` worker it needs to start a session. Even a found `a` could not have worked.

Maintainer's ask: *"aplexer should be a part of pocketshell cli it doesn't need to be installed separately"*, restated as *"it should be a dependency of pocketshell and shouldn't be installed separately"*.

## What changed

aplexer is now a pinned dependency, resolved next to `sys.executable` exactly like the pinned `quse`, so `uv tool install pocketshell` delivers both binaries and PATH stops mattering.

The PATH lookup is a **hard cut** (D22) — `shutil.which` is deleted, not conditioned. A host-level or locally-built `a` must not shadow the bundled copy, and an absent bundled copy fails loud as a packaging-integrity error rather than a "please install aplexer" nag. `APLEXER_BIN` remains the one explicit override.

A test asserts a binary present **only** on PATH is **not** used. That assertion is what encodes "never installed separately".

`sessions attach` and `sessions kill` invoked a bare `"a"` and relied on the same PATH lookup wearing a different hat; both now use the resolved path.

## The version this pins, and why it is not 0.1.1

Review caught that pinning the then-published 0.1.1 would have **silently downgraded** this host. The local build was 143 commits ahead, both self-reported `0.1.1`, and the profile `executable` override was missing — so `sessions create --engine codex --profile zcodex` resolved argv[0] to `codex` and failed with `command is not executable or was not found in PATH`. That is the maintainer's daily path.

aplexer 0.1.2 was cut to fix it. It took four attempts and surfaced three unrelated defects, each of which had never run in a release gate because the earlier one always failed first:

- a real startup race in `start_session` (`alexeygrigorev/aplexer@6fed5ba`) — a fast-exiting workload was reported as a startup failure
- a test whose descriptor budget had one unit of slack (`@5dbb0d9`)
- a publish action whose bundled tooling could not read modern wheel metadata (`@cd1ddf8`)

## Testing

Because a version string could **not** distinguish those two builds, `test_aplexer_contract.py` pins the bundled binary's *behaviour* through production `resolve_a`, using a throwaway `APLEXER_CONFIG` fixture so it does not depend on the maintainer's own profiles. Driven red against a 0.1.1 bundle this run: 5 failures, one reproducing the exact error above.

- `1268 passed, 4 skipped`
- `uv lock --check` clean; lock diff is exactly the aplexer bump plus the `aplexer-client` node 0.1.2 newly declares, zero drift across the other 26 packages
- End-to-end `sessions create --backend aplexer` over non-interactive SSH with a stripped PATH, with `/proc/<worker_pid>/exe` confirming the **bundled** worker answered rather than the host's own `a`

Reviewer independently reproduced the red contract test, the lock-diff cleanliness, and the end-to-end profile case.

## Notes

`[tool.uv] exclude-newer` moves to `2026-09-05T23:00:00Z` so 0.1.2 is visible to the resolver, following the precedent documented in that comment block for the quse 0.0.15 pin.

aplexer publishes Linux wheels only, hence `sys_platform == 'linux'`. 0.1.2 ships `manylinux_2_28` where 0.1.1 shipped `manylinux_2_17`, raising the CLI's glibc floor from 2.17 to 2.28. Reviewer and I independently concluded document-not-block: it fails loudly at install time rather than silently, and every excluded distro is EOL.

**Heads-up for anyone installing on this box:** the global `uv exclude-newer = "7 days"` in `~/.config/uv/uv.toml` makes a fresh `uv tool install pocketshell` fail with `there is no version of aplexer==0.1.2` until 2026-09-12. It reads like a broken pin but is host config; pass `--exclude-newer`. CI and in-project `uv lock`/`uv run --frozen` are unaffected.