### PR TITLE
fix: re-pin aplexer to 0.1.3 so a session being created cannot blank the tree

### DIFF
--- a/docs/aplexer-integration.md
+++ b/docs/aplexer-integration.md
@@ -36,7 +36,7 @@ aplexer is **not installed separately**. `tools/pocketshell/pyproject.toml`
 carries a pinned, Linux-marked hard dependency:
 
 ```toml
-"aplexer==0.1.2; sys_platform == 'linux'"
+"aplexer==0.1.3; sys_platform == 'linux'"
 ```
 
 so the documented host install — `uv tool install pocketshell` — also delivers
@@ -132,9 +132,54 @@ BEHAVIOUR the CLI depends on:
   `launch-spec --engine/--cwd/--profile/--no-skip-permissions`,
   `attach`, `kill`) exists in the bundled build.
 
+- a session directory with **no `session.json`** — the state `a start` leaves
+  on disk for 26-43 ms on every create — is SKIPPED, not treated as a corrupt
+  registry, by `a list` / `a snapshot`, by `session_enum._probe_aplexer` and
+  `sessions._aplexer_snapshot` driving the real binary, and by a concurrent
+  `a start` (see "0.1.3" below).
+
 Those assertions were verified to fail against published 0.1.1 and pass
-against 0.1.2. **Re-run that file whenever the pin moves** — it is what a bump
-has to re-verify, in place of a version check that cannot see the difference.
+against 0.1.2 (the `executable` / shell-env pair), and to fail against 0.1.2
+and pass against 0.1.3 (the registry-scan trio). **Re-run that file whenever
+the pin moves** — it is what a bump has to re-verify, in place of a version
+check that cannot see the difference.
+
+### 0.1.3 — a session being created must not blank the session tree
+
+aplexer#2 / aplexer#3. Through 0.1.2, `list_records` treated a session
+directory containing no `session.json` as a corrupt registry and failed the
+whole scan:
+
+```text
+a: load session registry entry <dir>: read <dir>/session.json:
+No such file or directory (os error 2)          exit=1
+```
+
+`start_session` creates that directory 26-43 ms *before* it writes the record,
+on every `a start`, so this is the normal create path, not an exotic state.
+Both writes happen under the registry lock, so no other `a start` could
+observe the gap — but every reader that does NOT take that lock can, and that
+is every reader PocketShell has. `a watch` polls forever and died on it (1 run
+in 60 on an idle box); `a list` was bricked outright for the duration.
+
+It reached the phone directly. `session_enum.py::_probe_aplexer` and
+`sessions.py::_aplexer_snapshot` both probe `a --json snapshot` and fall back
+to `a --json list`; that fallback cannot help, because the failure is in the
+shared registry scan underneath both. `aplexer.run_json` then collapses the
+failure to `None`, so while any session was being created the session tree
+lost **every** aplexer row.
+
+A record-less directory that outlives the window — a killed or crashed
+`a start` — is worse: it bricks a 0.1.2 registry permanently, including
+`a start` itself (the same scan runs under the lock), so
+`sessions create --backend aplexer` stops working until someone manually
+`rmdir`s the directory.
+
+Pinned behaviour, in `test_aplexer_contract.py`: with that exact on-disk shape
+present, `a --json list` succeeds, `_probe_aplexer` returns a list with no
+error, `_aplexer_snapshot` is not `None`, a live session stays listed, and a
+second `a start` still succeeds. Verified red on published 0.1.2, green on
+0.1.3.
 
 ### Lock cutoff
 
@@ -142,9 +187,20 @@ has to re-verify, in place of a version check that cannot see the difference.
 `uv.lock`'s `[options]`) is a project-local reproducibility cutoff, and a
 package uploaded *after* it is simply invisible to `uv lock` — which looks
 like a broken index rather than a stale cutoff. So it moves in lock-step with
-every new pin: past quse 0.0.15 (#2293), now past aplexer 0.1.2's
-2026-09-05T22:38:08Z upload (its `aplexer-client` runtime dependency landed at
-22:38:04Z). Bump both places together, or `uv lock --check` fails.
+every new pin: past quse 0.0.15 (#2293), then past aplexer 0.1.2's
+2026-09-05T22:38:08Z upload (#2543), now past aplexer 0.1.3's
+2026-09-06T00:32:09Z upload (its `aplexer-client` runtime dependency landed at
+00:32:04Z). Bump both places together, or `uv lock --check` fails.
+
+Two host-level traps when re-locking: this box carries a rolling global
+`exclude-newer = "7 days"` in `~/.config/uv/uv.toml`, so a local `uv lock` /
+`uv pip install` needs an explicit `--exclude-newer <cutoff>` to see a
+just-published pin; and PyPI's JSON API can list a release minutes before the
+simple index serves it, so a resolution failure claiming the version does not
+exist is worth one `--refresh` retry before concluding anything is wrong.
+After the bump, read the lock diff: moving the cutoff forward is exactly when
+an *unrelated* dependency can drift in unnoticed, so the diff should be the
+new pin and nothing else.
 
 ---
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -98,12 +98,42 @@ dependencies = [
     # so the pinned wheel is the ONLY aplexer this CLI can run. Bumping the
     # pin is a deliberate, reviewed change.
     #
-    # 0.1.2 (not 0.1.1) is required, and the version string alone cannot tell
-    # you why: aplexer HEAD sat 143 commits past the v0.1.1 tag while STILL
-    # self-reporting `a --version` as 0.1.1, so the published 0.1.1 wheel and
-    # the build every PocketShell host actually ran were indistinguishable by
-    # version. Pinning 0.1.1 under the hard cut would have silently DOWNGRADED
-    # every host to a build missing two fixes the real create-agent path needs:
+    # 0.1.3 is required for a USER-VISIBLE session-tree defect, not for
+    # version hygiene (aplexer#2 / aplexer#3). Through 0.1.2, aplexer's
+    # `list_records` treated a session directory containing no `session.json`
+    # as a CORRUPT REGISTRY and failed the entire scan:
+    #
+    #     a: load session registry entry <dir>: read <dir>/session.json:
+    #     No such file or directory (os error 2)          exit=1
+    #
+    # But `start_session` creates that directory 26-43 ms BEFORE it writes the
+    # record, on every single `a start`. The window is therefore on the normal
+    # create path, and every reader that does not hold the registry lock can
+    # land in it — which is every reader PocketShell has. `a watch` died on it
+    # (1 run in 60 on an idle box) and `a list` was bricked outright for the
+    # duration.
+    #
+    # That reaches the phone directly. `session_enum.py::_probe_aplexer` and
+    # `sessions.py::_aplexer_snapshot` both probe `a --json snapshot` and fall
+    # back to `a --json list`; the fallback cannot help, because the failure
+    # is in the shared registry scan underneath both. `aplexer.run_json`
+    # collapses any failure to None, so while a session was being created the
+    # session tree silently lost EVERY aplexer row. Worse, a record-less
+    # directory that outlives the window (a killed/crashed `a start`) bricks
+    # 0.1.2's registry permanently — including `a start` itself, which runs
+    # the same scan under the lock, so `sessions create --backend aplexer`
+    # stops working until someone manually `rmdir`s it.
+    # tests/test_aplexer_contract.py drives the bundled binary through both
+    # production probes with exactly that on-disk shape; verified red on
+    # published 0.1.2, green on 0.1.3.
+    #
+    # 0.1.2 (not 0.1.1) was the previous floor, and the version string alone
+    # could not tell you why: aplexer HEAD sat 143 commits past the v0.1.1 tag
+    # while STILL self-reporting `a --version` as 0.1.1, so the published
+    # 0.1.1 wheel and the build every PocketShell host actually ran were
+    # indistinguishable by version. Pinning 0.1.1 under the hard cut would
+    # have silently DOWNGRADED every host to a build missing two fixes the
+    # real create-agent path needs:
     #   * aplexer ee4b957 — profile `executable` override (argv[0]) for Codex
     #     variants. Without it, `[profiles.zcodex] engine="codex",
     #     executable="zcodex"` resolves argv[0] to `codex`, and `pocketshell
@@ -113,10 +143,10 @@ dependencies = [
     #   * aplexer d13ecb2 — preserve the provider environment for plain
     #     `shell` launches (0.1.1 stripped 71 provider vars from every shell
     #     session).
-    # tests/test_aplexer_contract.py pins BOTH behaviours against the BUNDLED
-    # binary, because `a --version` demonstrably cannot: a future pin that
-    # regresses to a build without them fails that test loudly instead of
-    # shipping a silent downgrade. Re-run it whenever this pin moves.
+    # tests/test_aplexer_contract.py pins ALL of these behaviours against the
+    # BUNDLED binary, because `a --version` demonstrably cannot: a future pin
+    # that regresses to a build without them fails that test loudly instead
+    # of shipping a silent downgrade. Re-run it whenever this pin moves.
     #
     # There is no separate release-time guard for the aplexer version itself
     # (scripts/check-pypi-version.sh only couples pocketshell's OWN version to
@@ -132,12 +162,12 @@ dependencies = [
     # fails loud (there is no PATH fallback — D22) while tmux, the default
     # backend, keeps working.
     #
-    # Install-surface note (0.1.2): the wheels moved from manylinux_2_17 to
-    # manylinux_2_28, raising the minimum glibc from 2.17 to 2.28. Linux hosts
-    # older than that (CentOS 7, Ubuntu 18.04) can no longer install
-    # pocketshell at all now that aplexer is a hard dependency. Flagged, not
-    # solved here — see docs/aplexer-integration.md.
-    "aplexer==0.1.2; sys_platform == 'linux'",
+    # Install-surface note (unchanged in 0.1.3): as of 0.1.2 the wheels moved
+    # from manylinux_2_17 to manylinux_2_28, raising the minimum glibc from
+    # 2.17 to 2.28. Linux hosts older than that (CentOS 7, Ubuntu 18.04) can
+    # no longer install pocketshell at all now that aplexer is a hard
+    # dependency. Flagged, not solved here — see docs/aplexer-integration.md.
+    "aplexer==0.1.3; sys_platform == 'linux'",
 ]
 
 [project.scripts]
@@ -198,8 +228,10 @@ required-version = "==0.10.11"
 # runtime dep landed at 22:38:04Z) for issue #2543. A package uploaded after
 # the cutoff is simply invisible to `uv lock`, which reads like a broken index
 # rather than a stale cutoff, so this value moves in lock-step with every new
-# pin — and the `uv.lock` options cutoff must be moved to match.
-exclude-newer = "2026-09-05T23:00:00Z"
+# pin — and the `uv.lock` options cutoff must be moved to match. Now past
+# aplexer 0.1.3's 2026-09-06T00:32:09Z PyPI upload (its `aplexer-client`
+# runtime dep landed at 00:32:04Z) for the session-tree regression fix above.
+exclude-newer = "2026-09-06T01:00:00Z"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tools/pocketshell/tests/test_aplexer_contract.py
+++ b/tools/pocketshell/tests/test_aplexer_contract.py
@@ -23,12 +23,21 @@ host. Two post-0.1.1 fixes the real create-agent path depends on were missing:
 * ``d13ecb2`` — preserve the provider environment for plain ``shell``
   launches. 0.1.1 stripped 71 provider vars from every shell session.
 
+The 0.1.3 bump proved the point a second time, from the other direction: a
+version comparison would have called it a patch release, while what it
+actually fixes is the phone's session tree going blank whenever a session is
+being created (see the ``aplexer#2 / #3`` block below).
+
 So these tests pin BEHAVIOUR, against the real bundled binary, with their own
-config fixture (``APLEXER_CONFIG``) — never the maintainer's personal
-``~/.config/aplexer/config.toml``, which would make them pass on exactly one
-machine. Every assertion here was verified to fail on published aplexer 0.1.1
-and pass on 0.1.2; a future pin that regresses fails loudly instead of
-shipping a silent downgrade.
+config, state and runtime fixtures (``APLEXER_CONFIG`` /
+``APLEXER_STATE_DIR`` / ``APLEXER_RUNTIME_DIR``) — never the maintainer's
+personal ``~/.config/aplexer/config.toml`` or the live sessions in
+``~/.local/state/aplexer``, which would make them pass on exactly one machine
+and disturb real work while doing it. Every assertion here was verified to
+fail on the previous published wheel and pass on the pinned one (0.1.1 -> 0.1.2
+for the ``executable`` / shell-env pair, 0.1.2 -> 0.1.3 for the registry-scan
+trio); a future pin that regresses fails loudly instead of shipping a silent
+downgrade.
 
 They run in the ``Python utility tests`` job (``tests.yml``), on Linux, with
 no Docker service or fixture port — the same gate the rest of this suite uses.
@@ -38,8 +47,10 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import tomllib
 import uuid
@@ -49,6 +60,8 @@ from typing import Any, Sequence
 import pytest
 
 from pocketshell import aplexer as _aplexer
+from pocketshell import session_enum as _session_enum
+from pocketshell import sessions as _sessions
 
 PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
 
@@ -109,13 +122,46 @@ def _pinned_version() -> str:
     return reqs[0].split(";")[0].strip().split("==", 1)[1]
 
 
+def _short_runtime_root() -> str:
+    """A throwaway ``APLEXER_RUNTIME_DIR`` short enough for AF_UNIX.
+
+    aplexer binds ``<runtime_root>/sessions/<uuid>/control.sock`` — 59 bytes
+    of suffix — and ``sun_path`` is capped at 108, so the runtime root cannot
+    be a deep pytest ``tmp_path``. That is why the fixture below could not
+    simply reuse ``tmp_path`` for it: with the pytest root the worker dies
+    with ``path must be shorter than SUN_LEN`` for reasons that have nothing
+    to do with the contract under test (observed while writing this file).
+
+    Prefer the platform temp dir; fall back to ``/dev/shm`` when ``TMPDIR``
+    is itself too deep. Fail loudly rather than silently producing a
+    mysterious worker-startup error.
+    """
+    suffix = len("/sessions/") + 36 + len("/control.sock")
+    for base in (tempfile.gettempdir(), "/dev/shm"):
+        if not os.path.isdir(base):
+            continue
+        root = tempfile.mkdtemp(prefix="ps-aplx-", dir=base)
+        if len(root) + suffix < 108:
+            return root
+        os.rmdir(root)
+    raise AssertionError(
+        "no temp base short enough for an AF_UNIX control socket; "
+        f"tried {tempfile.gettempdir()!r} and '/dev/shm'"
+    )
+
+
 @pytest.fixture
 def aplexer_fixture(tmp_path: Path):
-    """A throwaway aplexer config + a minimal env that runs against it.
+    """A throwaway aplexer config + state + runtime, and an env that uses them.
 
-    ``APLEXER_CONFIG`` is aplexer's own explicit config override
-    (``aplexer/src/lib.rs``), so the contract is asserted against OUR fixture
-    profiles, not whatever the developer has in ``~/.config/aplexer``.
+    ``APLEXER_CONFIG`` / ``APLEXER_STATE_DIR`` / ``APLEXER_RUNTIME_DIR`` are
+    aplexer's own explicit overrides (``aplexer/src/lib.rs::Paths::discover``),
+    so the contract is asserted against OUR fixture profiles and OUR session
+    registry — never whatever the developer has in ``~/.config/aplexer`` or
+    the live sessions in ``~/.local/state/aplexer``. The registry override
+    matters as much as the config one now that this file exercises the
+    session-listing path: a test that scanned the real registry would both
+    read the maintainer's live sessions and be at the mercy of them.
 
     ``PATH`` holds the system dirs only — no ``a``, no ``aplexer`` — so a host
     copy cannot answer for the bundled one, and ``XDG_RUNTIME_DIR`` is
@@ -131,14 +177,45 @@ def aplexer_fixture(tmp_path: Path):
             self.config = tmp_path / "aplexer-config.toml"
             self.home = tmp_path / "aplexer-home"
             self.workspace = tmp_path / "ws"
-            for directory in (self.home, self.workspace):
+            self.state_dir = tmp_path / "aplexer-state"
+            for directory in (self.home, self.workspace, self.state_dir):
                 directory.mkdir(exist_ok=True)
+            self.runtime_dir = _short_runtime_root()
             self.env = {
                 "PATH": "/usr/bin:/bin",
                 "HOME": str(self.home),
                 "TERM": "dumb",
                 "APLEXER_CONFIG": str(self.config),
+                "APLEXER_STATE_DIR": str(self.state_dir),
+                "APLEXER_RUNTIME_DIR": self.runtime_dir,
+                # conftest's autouse isolation sets POCKETSHELL_APLEXER=0 so
+                # that helper tests can never be answered by a host `a`. The
+                # tests here that drive the PRODUCTION probes
+                # (session_enum._probe_aplexer, sessions._aplexer_snapshot)
+                # must opt back in, or `run_json` short-circuits to None
+                # before running anything — a red that proves the kill switch
+                # works, not that the pin is wrong.
+                "POCKETSHELL_APLEXER": "1",
             }
+
+        @property
+        def sessions_root(self) -> Path:
+            """``<state>/sessions`` — the directory ``list_records`` scans."""
+            return self.state_dir / "sessions"
+
+        def make_record_less_session_dir(self) -> Path:
+            """The exact on-disk shape a concurrent ``a start`` leaves behind.
+
+            ``start_session`` creates ``<state>/sessions/<uuid>/`` and only
+            then writes ``session.json`` into it (26-43 ms later, measured),
+            both under the registry lock. Every reader that does NOT take that
+            lock — which is every ``a list`` / ``a snapshot`` / ``a watch``,
+            i.e. everything PocketShell drives — can observe the gap.
+            """
+            directory = self.sessions_root / str(uuid.uuid4())
+            directory.mkdir(parents=True)
+            assert not (directory / "session.json").exists()
+            return directory
 
         def write_config(self, body: str) -> None:
             self.config.write_text(body, encoding="utf-8")
@@ -163,7 +240,13 @@ def aplexer_fixture(tmp_path: Path):
             )
             return json.loads(completed.stdout)
 
-    return Fixture()
+    fixture = Fixture()
+    try:
+        yield fixture
+    finally:
+        # The runtime root lives outside ``tmp_path`` (AF_UNIX length), so
+        # pytest's own tmp retention does not clean it up.
+        shutil.rmtree(fixture.runtime_dir, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +379,170 @@ def test_bundled_aplexer_start_launches_the_profile_executable(aplexer_fixture) 
         aplexer_fixture.run(
             ["kill", "--workspace", str(aplexer_fixture.workspace), "--tag", tag]
         )
+
+
+# ---------------------------------------------------------------------------
+# aplexer#2 / #3 — a session being created must not erase the session list
+# ---------------------------------------------------------------------------
+#
+# The 0.1.3 pin exists for this. `list_records` treated a session directory
+# with no `session.json` in it as a CORRUPT REGISTRY and failed the whole
+# scan:
+#
+#     a: load session registry entry <dir>: read <dir>/session.json:
+#     No such file or directory (os error 2)                        exit=1
+#
+# But `start_session` creates that directory 26-43 ms BEFORE it writes the
+# record, on every single `a start`. So the window is not exotic — it is on
+# the normal create path, and any reader that does not hold the registry lock
+# can land in it. `a watch` polls forever and died on it (1 run in 60 on an
+# idle box); `a list` was bricked outright for the duration.
+#
+# That reaches the phone directly. `session_enum._probe_aplexer` and
+# `sessions._aplexer_snapshot` are the two production probes, and BOTH try
+# `a --json snapshot` then fall back to `a --json list` — the fallback cannot
+# help here, because the failure is in the shared registry scan underneath
+# both. `aplexer.run_json` then collapses the failure to `None`, so the
+# session tree loses every aplexer row while a session is being created.
+#
+# Worse, and found while writing these tests: a record-less directory that
+# OUTLIVES the window (a killed/crashed `a start`) bricks the registry
+# permanently on 0.1.2 — including `a start` itself, which scans the registry
+# under the lock. The host can then never create or list an aplexer session
+# again without manual `rmdir`.
+
+
+def test_bundled_aplexer_lists_through_a_session_being_created(
+    aplexer_fixture,
+) -> None:
+    """A record-less session dir must not fail the scan — it is skipped.
+
+    The narrow, worker-free half of the regression: the registry contains
+    exactly the directory `start_session` has just created and not yet
+    written into. Published 0.1.2 exits 1 here (verified); 0.1.3 returns
+    `[]`.
+    """
+    aplexer_fixture.write_config("version = 1\n")
+    incomplete = aplexer_fixture.make_record_less_session_dir()
+
+    completed = aplexer_fixture.run(["--json", "list"])
+
+    assert completed.returncode == 0, (
+        "the bundled aplexer failed the whole registry scan because a session "
+        "was mid-creation; this is aplexer#3, missing from published 0.1.2, "
+        "and it blanks the phone's session tree. "
+        f"exit={completed.returncode} stderr={completed.stderr.strip()!r}"
+    )
+    assert json.loads(completed.stdout) == [], completed.stdout
+    assert incomplete.exists(), "the fixture directory should not be consumed"
+
+
+def test_probe_aplexer_survives_a_session_being_created(aplexer_fixture) -> None:
+    """`session_enum._probe_aplexer` returns a LIST, never `None` + an error.
+
+    This is the production probe the session tree calls. On 0.1.2 it comes
+    back `(None, "…both failed or returned unreadable JSON…")`, which is the
+    aplexer-shaped hole the phone showed.
+    """
+    aplexer_fixture.write_config("version = 1\n")
+    aplexer_fixture.make_record_less_session_dir()
+
+    payload, error = _session_enum._probe_aplexer(aplexer_fixture.env)
+
+    assert error is None, (
+        "the production aplexer probe reported a failure for a session that "
+        f"was merely being created: {error}"
+    )
+    assert payload == [], payload
+
+
+def test_session_being_created_does_not_erase_live_aplexer_sessions(
+    aplexer_fixture, monkeypatch
+) -> None:
+    """End-to-end: a REAL running session stays listed, and `start` still works.
+
+    The narrow test above passes on an empty registry, which cannot show the
+    user-visible damage. This one starts a real session through a real
+    worker, then drops the record-less directory next to it and asserts that
+    BOTH production probes still see it. Verified against published 0.1.2:
+    the live session vanishes from both (`_probe_aplexer` -> `(None, error)`,
+    `sessions._aplexer_snapshot` -> `None`) and a second `a start` fails
+    outright.
+    """
+    shim = aplexer_fixture.workspace.parent / "aplx-regression-shim"
+    shim.write_text("#!/bin/sh\nexec sleep 60\n", encoding="utf-8")
+    shim.chmod(0o755)
+    aplexer_fixture.write_config(
+        "version = 1\n"
+        "[engines.aplxregression]\n"
+        f'command = ["{shim}"]\n'
+    )
+    for key, value in aplexer_fixture.env.items():
+        monkeypatch.setenv(key, value)
+
+    def start(tag: str) -> subprocess.CompletedProcess:
+        return aplexer_fixture.run(
+            [
+                "--json", "start",
+                "--workspace", str(aplexer_fixture.workspace),
+                "--tag", tag,
+                "--engine", "aplxregression",
+            ]
+        )
+
+    def kill(tag: str) -> None:
+        aplexer_fixture.run(
+            ["kill", "--workspace", str(aplexer_fixture.workspace), "--tag", tag]
+        )
+
+    live_tag = f"aplx-live-{uuid.uuid4().hex[:8]}"
+    second_tag = f"aplx-second-{uuid.uuid4().hex[:8]}"
+    started = start(live_tag)
+    try:
+        assert started.returncode == 0, (
+            f"could not start the fixture session: {started.stderr.strip()}"
+        )
+        assert json.loads(started.stdout)["phase"] == "running", started.stdout
+        assert [
+            row["tag"] for row in _session_enum._probe_aplexer(aplexer_fixture.env)[0]
+        ] == [live_tag], "precondition: the live session must be listed"
+
+        # …and now a concurrent `a start` is mid-flight.
+        aplexer_fixture.make_record_less_session_dir()
+
+        payload, error = _session_enum._probe_aplexer(aplexer_fixture.env)
+        assert error is None, (
+            "a session being created blanked the aplexer half of the session "
+            f"tree: {error}"
+        )
+        assert [row["tag"] for row in payload] == [live_tag], (
+            "the LIVE session disappeared from the listing because an "
+            f"unrelated session was being created: {payload}"
+        )
+
+        snapshot = _sessions._aplexer_snapshot()
+        assert snapshot is not None, (
+            "`sessions._aplexer_snapshot` returned None — `aplexer.run_json` "
+            "collapses this failure silently, which is why the phone showed "
+            "an empty tree with no error"
+        )
+        assert [row["tag"] for row in snapshot] == [live_tag], snapshot
+
+        # The same scan runs under the registry lock inside `start_session`,
+        # so 0.1.2 could not even create a session while one was pending.
+        second = start(second_tag)
+        assert second.returncode == 0, (
+            "`a start` itself failed while another session was mid-creation; "
+            "`pocketshell sessions create --backend aplexer` breaks with it. "
+            f"stderr={second.stderr.strip()!r}"
+        )
+        tags = {
+            row["tag"] for row in _session_enum._probe_aplexer(aplexer_fixture.env)[0]
+        }
+        assert tags == {live_tag, second_tag}, tags
+    finally:
+        kill(live_tag)
+        kill(second_tag)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/pocketshell/tests/test_aplexer_resolution.py
+++ b/tools/pocketshell/tests/test_aplexer_resolution.py
@@ -264,16 +264,25 @@ def _aplexer_requirement() -> str:
 def test_aplexer_is_pinned_exactly() -> None:
     """The pin is exact, like quse — a host upgrade must not reach us.
 
-    0.1.2, never 0.1.1: under the D22 hard cut the bundled wheel is the ONLY
-    aplexer this CLI can run, so pinning the older published wheel would
-    downgrade every host to a build missing the profile `executable` override
-    and the shell provider-env fix. ``test_aplexer_contract.py`` pins those
-    behaviours against the bundled binary, because `a --version` cannot
-    distinguish the two builds (both report 0.1.1).
+    Under the D22 hard cut the bundled wheel is the ONLY aplexer this CLI can
+    run, so the pin decides what every host gets and an older published wheel
+    is a silent DOWNGRADE, not merely stale:
+
+    * 0.1.2, never 0.1.1 — 0.1.1 lacks the profile `executable` override and
+      the shell provider-env fix, and `a --version` cannot distinguish the two
+      builds (both report 0.1.1).
+    * 0.1.3, never 0.1.2 — 0.1.2's `list_records` fails the whole registry
+      scan on a session directory that has no `session.json` yet, which is the
+      state every `a start` creates for 26-43 ms, so a session being created
+      blanked the phone's aplexer session rows (aplexer#2 / aplexer#3).
+
+    This assertion only guards the STRING. ``test_aplexer_contract.py`` pins
+    the behaviours themselves against the bundled binary, which is the part
+    a version comparison provably cannot do.
     """
     requirement = _aplexer_requirement()
     pin = requirement.split(";")[0].strip()
-    assert pin == "aplexer==0.1.2", pin
+    assert pin == "aplexer==0.1.3", pin
 
 
 def test_aplexer_dependency_marker_is_linux_only() -> None:

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-09-05T23:00:00Z"
+exclude-newer = "2026-09-06T01:00:00Z"
 
 [[package]]
 name = "annotated-doc"
@@ -16,23 +16,23 @@ wheels = [
 
 [[package]]
 name = "aplexer"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aplexer-client" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/56/19d475730a654df90a2b18af5f1dd85070c087ebbb6a4c6ef8909775ddb7/aplexer-0.1.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:a4c153dcdbefe70ba1738c18e712e83ba06b408f0eabf7a4d21922fc85f4fd90", size = 2627286, upload-time = "2026-09-05T22:38:07.758Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/1d/682bdf6071269466302e0d0b298b412521b5ad79c88d7eec985fb713d417/aplexer-0.1.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:bd19cde5608cb248a883326745484957fcbf3d79f58d66df4abeac237f270c6f", size = 2726923, upload-time = "2026-09-05T22:38:08.988Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/af/f543f10a7a60b17b92c7d2c07a70297eaa5ca28fd15723b72adecb68ab79/aplexer-0.1.3-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fcbeb382cae10a845642354abdf5b9f92a904b1c5c89884f5eb401dcab0ced50", size = 2628621, upload-time = "2026-09-06T00:32:08.244Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a9/0e94c7111b3065a1988a3c8c22a6694a3cb9d1ebeb9319418badcabcd907/aplexer-0.1.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:98296baeb01a4970f9526f841a93a774efbcb2cc0eb72f709c9df0639be88f26", size = 2729042, upload-time = "2026-09-06T00:32:09.795Z" },
 ]
 
 [[package]]
 name = "aplexer-client"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/33/03cb46de17f575648d7cc72ee9021b4199bb1f77c7eb1f10e3eb878b46a5/aplexer_client-0.1.2-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d4f0a217ddaf9f8df2157bc2538b98e5e5140207558493cffb02a221aeb5733f", size = 1172032, upload-time = "2026-09-05T22:38:02.78Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/c9/88332107b9f4d303d1827749be93d7fea03df768fee7e3e64b4e5747b4b9/aplexer_client-0.1.2-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3280caf342618c8ceca3bc7e9788fbe29ae24ab4053cb3cc04e0ba151eccbb1b", size = 1202575, upload-time = "2026-09-05T22:38:04.362Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/08/14dd9dff0689b53962f6098d8b301180765530e361745078419f1a7352cc/aplexer_client-0.1.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d7d1bb379e1a1ec4877c376d5404db686c3f376d05ed382544d9fe0c3e7d0e52", size = 1172818, upload-time = "2026-09-06T00:32:03.086Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a4/34a98e50347da9e954a20c78ee0b6a01640bd287dba294444e4730517a2d/aplexer_client-0.1.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:58821be985be0cb179fb7647da1e899499372fa728cff8a75e67ff360d4c0022", size = 1202892, upload-time = "2026-09-06T00:32:04.375Z" },
 ]
 
 [[package]]
@@ -363,7 +363,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aplexer", marker = "sys_platform == 'linux'", specifier = "==0.1.2" },
+    { name = "aplexer", marker = "sys_platform == 'linux'", specifier = "==0.1.3" },
     { name = "click", specifier = ">=8.2.0" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },


### PR DESCRIPTION
Follow-up to PocketShell-io/pocketshell#2543. Not routine version churn — aplexer 0.1.3 fixes a defect that reached the phone.

## The defect

`list_records` treated a session directory with no `session.json` as a corrupt registry and failed the whole scan. But `start_session` creates that directory **26-43 ms before writing the record, on every `a start`**.

`session_enum.py:576` and `sessions.py:720` probe `a --json snapshot` falling back to `a --json list`, and `run_json` returns `None` on any failure, silently. So a concurrent session create blanked the aplexer half of the session tree while the command still exited 0.

End to end against both published wheels, two real workers running, one mid-create directory present:

| | rows | errors |
|---|---|---|
| **0.1.2** | `[]` — blank | `aplexer: "snapshot and list both failed"` |
| **0.1.3** | `[ws:e2e-two, ws:e2e-one]` — intact | none |

**Worse than the transient window suggests:** a record-less directory that *outlives* it — a killed or crashed `a start` — bricks a 0.1.2 registry **permanently**, `a start` included, because the same scan runs under the registry lock. `sessions create --backend aplexer` then stays broken until someone removes the directory by hand. Verified rc=1 on 0.1.2, rc=0 on 0.1.3.

## Tests

Three regression tests, red on 0.1.2 and green on 0.1.3, driving the bundled binary through production code: the raw listing, the tree's own `_probe_aplexer`, and a real `a start` + worker that must survive a mid-create directory and still accept a second start.

The red is honest, which took a correction worth recording. `conftest.py` sets `POCKETSHELL_APLEXER=0` autouse, so the first red was partly the kill switch working rather than the pin being wrong. The fixture now opts in explicitly, and each failure carries the registry-scan signature — a kill-switch red would fail a *different* assertion one line later, which is what makes the two distinguishable.

0.1.3's skip is narrow, confirmed by the reviewer against the real wheels: a garbage `session.json` and a valid-JSON-wrong-schema record both still hard-fail. Only the transient-create shape is skipped.

## Verification

- `1271 passed, 4 skipped` (baseline 1268 + 3 new)
- `uv lock --check` clean; lock diff verified **structurally**, not by eye: 28 packages before and after, none added or removed, only `aplexer` and `aplexer-client` changed
- macOS and Windows resolve with no aplexer at all
- Binary identity proven via `resolve_a` reporting `source='bundled'` with no PATH step attempted

Reviewer independently reproduced the red on a separate 0.1.2 venv, the permanent-brick finding, and the end-to-end blanking.

## Notes

`[tool.uv] exclude-newer` moves to `2026-09-06T01:00:00Z` so 0.1.3 is visible to the resolver.

`test_aplexer_resolution.py` changes too because it asserts the pin as a literal string. It stays an exact-equality pin, so a downgrade or a loosening to `>=` both still fail.

Why `run_json` swallowed this silently is filed separately as PocketShell-io/pocketshell-cli#1 — that is a contract change across every call site and does not belong in a version pin.