### PR TITLE
terminal: palette as default scheme, clipboard callbacks, drop dead vendored patches

### DIFF
--- a/app2/src/main/java/com/pocketshell/next/terminal/TerminalGeometry.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/TerminalGeometry.kt
@@ -40,8 +40,10 @@ import kotlin.math.ceil
  *
  * [terminalCells] and [measureTerminalCellMetrics] mirror
  * `TerminalView.updateSize()` and `TerminalRenderer`'s constructor, which live
- * in `shared/core-terminal` and are pinned byte-identical to upstream (see its
- * `VENDORED.md`). They cannot call into them: both the metric fields and
+ * in the vendored `shared/core-terminal` (see its `VENDORED.md` for the
+ * upstream pin and `PATCHES.md` for the local deviations — the row-pitch
+ * formula mirrored here is itself one of them, #241). They cannot call into
+ * them: both the metric fields and
  * `LINE_SPACING_MULTIPLIER` are package-private to `com.termux.view`. If a
  * Termux refresh changes either formula, the worst case here is an estimate
  * that is off by a row or two and gets corrected by the first frame — the same

--- a/app2/src/main/java/com/pocketshell/next/terminal/TerminalHostView.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/TerminalHostView.kt
@@ -1,5 +1,8 @@
 package com.pocketshell.next.terminal
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.view.KeyEvent
 import android.view.MotionEvent
 import androidx.compose.runtime.Composable
@@ -12,6 +15,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.viewinterop.AndroidView
 import com.pocketshell.next.settings.LocalAppSettings
 import com.pocketshell.uikit.theme.PocketShellColors
+import com.termux.terminal.TerminalColors
 import com.termux.terminal.TerminalSession
 import com.termux.terminal.TerminalSessionClient
 import com.termux.terminal.TextStyle
@@ -41,21 +45,43 @@ const val SESSION_TERMINAL_TAG: String = "session-terminal"
 internal const val TERMINAL_TEXT_SIZE_RAW_PX: Int = 28
 
 /**
- * The terminal's own palette entries, in ARGB.
+ * Makes the ui-kit tokens the vendored emulator's DEFAULT colour scheme.
  *
- * Two places need the background and both matter: `setDefaultBackgroundColor`
- * paints the View (including the strip below the last drawn row), while the
- * emulator's `mColors` decides what a cell with DEFAULT attributes is filled
+ * The scheme is what `TerminalColors.reset()` copies from, so it is both what
+ * a fresh emulator starts with and what it returns to on `ESC c` (the `reset`
+ * command), `OSC 104` and `OSC 110`–`112` (an app undoing the colours it set).
+ * Patching the live palette after the fact — what the pre-rewrite client did
+ * in `onEmulatorSet` and re-did on every `onColorsChanged` — held only until
+ * the first of those, after which the grid fell back to Termux's pure black
+ * against the app's near-black chrome, and it also undid colours an app had
+ * legitimately asked for. Installing the defaults once, before the emulator is
+ * built, leaves every reset and every app-chosen colour to the emulator.
+ *
+ * The scheme is one process-wide object upstream (`TerminalColors.COLOR_SCHEME`),
+ * which suits an app with one palette. Idempotent; called by
+ * [createRemoteTerminalSession].
+ */
+internal fun installTerminalPalette() {
+    val defaults = TerminalColors.COLOR_SCHEME.mDefaultColors
+    defaults[TextStyle.COLOR_INDEX_BACKGROUND] = PocketShellColors.Background.toArgb()
+    defaults[TextStyle.COLOR_INDEX_FOREGROUND] = PocketShellColors.Text.toArgb()
+    defaults[TextStyle.COLOR_INDEX_CURSOR] = PocketShellColors.Accent.toArgb()
+}
+
+/**
+ * Paints the View's own background from the session's CURRENT palette.
+ *
+ * Two places paint the background and both matter: `setDefaultBackgroundColor`
+ * fills the View (including the strip below the last drawn row), while the
+ * emulator's palette decides what a cell with DEFAULT attributes is filled
  * with — upstream's renderer skips painting a cell whose background equals the
  * palette default, so the two have to agree or the grid and the gutter end up
- * different blacks.
- *
- * They are the ui-kit tokens, not terminal-only constants: a third black next
- * to the app's chrome is exactly the seam a phone screen shows up.
+ * different colours. Called on attach and whenever the emulator reports the
+ * palette moved, so a background an app sets with `OSC 11` actually shows.
  */
-private val TERMINAL_BACKGROUND_ARGB: Int = PocketShellColors.Background.toArgb()
-private val TERMINAL_FOREGROUND_ARGB: Int = PocketShellColors.Text.toArgb()
-private val TERMINAL_CURSOR_ARGB: Int = PocketShellColors.Accent.toArgb()
+private fun TerminalView.paintBackgroundFrom(session: TerminalSession) {
+    setDefaultBackgroundColor(session.emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_BACKGROUND])
+}
 
 /** `assets/` path of the face vendored inside `:shared:core-terminal`. */
 private const val TERMINAL_FONT_ASSET: String = "fonts/JetBrainsMono-Regular.ttf"
@@ -94,7 +120,8 @@ internal fun terminalTypeface(context: android.content.Context): android.graphic
  *  1. build the view, give it a client, attach the session;
  *  2. install a [TerminalSessionClient] that turns the emulator's
  *     "text changed" callback into a repaint — without it the vendored drain
- *     parses bytes into a grid nobody ever draws;
+ *     parses bytes into a grid nobody ever draws — and gives its palette and
+ *     clipboard callbacks a window and a clipboard ([HostedSessionClient]);
  *  3. report the size the view computes from its own font metrics back to the
  *     session layer, which is the ONLY path to `pty.resize`.
  *
@@ -134,7 +161,7 @@ fun TerminalHostView(
 ) {
     // Held across recompositions so a state change in the enclosing screen does
     // not detach and re-attach the terminal (which would reset the viewport).
-    val repaintClient = remember(session) { RepaintingSessionClient() }
+    val repaintClient = remember(session) { HostedSessionClient() }
 
     // The view's client is built once, inside `factory`, so it would otherwise
     // capture the FIRST composition's `ctrlArmed` value and never see another.
@@ -193,8 +220,8 @@ fun TerminalHostView(
                 setTextSize(textSizePx)
                 appliedTextSizePx[0] = textSizePx
                 setTypeface(terminalTypeface(context))
-                setDefaultBackgroundColor(TERMINAL_BACKGROUND_ARGB)
                 attachSession(session)
+                paintBackgroundFrom(session)
                 repaintClient.view = this
             }
         },
@@ -206,6 +233,7 @@ fun TerminalHostView(
             repaintClient.view = view
             if (view.currentSession !== session) {
                 view.attachSession(session)
+                view.paintBackgroundFrom(session)
             }
             // Focus is requested here rather than in `factory`: the view is not
             // attached to a window yet at construction time, so `requestFocus()`
@@ -219,12 +247,13 @@ fun TerminalHostView(
 }
 
 /**
- * Bridges the vendored session's "the grid changed" callback to the view's
- * repaint. Everything else stays a no-op for now: clipboard, bell and colour
- * changes belong to later polish tasks, and a wrong implementation of any of
- * them would be worse than none.
+ * The session's client while a view hosts it: the emulator's callbacks that
+ * need a screen, a clipboard or a window behind them. Every callback is inert
+ * when [view] is null (the session outlives the composition), and the bell
+ * stays a no-op — a phone vibrating on every `BEL` a TUI emits is worse than
+ * silence.
  */
-private class RepaintingSessionClient : TerminalSessionClient by NoOpTerminalSessionClient() {
+private class HostedSessionClient : TerminalSessionClient by NoOpTerminalSessionClient() {
 
     @Volatile
     var view: TerminalView? = null
@@ -232,7 +261,42 @@ private class RepaintingSessionClient : TerminalSessionClient by NoOpTerminalSes
     override fun onTextChanged(changedSession: TerminalSession) {
         view?.onScreenUpdated()
     }
+
+    /**
+     * `OSC 4/10/11/12` set, `OSC 104/110-112` reset or `ESC c`: the palette
+     * moved, so the View's own background has to follow it (see
+     * [paintBackgroundFrom]) and the grid needs a repaint.
+     */
+    override fun onColorsChanged(session: TerminalSession) {
+        view?.apply {
+            paintBackgroundFrom(session)
+            onScreenUpdated()
+        }
+    }
+
+    /** Copy in the long-press selection menu, and `OSC 52` from the remote. */
+    override fun onCopyTextToClipboard(session: TerminalSession, text: String?) {
+        val target = view ?: return
+        if (text.isNullOrEmpty()) return
+        target.context.clipboard?.setPrimaryClip(ClipData.newPlainText("Terminal", text))
+    }
+
+    /**
+     * Paste in the long-press selection menu. The emulator's own `paste`
+     * strips control bytes, turns newlines into carriage returns and brackets
+     * the text when the remote asked for that (`DECSET 2004`).
+     */
+    override fun onPasteTextFromClipboard(session: TerminalSession?) {
+        val target = view ?: return
+        val clip = target.context.clipboard?.primaryClip ?: return
+        if (clip.itemCount == 0) return
+        val text = clip.getItemAt(0).coerceToText(target.context) ?: return
+        session?.emulator?.paste(text.toString())
+    }
 }
+
+private val Context.clipboard: ClipboardManager?
+    get() = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
 
 /**
  * The mutable seam between a Compose recomposition and the long-lived
@@ -334,13 +398,6 @@ private class SessionTerminalViewClient(
      */
     override fun onEmulatorSet() {
         val emulator = view.mEmulator ?: return
-        // The emulator does not exist until the view's first non-zero layout, so
-        // this — not the factory — is the only moment its palette can be set.
-        emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_BACKGROUND] =
-            TERMINAL_BACKGROUND_ARGB
-        emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_FOREGROUND] =
-            TERMINAL_FOREGROUND_ARGB
-        emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_CURSOR] = TERMINAL_CURSOR_ARGB
         onResized(emulator.mColumns, emulator.mRows)
     }
 

--- a/app2/src/main/java/com/pocketshell/next/terminal/TerminalPtyBridge.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/TerminalPtyBridge.kt
@@ -335,6 +335,9 @@ fun createRemoteTerminalSession(
         /* transcriptRows = */ transcriptRows,
         /* client = */ client,
     )
+    // Before the emulator: its constructor copies the default scheme into the
+    // live palette, and every later reset copies it again.
+    installTerminalPalette()
     val emulator = TerminalEmulator(
         /* session = */ session,
         /* columns = */ cols,

--- a/app2/src/main/java/com/pocketshell/next/terminal/TerminalPtyBridge.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/TerminalPtyBridge.kt
@@ -382,11 +382,13 @@ class NoOpTerminalSessionClient : TerminalSessionClient {
  * touches, and nothing else.
  *
  * Reflection rather than a patch to the vendored source because
- * `shared/core-terminal` is pinned byte-identical to upstream Termux (its
- * `build.gradle.kts` states the "do not refactor" rule and `VENDORED.md`
- * documents the refresh procedure). A missing field fails loudly, naming the
- * refresh as the likely cause, instead of degrading into a silently dead
- * terminal.
+ * `shared/core-terminal` is pinned to an upstream Termux commit and every
+ * local deviation has to be re-applied by hand on a refresh (its
+ * `build.gradle.kts` states the "do not refactor" rule, `VENDORED.md`
+ * documents the refresh procedure, and `PATCHES.md` is the complete record of
+ * the patches we do carry). Keeping this out of the vendored source means one
+ * fewer hunk to re-apply. A missing field fails loudly, naming the refresh as
+ * the likely cause, instead of degrading into a silently dead terminal.
  */
 internal object TerminalSessionInternals {
 

--- a/app2/src/test/java/com/pocketshell/next/terminal/TerminalHostViewSessionClientTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/TerminalHostViewSessionClientTest.kt
@@ -1,0 +1,275 @@
+package com.pocketshell.next.terminal
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.graphics.drawable.ColorDrawable
+import android.util.Base64
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.termux.terminal.TerminalEmulator
+import com.termux.terminal.TerminalSession
+import com.termux.terminal.TextStyle
+import com.termux.view.TerminalView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The emulator callbacks the pre-0.5.0 client answered and the rewrite's
+ * host view left as no-ops: the palette after a terminal reset, and the
+ * selection menu's Copy and Paste.
+ *
+ * ## Palette
+ *
+ * The rewrite patched PocketShell's colours onto the live emulator in
+ * `onEmulatorSet`. `ESC c` (what the `reset` command sends) and `OSC 104` /
+ * `OSC 110`–`112` (an app undoing its own colours) copy the vendored DEFAULT
+ * scheme back over the live palette, so after any of them the grid was
+ * Termux's pure black on white against the app's near-black chrome, and
+ * nothing ever put it back. The pre-rewrite client re-patched on every
+ * `onColorsChanged`, which also clobbered colours an app had asked for.
+ * [installTerminalPalette] fixes both by making the tokens the default scheme.
+ *
+ * ## Clipboard
+ *
+ * Long-press → drag → Copy in the vendored selection action mode calls
+ * `session.onCopyTextToClipboard`, and Paste calls
+ * `session.onPasteTextFromClipboard`; both reach the session's client. With a
+ * no-op client the menu items did nothing, silently. `OSC 52` (tmux
+ * `set-clipboard`, an agent copying a snippet) lands on the same copy path.
+ *
+ * These tests drive the vendored entry points the menu itself calls, on the
+ * REAL emulator and the REAL hosted view under Robolectric, and read the
+ * result from the system clipboard, the view's background drawable and the
+ * session's own terminal→process queue — the bytes the remote would receive.
+ */
+@RunWith(AndroidJUnit4::class)
+class TerminalHostViewSessionClientTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private var rootView: View? = null
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    // --- palette -----------------------------------------------------------
+
+    @Test
+    fun `a fresh emulator starts on the PocketShell palette`() {
+        val emulator = createRemoteTerminalSession().emulator
+
+        assertPocketShellPalette(emulator)
+    }
+
+    @Test
+    fun `a full terminal reset returns to the PocketShell palette, not Termux black`() {
+        val emulator = createRemoteTerminalSession().emulator
+        emulator.feed(OSC_SET_BACKGROUND_RED)
+        assertEquals("an app may set its own background", RED, emulator.background())
+
+        emulator.feed(RIS)
+
+        assertPocketShellPalette(emulator)
+        assertNotEquals(
+            "the whole point: a reset must not land on Termux's default black",
+            TERMUX_DEFAULT_BLACK,
+            emulator.background(),
+        )
+    }
+
+    @Test
+    fun `an app resetting the colours it set lands on the PocketShell palette`() {
+        val emulator = createRemoteTerminalSession().emulator
+        emulator.feed(OSC_SET_BACKGROUND_RED)
+        emulator.feed(OSC_SET_FOREGROUND_RED)
+
+        emulator.feed(OSC_RESET_BACKGROUND)
+        assertEquals(BACKGROUND, emulator.background())
+        assertEquals("only the background was reset", RED, emulator.foreground())
+
+        emulator.feed(OSC_RESET_ALL_COLOURS)
+        assertPocketShellPalette(emulator)
+    }
+
+    @Test
+    fun `the hosted view's background follows the emulator's palette`() {
+        val session = host()
+        assertEquals(BACKGROUND, requireTerminalView().backgroundColour())
+
+        feedOnMain(session, OSC_SET_BACKGROUND_RED)
+        assertEquals(
+            "the renderer leaves default-background cells unpainted, so a " +
+                "background an app sets is only visible if the View follows it",
+            RED,
+            requireTerminalView().backgroundColour(),
+        )
+
+        feedOnMain(session, RIS)
+        assertEquals(BACKGROUND, requireTerminalView().backgroundColour())
+    }
+
+    // --- clipboard ---------------------------------------------------------
+
+    @Test
+    fun `copy from the selection menu lands the text on the system clipboard`() {
+        val session = host()
+
+        composeRule.runOnUiThread { session.onCopyTextToClipboard("echo copied") }
+
+        assertEquals("echo copied", clipboardText())
+    }
+
+    @Test
+    fun `OSC 52 from the remote lands on the system clipboard`() {
+        val session = host()
+        val payload = Base64.encodeToString("from the remote".toByteArray(), Base64.NO_WRAP)
+
+        feedOnMain(session, "]52;c;$payload")
+
+        assertEquals("from the remote", clipboardText())
+    }
+
+    @Test
+    fun `paste from the selection menu writes the clipboard text to the remote`() {
+        val session = host()
+        setClipboard("ls -la\n")
+
+        composeRule.runOnUiThread { session.onPasteTextFromClipboard() }
+
+        assertEquals("ls -la\r", session.bytesForRemote())
+    }
+
+    @Test
+    fun `paste is bracketed when the remote asked for it`() {
+        val session = host()
+        feedOnMain(session, ENABLE_BRACKETED_PASTE)
+        setClipboard("ls -la")
+
+        composeRule.runOnUiThread { session.onPasteTextFromClipboard() }
+
+        assertEquals("[200~ls -la[201~", session.bytesForRemote())
+    }
+
+    @Test
+    fun `an empty clipboard pastes nothing`() {
+        val session = host()
+
+        composeRule.runOnUiThread { session.onPasteTextFromClipboard() }
+
+        assertEquals("", session.bytesForRemote())
+    }
+
+    @Test
+    fun `without a hosting view the clipboard callbacks are inert, not crashes`() {
+        val session = createRemoteTerminalSession()
+        setClipboard("never sent")
+
+        session.onCopyTextToClipboard("never copied")
+        session.onPasteTextFromClipboard()
+
+        assertEquals("never sent", clipboardText())
+        assertEquals("", session.bytesForRemote())
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private fun host(): TerminalSession {
+        val session = createRemoteTerminalSession()
+        composeRule.setContent {
+            rootView = LocalView.current
+            TerminalHostView(
+                session = session,
+                onResized = { _, _ -> },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        composeRule.waitForIdle()
+        return session
+    }
+
+    /** Parses [sequence] on the main thread, the way the vendored drain does. */
+    private fun feedOnMain(session: TerminalSession, sequence: String) {
+        composeRule.runOnUiThread { session.emulator.feed(sequence) }
+        composeRule.waitForIdle()
+    }
+
+    private fun TerminalEmulator.feed(sequence: String) {
+        val bytes = sequence.toByteArray()
+        append(bytes, bytes.size)
+    }
+
+    private fun TerminalEmulator.background(): Int =
+        mColors.mCurrentColors[TextStyle.COLOR_INDEX_BACKGROUND]
+
+    private fun TerminalEmulator.foreground(): Int =
+        mColors.mCurrentColors[TextStyle.COLOR_INDEX_FOREGROUND]
+
+    private fun assertPocketShellPalette(emulator: TerminalEmulator) {
+        assertEquals(BACKGROUND, emulator.background())
+        assertEquals(FOREGROUND, emulator.foreground())
+        assertEquals(CURSOR, emulator.mColors.mCurrentColors[TextStyle.COLOR_INDEX_CURSOR])
+    }
+
+    /** Everything the emulator has queued for the remote, i.e. what the bridge's input pump would send. */
+    private fun TerminalSession.bytesForRemote(): String {
+        val buffer = ByteArray(4096)
+        val read = TerminalSessionInternals.readTerminalToProcessQueue(this, buffer)
+        return if (read <= 0) "" else String(buffer, 0, read)
+    }
+
+    private fun clipboard(): ClipboardManager =
+        context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+
+    private fun setClipboard(text: String) {
+        clipboard().setPrimaryClip(ClipData.newPlainText("test", text))
+    }
+
+    private fun clipboardText(): String? =
+        clipboard().primaryClip?.getItemAt(0)?.coerceToText(context)?.toString()
+
+    private fun TerminalView.backgroundColour(): Int = (background as ColorDrawable).color
+
+    private fun requireTerminalView(): TerminalView =
+        requireNotNull(findTerminalView(requireNotNull(rootView).rootView)) {
+            "no TerminalView in the composition — TerminalHostView did not host the vendored view"
+        }
+
+    private fun findTerminalView(view: View): TerminalView? {
+        if (view is TerminalView) return view
+        if (view !is ViewGroup) return null
+        for (index in 0 until view.childCount) {
+            findTerminalView(view.getChildAt(index))?.let { return it }
+        }
+        return null
+    }
+
+    private companion object {
+        val BACKGROUND: Int = PocketShellColors.Background.toArgb()
+        val FOREGROUND: Int = PocketShellColors.Text.toArgb()
+        val CURSOR: Int = PocketShellColors.Accent.toArgb()
+        const val RED: Int = 0xFFFF0000.toInt()
+
+        /** `TerminalColorScheme.DEFAULT_COLORSCHEME`'s background: what a reset used to land on. */
+        const val TERMUX_DEFAULT_BLACK: Int = 0xFF000000.toInt()
+
+        /** `ESC c` — RIS, what the `reset` command sends. */
+        const val RIS = "c"
+        const val OSC_SET_BACKGROUND_RED = "]11;#ff0000\\"
+        const val OSC_SET_FOREGROUND_RED = "]10;#ff0000\\"
+        const val OSC_RESET_BACKGROUND = "]111\\"
+        const val OSC_RESET_ALL_COLOURS = "]104\\"
+        const val ENABLE_BRACKETED_PASTE = "[?2004h"
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/terminal/TerminalTextSizeSettingWiringTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/TerminalTextSizeSettingWiringTest.kt
@@ -218,9 +218,9 @@ class TerminalTextSizeSettingWiringTest {
     /**
      * The size [TerminalView.setTextSize] actually built a renderer at.
      *
-     * [com.termux.view.TerminalRenderer.mTextSize] is package-private (the
-     * vendored class is pinned byte-identical to upstream), so this is a
-     * reflective read of the field `setTextSize` writes — the same field
+     * [com.termux.view.TerminalRenderer.mTextSize] is package-private in the
+     * vendored Termux source, which we keep as close to its upstream pin as we
+     * can, so this is a reflective read of the field `setTextSize` writes — the same field
      * `setTypeface` then reads. A test that stubbed `setTextSize` would still
      * pass with the factory hard-coding 28.
      */

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,7 +143,12 @@ Everything that used to sit between SSH and that emulator — `SshTerminalBridge
 `TerminalSurfaceState`, the drain schedulers/budgets, the frame coalescer — is
 gone. Its replacement is `app2`'s `TerminalPtyBridge`: PTY output → emulator,
 emulator input → PTY, one resize path. `TerminalHostView` is a thin `AndroidView`
-around `com.termux.view.TerminalView`.
+around `com.termux.view.TerminalView`; its session client is where the emulator's
+palette (installed as the vendored *default* scheme so `reset`/`OSC 104` return
+to it), the selection menu's Copy/Paste and `OSC 52` get a window and a
+clipboard. The emulator answers terminal queries (`DA`, `DSR`, `OSC 11 ?`) on
+the wire itself — it is the real terminal the remote program talks to, so the
+old tmux-mode suppression is gone.
 
 ## Connecting to a host
 

--- a/shared/core-terminal/PATCHES.md
+++ b/shared/core-terminal/PATCHES.md
@@ -45,6 +45,52 @@ Not byte-identical to upstream.
   `#259` cases in `TerminalTest.java`, `StatusSpinnerRewriteGridTest`, and
   `CapturePaneSeedReplayGridTest`.
 
-`com.termux.view.TerminalView` and the rest of `com.termux.terminal.**` remain
-byte-identical to upstream — see `TerminalRendererSpinnerRewriteInstrumentedTest`
-for the render-side coverage.
+## `src/main/java/com/termux/terminal/TerminalSession.java`
+
+Not byte-identical to upstream.
+
+- **#796/#803** — `MainThreadHandler` reads one 2 KB slice per `MSG_NEW_INPUT`
+  (upstream: 64 KB) and never re-posts itself; the poster (app2's
+  `TerminalPtyBridge`) writes the remote stream in slices of that size and
+  posts one message per slice, so no single main-thread turn parses more than
+  a slice of clear-heavy alt-screen content. `MSG_PROCESS_EXITED` drains the
+  whole queue first. The handler is pinned to `Looper.getMainLooper()`.
+
+## `src/main/java/com/termux/terminal/TerminalBuffer.java`, `TerminalRow.java`
+
+Not byte-identical to upstream.
+
+- **#469** — per-row `mGeneration` content stamps, bumped at every mutating
+  chokepoint, so `TerminalRenderer` can skip unchanged rows.
+- **#966/#967/#1153** — `getVisibleScreenText`, `getVisibleScreenTextFullyJoined`,
+  `getVisibleScreenRows` on the buffer, and `mHardWrapStart` on the row. These
+  fed the pre-0.5.0 stale-render oracles and smart-selection overlays; nothing
+  in app2 calls them today.
+
+## `src/main/java/com/termux/view/TerminalView.java`, `TerminalViewClient.java`
+
+Not byte-identical to upstream.
+
+- **#469/#721** — `onScreenUpdated` coalesces repaints through one
+  `postOnAnimation` runnable (`scheduleRenderInvalidation`) and
+  `forceFullRepaint()` resets the renderer's dirty cache.
+- **#966/#967** — `onDraw`/`updateSize` catch `Throwable` (an `Error` mid-render
+  used to crash the composition), paint one background frame, force a full
+  repaint next frame, and report through `TerminalViewClient.onTerminalRenderFailure`.
+- **#529/#1854** — smart-text IME staging behind
+  `TerminalViewClient.shouldUseSmartTextInput()` (default false), and a
+  multi-line IME commit is framed with `BracketedPaste` before it is written.
+- **#2154** — a resize during a live text selection keeps the viewport row
+  instead of snapping to the bottom; `TerminalViewClient.onScrollChanged()`
+  reports viewport moves.
+
+Removed on 2026-09-06 (the rewrite left them without a caller): the emulator's
+`setSuppressQueryResponses` (#246 — with one PTY source every query must be
+answered; `TerminalTest.testQueryResponsesAreAnswered` pins that), the
+session's `availableProcessOutputBytes` / `onProcessOutputDrained` drain seams
+(#803), the view's `FramePaintObserver`, `forceSurfaceRepaint` and PixelCopy
+surface-black probe (#1192/#1203/#1296/#1443/#2003), and the buffer's
+`hasNonBlankVisibleRow`.
+
+`TerminalSessionClient.java` and everything not listed above is byte-identical
+to upstream at the pinned commit.

--- a/shared/core-terminal/PATCHES.md
+++ b/shared/core-terminal/PATCHES.md
@@ -1,12 +1,124 @@
 # Local patches to the vendored Termux sources
 
-`VENDORED.md` pins the upstream commit and lists which files are *byte-identical*
-to upstream. Any deviation — even a one-character change — is recorded here so a
-future vendoring refresh knows what to re-apply.
+`VENDORED.md` pins the upstream commit. This file is the complete list of files
+that deviate from that pin and what each deviation is, so a future vendoring
+refresh knows what to re-apply. Any deviation — even a one-character change —
+is recorded here.
+
+The list below was produced by diffing the whole vendored tree
+(`src/main/java/com/termux/**`, `src/test/java/com/termux/**`,
+`src/main/res/**`, `src/main/jni/**`) against the pinned upstream commit
+`30ebb2dee381d292ade0f2868cfde0f9f20b89fe`. **Eight production files and four
+test files deviate; every other vendored file — including
+`TerminalSessionClient.java`, `ByteQueue.java`, the `textselection` package,
+the resources and the JNI sources — is byte-identical to upstream.** Re-run
+that diff (see `VENDORED.md` → "Refresh procedure") whenever this file is
+edited: a claim of byte-identity is only useful if it has been checked, and
+this file has been wrong about it before.
+
+Deviating files:
+
+| File | Patch families |
+|---|---|
+| `src/main/java/com/termux/terminal/TerminalEmulator.java` | #259, #1955/#1961 |
+| `src/main/java/com/termux/terminal/TerminalBuffer.java` | #469, #966/#967/#1153, #1955/#1961 |
+| `src/main/java/com/termux/terminal/TerminalRow.java` | #469, #1955 |
+| `src/main/java/com/termux/terminal/TerminalSession.java` | #796/#803 |
+| `src/main/java/com/termux/terminal/TextStyle.java` | #1955/#1961 |
+| `src/main/java/com/termux/view/TerminalRenderer.java` | #172, #241, #259, #469 |
+| `src/main/java/com/termux/view/TerminalView.java` | #107, #469/#721, #529/#1854, #568/#588, #966/#967, #2154 |
+| `src/main/java/com/termux/view/TerminalViewClient.java` | #529/#1854, #966/#967, #2154 |
+| `src/test/java/com/termux/terminal/*` (4 files) | see "Vendored test sources" below |
+
+## `src/main/java/com/termux/terminal/TerminalEmulator.java`
+
+- **#259** — carriage-return overwrite tracking. When the agent rewrites its
+  status/spinner line in place with a bare `\r` followed by a *shorter* string,
+  upstream leaves the tail of the previous (longer) frame stranded on the row,
+  so two spinner frames coexist (the "rows run together / `gthinkingwithout`"
+  garble). The patch tracks a pending CR-overwrite region
+  (`mCarriageReturnOverwrite*` fields + `recordCarriageReturnOverwrite` /
+  `markCarriageReturnOverwriteOutput` / `finishCarriageReturnOverwrite` /
+  `clearCarriageReturnOverwrite`, called from the `\r` control case,
+  `doLinefeed`, `scrollDownOneLine`, `setCursorCol` and the cell-emit path): on
+  a bare `\r` it remembers the original line-end column, and when the rewrite
+  finishes shorter it clears the stale tail cells. Intentional, tested
+  deviation from strict xterm semantics, tuned for agent spinners — see the
+  `#259` cases in `TerminalTest.java`, `StatusSpinnerRewriteGridTest`, and
+  `CapturePaneSeedReplayGridTest`.
+- **#1955/#1961** — OSC 8 hyperlink provenance. `doOsc` gains a `case 8:` that
+  tracks whether a hyperlink is open (`mOsc8HyperlinkActive` /
+  `mOsc8HyperlinkStartPending`; the URI itself is deliberately **not** stored),
+  `getStyle()` ORs the two `TextStyle` provenance bits into every emitted
+  cell's style, the cell-emit path clears the start-pending flag after the
+  first printable cell, and `reset()` clears both flags. Consumed by
+  `com.pocketshell.core.terminal.selection.ViewportTextExtraction`, which uses
+  the marker to tell a declared hyperlink continuation apart from
+  same-colour text on the next row.
+- **#1955** — cursor-addressed hard-wrap tracking (`mHardWrapCandidateRow` /
+  `mHardWrapContinuationRow`, `recordCursorAddressedHardWrap`,
+  `confirmHardWrapStart`, `clearHardWrapTracking`, and the
+  `setCursorRow(int, boolean fromLinefeed)` overload). A fixed-width agent TUI
+  commonly disables autowrap and paints the continuation of a long URL by
+  addressing the next row with CSI, so upstream's `mLineWrap` bit stays false
+  and a wrapped link cannot be rejoined. The patch records the boundary on the
+  buffer instead (`TerminalBuffer.setHardWrapStart`, below).
+- **Cosmetic** — the two-line CPR comment in the `DSR 6` case is reflowed onto
+  one line. No behaviour change; re-flow or drop it freely on a refresh.
+
+## `src/main/java/com/termux/terminal/TerminalBuffer.java`
+
+- **#469** — `getScreenFirstRow()` / `getTotalRows()` expose the circular
+  buffer's origin and length so `TerminalRenderer`'s dirty-region cache can
+  detect ring-buffer scroll and shift its per-row generation stamps; the
+  direct style write in `setOrClearEffect` calls `TerminalRow.bumpGeneration()`
+  because it bypasses `TerminalRow.setChar`. `getScreenFirstRow` /
+  `getTotalRows` currently have no caller outside the vendored tree.
+- **#966/#967/#1153** — `getVisibleScreenText()`,
+  `getVisibleScreenTextFullyJoined()`, `getVisibleScreenRows()`. These fed the
+  pre-0.5.0 stale-render oracles; nothing in app2 calls them today.
+- **#1955** — `getHardWrapStart` / `setHardWrapStart` / `clearHardWrapStart` /
+  `clearAllHardWrapStarts` and `lineFillsWidth(row)`, plus the
+  `clearAllHardWrapStarts()` call at the top of `resize(...)` (a reflow
+  invalidates boundaries recorded under the old geometry). `getHardWrapStart`
+  is read by `ViewportTextExtraction`; the setters are driven by
+  `TerminalEmulator`'s hard-wrap tracking above.
+- **#1961** — `setOrClearEffect` writes
+  `TextStyle.encodePreservingProvenance(...)` instead of `TextStyle.encode(...)`
+  so a DECCARA/DECRARA rectangular attribute change over an already-painted
+  cell does not erase that cell's OSC 8 provenance bits.
+
+## `src/main/java/com/termux/terminal/TerminalRow.java`
+
+- **#469** — the public `mGeneration` content stamp (starting at `1`) and
+  `bumpGeneration()`, bumped at every mutating chokepoint (`setChar`, `clear`,
+  and the buffer's direct style writes) so `TerminalRenderer` can skip
+  unchanged rows.
+- **#1955** — the `mHardWrapStart` row flag: cleared by `setChar` and `clear`
+  (a direct cell write is a content replacement, so stale provenance must not
+  survive), and transferred by `copyInterval` only for a whole-row copy.
+
+## `src/main/java/com/termux/terminal/TextStyle.java`
+
+- **#1955/#1961** — the OSC 8 provenance encoding:
+  `CHARACTER_ATTRIBUTE_OSC8_HYPERLINK` (bit 11),
+  `CHARACTER_ATTRIBUTE_OSC8_HYPERLINK_START` (bit 12), `OSC8_PROVENANCE_MASK`,
+  and `encodePreservingProvenance(fore, back, effect, previousStyle)`. Bits
+  11..15 are unused by Termux's effect/colour encoding and are deliberately
+  kept out of `decodeEffect(long)`, so the markers are rendering-neutral. No
+  hyperlink URI is ever stored in a cell — the bits are pure provenance.
+
+## `src/main/java/com/termux/terminal/TerminalSession.java`
+
+- **#796/#803** — `MainThreadHandler` reads one 2 KB slice per `MSG_NEW_INPUT`
+  (upstream: 64 KB) and never re-posts itself; the poster (app2's
+  `TerminalPtyBridge`) writes the remote stream in slices of that size and
+  posts one message per slice, so no single main-thread turn parses more than
+  a slice of clear-heavy alt-screen content. `MSG_PROCESS_EXITED` drains the
+  whole queue first (`drainAllProcessOutput`). The handler is pinned to
+  `Looper.getMainLooper()`.
 
 ## `src/main/java/com/termux/view/TerminalRenderer.java`
-
-Not byte-identical to upstream. PocketShell terminal-rendering polish lives here:
 
 - **#172** — Option A "pin cell width to regular-advance": bold runs are
   re-measured with the bold paint and squashed into the regular-advance cell
@@ -16,6 +128,9 @@ Not byte-identical to upstream. PocketShell terminal-rendering polish lives here
 - **#241** — row pitch derived from the glyph bounding box
   (`-ascent + descent`) times `LINE_SPACING_MULTIPLIER` instead of
   `Paint#getFontSpacing()`, to fit more rows on a phone viewport.
+  `getFontLineSpacingAndAscent()` exposes the derived metric; it currently has
+  no caller outside the vendored tree (`TerminalGeometry` re-derives the same
+  formula because the fields are package-private).
 - **#259** — disable font ligatures / contextual alternates on the text paint
   (`setFontFeatureSettings("'liga' 0, 'clig' 0, 'dlig' 0, 'calt' 0")`). A
   terminal is a fixed monospace cell grid; programming fonts ship
@@ -27,70 +142,102 @@ Not byte-identical to upstream. PocketShell terminal-rendering polish lives here
   cell. On the bundled face the per-glyph advances are already uniform so cell
   layout is unchanged (verified by `allRegularCellsRemainAligned` + the #172
   tests); this removes the visual cell-merging a face's shaper could apply.
+- **#469** — dirty-region rendering: a per-logical-row generation cache
+  (keyed off `TerminalRow.mGeneration` plus cursor/selection/palette/reverse
+  state), `peekDirtyRows(...)` with the `PEEK_FULL` / `PEEK_NONE` sentinels,
+  `computeDirtyRows(...)`, `rowTopPx(i)` / `rowBottomPx(i)`,
+  `invalidateDirtyCache()`, the `mClipScratch` clip-bounds scratch, and the
+  clip-gated per-row skip inside `render(...)`.
+  `getLastRenderedRowCountForTesting()` is a leftover hook with no caller
+  outside the vendored tree.
 
-## `src/main/java/com/termux/terminal/TerminalEmulator.java`
+## `src/main/java/com/termux/view/TerminalView.java`
 
-Not byte-identical to upstream.
-
-- **#259** — carriage-return overwrite tracking. When the agent rewrites its
-  status/spinner line in place with a bare `\r` followed by a *shorter* string,
-  upstream leaves the tail of the previous (longer) frame stranded on the row,
-  so two spinner frames coexist (the "rows run together / `gthinkingwithout`"
-  garble). The patch tracks a pending CR-overwrite region
-  (`mCarriageReturnOverwrite*` fields + `recordCarriageReturnOverwrite` /
-  `markCarriageReturnOverwriteOutput` / `finishCarriageReturnOverwrite`): on a
-  bare `\r` it remembers the original line-end column, and when the rewrite
-  finishes shorter it clears the stale tail cells. Intentional, tested
-  deviation from strict xterm semantics, tuned for agent spinners — see the
-  `#259` cases in `TerminalTest.java`, `StatusSpinnerRewriteGridTest`, and
-  `CapturePaneSeedReplayGridTest`.
-
-## `src/main/java/com/termux/terminal/TerminalSession.java`
-
-Not byte-identical to upstream.
-
-- **#796/#803** — `MainThreadHandler` reads one 2 KB slice per `MSG_NEW_INPUT`
-  (upstream: 64 KB) and never re-posts itself; the poster (app2's
-  `TerminalPtyBridge`) writes the remote stream in slices of that size and
-  posts one message per slice, so no single main-thread turn parses more than
-  a slice of clear-heavy alt-screen content. `MSG_PROCESS_EXITED` drains the
-  whole queue first. The handler is pinned to `Looper.getMainLooper()`.
-
-## `src/main/java/com/termux/terminal/TerminalBuffer.java`, `TerminalRow.java`
-
-Not byte-identical to upstream.
-
-- **#469** — per-row `mGeneration` content stamps, bumped at every mutating
-  chokepoint, so `TerminalRenderer` can skip unchanged rows.
-- **#966/#967/#1153** — `getVisibleScreenText`, `getVisibleScreenTextFullyJoined`,
-  `getVisibleScreenRows` on the buffer, and `mHardWrapStart` on the row. These
-  fed the pre-0.5.0 stale-render oracles and smart-selection overlays; nothing
-  in app2 calls them today.
-
-## `src/main/java/com/termux/view/TerminalView.java`, `TerminalViewClient.java`
-
-Not byte-identical to upstream.
-
+- **#107** — `mDefaultBackgroundColor` + `setDefaultBackgroundColor(int)`
+  (which also mirrors into `setBackgroundColor`), used by both `onDraw`
+  fallbacks instead of a hard-coded `0xFF000000`, so the unattached canvas
+  paints the PocketShell design background rather than flashing pure black.
+  app2's `TerminalHostView` drives it from the emulator's palette.
 - **#469/#721** — `onScreenUpdated` coalesces repaints through one
-  `postOnAnimation` runnable (`scheduleRenderInvalidation`) and
-  `forceFullRepaint()` resets the renderer's dirty cache.
-- **#966/#967** — `onDraw`/`updateSize` catch `Throwable` (an `Error` mid-render
-  used to crash the composition), paint one background frame, force a full
-  repaint next frame, and report through `TerminalViewClient.onTerminalRenderFailure`.
+  `postOnAnimation` runnable (`scheduleRenderInvalidation`),
+  `invalidateDirtyRegion()` invalidates one rect per contiguous dirty run from
+  `TerminalRenderer.peekDirtyRows`, and `forceFullRepaint()` resets the
+  renderer's dirty cache (also called from `onAttachedToWindow`, since a
+  reattached View starts on a cleared surface the cache still believes is
+  painted). The five `*ForTesting` render-invalidation hooks
+  (`hasPendingRenderInvalidationForTesting`,
+  `getPendingRenderInvalidationRequestsForTesting`,
+  `getCoalescedRenderInvalidationFramesForTesting`,
+  `requestRenderInvalidationForTesting`,
+  `drainPendingRenderInvalidationForTesting`) have no caller since the 0.5.0
+  rewrite.
 - **#529/#1854** — smart-text IME staging behind
-  `TerminalViewClient.shouldUseSmartTextInput()` (default false), and a
-  multi-line IME commit is framed with `BracketedPaste` before it is written.
+  `TerminalViewClient.shouldUseSmartTextInput()` (default false): the
+  `SmartTextStagingPolicy` enum, `mSmartTextStagingEditable` and its
+  `rememberSmartTextStaging` / `hasSmartTextStaging` / `clearSmartTextStaging`
+  / `flushSmartTextStagingToTerminal` / `prepareForRawTerminalInput` helpers,
+  the extra `InputConnection` overrides (`setComposingText`,
+  `performContextMenuAction`, `performEditorAction`, `sendKeyEvent`), and the
+  `isMultiLinePasteText` / `sendBracketedPasteToTerminal` split that frames a
+  commit containing a *content* line break with `BracketedPaste` (a single
+  trailing newline stays an ordinary submit). This is the one place the
+  vendored source imports PocketShell code
+  (`com.pocketshell.core.terminal.input.BracketedPaste`).
+  `prepareForRawTerminalInput` has no caller since the 0.5.0 rewrite.
+- **#568/#588** — the `requestFocus()` call in the single-tap gesture handler
+  is **removed**, so tapping the terminal does not steal focus from the
+  keyboard accessory row.
+- **#966/#967** — `onDraw`/`updateSize` catch `Throwable` (an `Error`
+  mid-render used to crash the composition), paint one background frame,
+  force a full repaint next frame, and report through
+  `reportTerminalViewFailure` → `TerminalViewClient.onTerminalRenderFailure`;
+  the IME `InputConnection` overrides catch `RuntimeException` the same way.
+  `updateSize` also returns early on non-positive font metrics.
 - **#2154** — a resize during a live text selection keeps the viewport row
-  instead of snapping to the bottom; `TerminalViewClient.onScrollChanged()`
-  reports viewport moves.
+  instead of snapping to the bottom; `doScroll` and `setTopRow` only fire when
+  the top row actually moves and report the move through
+  `TerminalViewClient.onScrollChanged()`.
 
-Removed on 2026-09-06 (the rewrite left them without a caller): the emulator's
-`setSuppressQueryResponses` (#246 — with one PTY source every query must be
-answered; `TerminalTest.testQueryResponsesAreAnswered` pins that), the
-session's `availableProcessOutputBytes` / `onProcessOutputDrained` drain seams
-(#803), the view's `FramePaintObserver`, `forceSurfaceRepaint` and PixelCopy
-surface-black probe (#1192/#1203/#1296/#1443/#2003), and the buffer's
+## `src/main/java/com/termux/view/TerminalViewClient.java`
+
+Three added default methods, so upstream clients stay source-compatible:
+
+- **#529/#1854** — `shouldUseSmartTextInput()` (default `false`).
+- **#966/#967** — `onTerminalRenderFailure(String, Throwable)` (default no-op);
+  `Throwable` rather than `Exception` so an `Error` thrown while rendering
+  reaches the same recovery path.
+- **#2154** — `onScrollChanged()` (default no-op).
+
+## Vendored test sources
+
+`src/test/java/com/termux/terminal/**` is otherwise upstream; four files add
+PocketShell cases (no upstream case is modified or deleted):
+
+- **`TerminalTest.java`** — the #259 CR-overwrite cases
+  (`testCarriageReturnOverwriteClearsStaleTailBeforeLinefeed`,
+  `testCursorOverwriteClearsStaleTailBeforeLinefeed`,
+  `testCarriageReturnLinefeedWithoutOverwriteKeepsLine`) and
+  `testQueryResponsesAreAnswered`, which pins that `CSI 14t`/`18t`, `CSI c`,
+  `CSI >c`, `CSI 5n`, `CSI 6n` and `OSC 11 ?` are answered on the wire now that
+  the #246 query-suppression flag is gone (#2557).
+- **`OperatingSystemControlTest.java`** — five OSC 8 provenance and
+  cursor-addressed hard-wrap cases (#1955).
+- **`RectangularAreasTest.java`** — four DECCARA/DECRARA cases pinning that a
+  rectangular attribute change preserves OSC 8 provenance (#1961).
+- **`TextStyleTest.java`** — four cases pinning the provenance bit layout and
+  `encodePreservingProvenance` (#1955/#1961).
+
+## Removed patches
+
+Removed on 2026-09-06 (the 0.5.0 rewrite left them without a caller), restoring
+those hunks to upstream: the emulator's `setSuppressQueryResponses` (#246 —
+with one PTY source every query must be answered;
+`TerminalTest.testQueryResponsesAreAnswered` pins that), the session's
+`availableProcessOutputBytes` / `onProcessOutputDrained` drain seams and
+`ByteQueue.getAvailable()` (#803), `TerminalSessionClient.onProcessOutputDrained`
+(which restores that file byte-identical to upstream), the view's
+`FramePaintObserver`, `forceSurfaceRepaint` and PixelCopy surface-black probe
+(#1192/#1203/#1296/#1443/#2003) with the `android.graphics.Color` /
+`android.graphics.Rect` / `android.view.Window` /
+`androidx.annotation.VisibleForTesting` imports they needed, and the buffer's
 `hasNonBlankVisibleRow`.
-
-`TerminalSessionClient.java` and everything not listed above is byte-identical
-to upstream at the pinned commit.

--- a/shared/core-terminal/VENDORED.md
+++ b/shared/core-terminal/VENDORED.md
@@ -42,15 +42,18 @@ modifications).
 
 | Path | Source | Notes |
 |---|---|---|
-| `src/main/java/com/termux/terminal/**` | upstream `terminal-emulator/src/main/java/com/termux/terminal/**` | **patched** — `TerminalEmulator`, `TerminalSession`, `TerminalBuffer`, `TerminalRow`; every deviation is listed in `PATCHES.md`. Rest byte-identical. |
-| `src/main/java/com/termux/view/**` | upstream `terminal-view/src/main/java/com/termux/view/**` | **patched** — `TerminalRenderer`, `TerminalView`, `TerminalViewClient`; every deviation is listed in `PATCHES.md`. Rest byte-identical. |
+| `src/main/java/com/termux/terminal/**` | upstream `terminal-emulator/src/main/java/com/termux/terminal/**` | **patched** — `TerminalEmulator`, `TerminalBuffer`, `TerminalRow`, `TerminalSession`, `TextStyle`; every deviation is listed in `PATCHES.md`. Rest (including `ByteQueue`, `TerminalSessionClient`) byte-identical. |
+| `src/main/java/com/termux/view/**` | upstream `terminal-view/src/main/java/com/termux/view/**` | **patched** — `TerminalRenderer`, `TerminalView`, `TerminalViewClient`; every deviation is listed in `PATCHES.md`. Rest (including the `textselection` package) byte-identical. |
 | `src/main/res/drawable/text_select_handle_*.xml` | upstream `terminal-view/src/main/res/drawable/` | byte-identical |
 | `src/main/res/values/strings.xml` | upstream `terminal-view/src/main/res/values/strings.xml` | byte-identical |
 | `src/main/jni/termux.c`, `src/main/jni/Android.mk` | upstream `terminal-emulator/src/main/jni/` | **not compiled** — see "JNI handling" |
-| `src/test/java/com/termux/terminal/**` | upstream `terminal-emulator/src/test/java/com/termux/terminal/**` | patched — adds #259 CR-overwrite cases and `testQueryResponsesAreAnswered` to `TerminalTest.java`; rest byte-identical |
+| `src/test/java/com/termux/terminal/**` | upstream `terminal-emulator/src/test/java/com/termux/terminal/**` | **patched** — adds cases (never modifies upstream ones) to `TerminalTest`, `OperatingSystemControlTest`, `RectangularAreasTest`, `TextStyleTest`; listed in `PATCHES.md`. Rest byte-identical. |
 
 If we ever deviate from upstream — even a one-character patch — record it in
-`PATCHES.md` alongside this file.
+`PATCHES.md` alongside this file. `PATCHES.md`'s file list is authoritative and
+was produced by diffing the whole vendored tree against the pin; regenerate it
+the same way (step 5 of the refresh procedure) rather than editing it from
+memory.
 
 ## Namespace handling
 
@@ -147,8 +150,9 @@ When #9 lands, it will either:
 - Vendor a fresh fork of `TerminalSession` (non-final) into our own
   package that drives `TerminalEmulator` + `TerminalBuffer` from
   SSH-attached PTY bytes, bypassing JNI entirely. The vendored
-  `TerminalSession` source stays byte-identical to upstream as
-  refresh-tracking parity; our fork lives under `com.pocketshell.core.terminal.*`.
+  `TerminalSession` source stays as close to upstream as possible for
+  refresh-tracking parity (its actual deviations are listed in `PATCHES.md`);
+  our fork lives under `com.pocketshell.core.terminal.*`.
 
 Either path keeps the #8 public API stable.
 
@@ -156,7 +160,8 @@ Either path keeps the #8 public API stable.
 
 `com.pocketshell.core.terminal.bridge.SshTerminalBridge` (in this module) is
 intentionally kept outside the `com.termux.terminal` package so the vendored
-sources stay byte-identical to upstream. To do that without forking Termux,
+sources need as few local patches as possible. To do that without forking
+Termux,
 the bridge reaches into a handful of package-private members of
 [`TerminalSession`](src/main/java/com/termux/terminal/TerminalSession.java)
 and [`ByteQueue`](src/main/java/com/termux/terminal/ByteQueue.java) via
@@ -259,9 +264,13 @@ When a future Termux release fixes a bug or adds a CSI sequence we care about:
    cp -r /tmp/termux-app/terminal-emulator/src/test/java/com/termux \
          shared/core-terminal/src/test/java/com/termux
    ```
-5. Diff against the previous pin; if the upstream `androidx.annotation`
-   version changed, bump `androidx-annotation` in `gradle/libs.versions.toml`
-   to match.
+5. Diff the whole vendored tree against the new pin (`diff -rq` of
+   `src/main/java/com/termux`, `src/test/java/com/termux`, `src/main/res` and
+   `src/main/jni` against the upstream checkout) and **regenerate `PATCHES.md`
+   from that diff**, not from memory — its file list is the record a future
+   refresh re-applies from, and it has been wrong before. If the upstream
+   `androidx.annotation` version changed, bump `androidx-annotation` in
+   `gradle/libs.versions.toml` to match.
 6. Re-read upstream `LICENSE.md` — if the `terminal-emulator` /
    `terminal-view` license stops being Apache 2.0, update `LICENSE.txt` and
    `app/src/main/res/raw/third_party_licenses.txt`.

--- a/shared/core-terminal/VENDORED.md
+++ b/shared/core-terminal/VENDORED.md
@@ -42,12 +42,12 @@ modifications).
 
 | Path | Source | Notes |
 |---|---|---|
-| `src/main/java/com/termux/terminal/**` | upstream `terminal-emulator/src/main/java/com/termux/terminal/**` | **patched** — `TerminalEmulator.java` carries the #259 CR-overwrite fix; see `PATCHES.md`. Rest byte-identical. |
-| `src/main/java/com/termux/view/**` | upstream `terminal-view/src/main/java/com/termux/view/**` | **patched** — `TerminalRenderer.java` carries #172/#241/#259 changes; see `PATCHES.md`. Rest byte-identical. |
+| `src/main/java/com/termux/terminal/**` | upstream `terminal-emulator/src/main/java/com/termux/terminal/**` | **patched** — `TerminalEmulator`, `TerminalSession`, `TerminalBuffer`, `TerminalRow`; every deviation is listed in `PATCHES.md`. Rest byte-identical. |
+| `src/main/java/com/termux/view/**` | upstream `terminal-view/src/main/java/com/termux/view/**` | **patched** — `TerminalRenderer`, `TerminalView`, `TerminalViewClient`; every deviation is listed in `PATCHES.md`. Rest byte-identical. |
 | `src/main/res/drawable/text_select_handle_*.xml` | upstream `terminal-view/src/main/res/drawable/` | byte-identical |
 | `src/main/res/values/strings.xml` | upstream `terminal-view/src/main/res/values/strings.xml` | byte-identical |
 | `src/main/jni/termux.c`, `src/main/jni/Android.mk` | upstream `terminal-emulator/src/main/jni/` | **not compiled** — see "JNI handling" |
-| `src/test/java/com/termux/terminal/**` | upstream `terminal-emulator/src/test/java/com/termux/terminal/**` | patched — adds #259 CR-overwrite cases to `TerminalTest.java`; rest byte-identical |
+| `src/test/java/com/termux/terminal/**` | upstream `terminal-emulator/src/test/java/com/termux/terminal/**` | patched — adds #259 CR-overwrite cases and `testQueryResponsesAreAnswered` to `TerminalTest.java`; rest byte-identical |
 
 If we ever deviate from upstream — even a one-character patch — record it in
 `PATCHES.md` alongside this file.

--- a/shared/core-terminal/src/main/java/com/termux/terminal/ByteQueue.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/ByteQueue.java
@@ -17,17 +17,6 @@ final class ByteQueue {
         notify();
     }
 
-    /**
-     * PocketShell #803: the number of bytes currently buffered and not yet read.
-     * The PocketShell MainThreadDrainScheduler reads this on the main thread to
-     * decide whether a frame-budgeted drain turn must yield-and-continue (more
-     * bytes pending) or has emptied the queue. Synchronized for the same
-     * happens-before guarantees as {@link #read} / {@link #write}.
-     */
-    public synchronized int getAvailable() {
-        return mStoredBytes;
-    }
-
     public synchronized int read(byte[] buffer, boolean block) {
         while (mStoredBytes == 0 && mOpen) {
             if (block) {

--- a/shared/core-terminal/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -83,25 +83,6 @@ public final class TerminalBuffer {
         return mScreenRows;
     }
 
-    /**
-     * Issue #1296: does ANY currently VISIBLE screen row (0..mScreenRows,
-     * scrollback excluded) carry a non-blank cell? A cheap, allocation-free
-     * early-exit scan (returns on the first non-blank row) — unlike
-     * {@link #getVisibleScreenText()} it builds no string, so it is safe to call
-     * every frame from the {@link com.termux.view.TerminalView#onDraw} render
-     * path. Used by the paint-confirmation seam to decide whether a frame that
-     * bound a non-null emulator actually rendered CONTENT (true) or is effectively
-     * blank/black (false) — {@code mEmulator != null} alone is NOT proof of a
-     * painted frame.
-     */
-    public boolean hasNonBlankVisibleRow() {
-        for (int row = 0; row < mScreenRows; row++) {
-            TerminalRow line = mLines[externalToInternalRow(row)];
-            if (line != null && !line.isBlank()) return true;
-        }
-        return false;
-    }
-
     public String getTranscriptTextWithoutJoinedLines() {
         return getSelectedText(0, -getActiveTranscriptRows(), mColumns, mScreenRows, false).trim();
     }

--- a/shared/core-terminal/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -181,12 +181,6 @@ public final class TerminalEmulator {
     /** The terminal session this emulator is bound to. */
     private final TerminalOutput mSession;
 
-    private boolean mSuppressQueryResponses = false;
-
-    public void setSuppressQueryResponses(boolean suppress) {
-        mSuppressQueryResponses = suppress;
-    }
-
     private int mCarriageReturnOverwriteRow = -1;
     private int mCarriageReturnOverwriteOriginalEndCol = -1;
     private int mCarriageReturnOverwriteNewEndCol = -1;
@@ -888,7 +882,7 @@ public final class TerminalEmulator {
                                     value = 0; // 0=not recognized, 3=permanently set, 4=permanently reset
                                 }
                             }
-                            if (!mSuppressQueryResponses) mSession.write(String.format(Locale.US, "\033[?%d;%d$y", mode, value));
+                            mSession.write(String.format(Locale.US, "\033[?%d;%d$y", mode, value));
                         } else {
                             unknownSequence(b);
                         }
@@ -950,7 +944,7 @@ public final class TerminalEmulator {
                     if (dcs.equals("$q\"p")) {
                         // DECSCL, conformance level, http://www.vt100.net/docs/vt510-rm/DECSCL:
                         String csiString = "64;1\"p";
-                        if (!mSuppressQueryResponses) mSession.write("\033P1$r" + csiString + "\033\\");
+                        mSession.write("\033P1$r" + csiString + "\033\\");
                     } else {
                         finishSequenceAndLogError("Unrecognized DECRQSS string: '" + dcs + "'");
                     }
@@ -1031,13 +1025,13 @@ public final class TerminalEmulator {
                                         Logger.logWarn(mClient, LOG_TAG, "Unhandled termcap/terminfo name: '" + trans + "'");
                                 }
                                 // Respond with invalid request:
-                                if (!mSuppressQueryResponses) mSession.write("\033P0+r" + part + "\033\\");
+                                mSession.write("\033P0+r" + part + "\033\\");
                             } else {
                                 StringBuilder hexEncoded = new StringBuilder();
                                 for (int j = 0; j < responseValue.length(); j++) {
                                     hexEncoded.append(String.format("%02X", (int) responseValue.charAt(j)));
                                 }
-                                if (!mSuppressQueryResponses) mSession.write("\033P1+r" + part + "=" + hexEncoded + "\033\\");
+                                mSession.write("\033P1+r" + part + "=" + hexEncoded + "\033\\");
                             }
                         } else {
                             Logger.logError(mClient, LOG_TAG, "Invalid device termcap/terminfo name of odd length: " + part);
@@ -1176,7 +1170,7 @@ public final class TerminalEmulator {
                 switch (getArg0(-1)) {
                     case 6:
                         // Extended Cursor Position (DECXCPR - http://www.vt100.net/docs/vt510-rm/DECXCPR). Page=1.
-                        if (!mSuppressQueryResponses) mSession.write(String.format(Locale.US, "\033[?%d;%d;1R", mCursorRow + 1, mCursorCol + 1));
+                        mSession.write(String.format(Locale.US, "\033[?%d;%d;1R", mCursorRow + 1, mCursorCol + 1));
                         break;
                     default:
                         finishSequence();
@@ -1321,7 +1315,7 @@ public final class TerminalEmulator {
                 // * vim checks xterm version number >140 for "Request termcap/terminfo string" functionality >276 for SGR
                 // mouse report.
                 // The third number is a keyboard identifier not used nowadays.
-                if (!mSuppressQueryResponses) mSession.write("\033[>41;320;0c");
+                mSession.write("\033[>41;320;0c");
                 break;
             case 'm':
                 // https://bugs.launchpad.net/gnome-terminal/+bug/96676/comments/25
@@ -1743,9 +1737,7 @@ public final class TerminalEmulator {
                 // The important part that may still be used by some (tmux stores this value but does not currently use it)
                 // is the first response parameter identifying the terminal service class, where we send 64 for "vt420".
                 // This is followed by a list of attributes which is probably unused by applications. Send like xterm.
-                if (!mSuppressQueryResponses) {
-                    if (getArg0(0) == 0) mSession.write("\033[?64;1;2;6;9;15;18;21;22c");
-                }
+                if (getArg0(0) == 0) mSession.write("\033[?64;1;2;6;9;15;18;21;22c");
                 break;
             case 'd': // ESC [ Pn d - Vert Position Absolute
                 setCursorRow(Math.min(Math.max(1, getArg0(1)), mRows) - 1);
@@ -1782,15 +1774,13 @@ public final class TerminalEmulator {
                 // sendDeviceAttributes()
                 switch (getArg0(0)) {
                     case 5: // Device status report (DSR):
-                        if (!mSuppressQueryResponses) {
-                            // Answer is ESC [ 0 n (Terminal OK).
-                            byte[] dsr = {(byte) 27, (byte) '[', (byte) '0', (byte) 'n'};
-                            mSession.write(dsr, 0, dsr.length);
-                        }
+                        // Answer is ESC [ 0 n (Terminal OK).
+                        byte[] dsr = {(byte) 27, (byte) '[', (byte) '0', (byte) 'n'};
+                        mSession.write(dsr, 0, dsr.length);
                         break;
                     case 6: // Cursor position report (CPR):
                         // Answer is ESC [ y ; x R, where x,y is the cursor location.
-                        if (!mSuppressQueryResponses) mSession.write(String.format(Locale.US, "\033[%d;%dR", mCursorRow + 1, mCursorCol + 1));
+                        mSession.write(String.format(Locale.US, "\033[%d;%dR", mCursorRow + 1, mCursorCol + 1));
                         break;
                     default:
                         break;
@@ -1827,29 +1817,29 @@ public final class TerminalEmulator {
             case 't': // Window manipulation (from dtterm, as well as extensions)
                 switch (getArg0(0)) {
                     case 11: // Report xterm window state. If the xterm window is open (non-iconified), it returns CSI 1 t .
-                        if (!mSuppressQueryResponses) mSession.write("\033[1t");
+                        mSession.write("\033[1t");
                         break;
                     case 13: // Report xterm window position. Result is CSI 3 ; x ; y t
-                        if (!mSuppressQueryResponses) mSession.write("\033[3;0;0t");
+                        mSession.write("\033[3;0;0t");
                         break;
                     case 14: // Report xterm window in pixels. Result is CSI 4 ; height ; width t
-                        if (!mSuppressQueryResponses) mSession.write(String.format(Locale.US, "\033[4;%d;%dt", mRows * mCellHeightPixels, mColumns * mCellWidthPixels));
+                        mSession.write(String.format(Locale.US, "\033[4;%d;%dt", mRows * mCellHeightPixels, mColumns * mCellWidthPixels));
                         break;
                     case 16: // Report xterm character cell size in pixels. Result is CSI 6 ; height ; width t
-                        if (!mSuppressQueryResponses) mSession.write(String.format(Locale.US, "\033[6;%d;%dt", mCellHeightPixels, mCellWidthPixels));
+                        mSession.write(String.format(Locale.US, "\033[6;%d;%dt", mCellHeightPixels, mCellWidthPixels));
                         break;
                     case 18: // Report the size of the text area in characters. Result is CSI 8 ; height ; width t
-                        if (!mSuppressQueryResponses) mSession.write(String.format(Locale.US, "\033[8;%d;%dt", mRows, mColumns));
+                        mSession.write(String.format(Locale.US, "\033[8;%d;%dt", mRows, mColumns));
                         break;
                     case 19: // Report the size of the screen in characters. Result is CSI 9 ; height ; width t
                         // We report the same size as the view, since it's the view really isn't resizable from the shell.
-                        if (!mSuppressQueryResponses) mSession.write(String.format(Locale.US, "\033[9;%d;%dt", mRows, mColumns));
+                        mSession.write(String.format(Locale.US, "\033[9;%d;%dt", mRows, mColumns));
                         break;
                     case 20: // Report xterm windows icon label. Result is OSC L label ST. Disabled due to security concerns:
-                        if (!mSuppressQueryResponses) mSession.write("\033]LIconLabel\033\\");
+                        mSession.write("\033]LIconLabel\033\\");
                         break;
                     case 21: // Report xterm windows title. Result is OSC l label ST. Disabled due to security concerns:
-                        if (!mSuppressQueryResponses) mSession.write("\033]l\033\\");
+                        mSession.write("\033]l\033\\");
                         break;
                     case 22:
                         // 22;0 -> Save xterm icon and window title on stack.
@@ -2127,7 +2117,7 @@ public final class TerminalEmulator {
                                 int r = (65535 * ((rgb & 0x00FF0000) >> 16)) / 255;
                                 int g = (65535 * ((rgb & 0x0000FF00) >> 8)) / 255;
                                 int b = (65535 * ((rgb & 0x000000FF))) / 255;
-                                if (!mSuppressQueryResponses) mSession.write("\033]" + value + ";rgb:" + String.format(Locale.US, "%04x", r) + "/" + String.format(Locale.US, "%04x", g) + "/"
+                                mSession.write("\033]" + value + ";rgb:" + String.format(Locale.US, "%04x", r) + "/" + String.format(Locale.US, "%04x", g) + "/"
                                     + String.format(Locale.US, "%04x", b) + bellOrStringTerminator);
                             } else {
                                 mColors.tryParseColor(specialIndex, colorSpec);

--- a/shared/core-terminal/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/TerminalSession.java
@@ -334,17 +334,6 @@ public final class TerminalSession extends TerminalOutput {
         return result;
     }
 
-    /**
-     * PocketShell #803: bytes currently buffered in the process→terminal queue
-     * and not yet parsed by the emulator. Read on the main thread by the
-     * PocketShell MainThreadDrainScheduler to drive frame-budgeted drain
-     * continuation (yield-and-continue while &gt; 0, stop when 0). Reflected into
-     * by SshTerminalBridge so the scheduler can live outside this package.
-     */
-    int availableProcessOutputBytes() {
-        return mProcessToTerminalIOQueue.getAvailable();
-    }
-
     @SuppressLint("HandlerLeak")
     class MainThreadHandler extends Handler {
 
@@ -353,20 +342,14 @@ public final class TerminalSession extends TerminalOutput {
         }
 
         // PocketShell #796/#803: ONE MSG_NEW_INPUT dispatch parses at most this
-        // many bytes in a single, uninterruptible mEmulator.append() call. It was
-        // 16 KB, but a 16 KB slice of clear-heavy alt-screen content (an agent's
-        // full-viewport redraw: ESC[H + 30x ESC[K per chunk) does ~4000
-        // blockClear/allocateFullLineIfNecessary ops — far more main-thread WORK
-        // per byte than append text — and on a swiftshader emulator that one
-        // atomic append pinned the looper for >1 s (the #796 ANR). The byte budget
-        // did not model that work. Shrinking the per-dispatch slice gives the
-        // PocketShell MainThreadDrainScheduler a fine enough granularity to apply
-        // an ELAPSED-TIME budget across slices and yield mid-burst, so no single
-        // main-thread turn blows the frame/ANR deadline even for clear-heavy
-        // content. 2 KB keeps the worst-case single atomic append well under the
-        // responsiveness budget while keeping per-slice dispatch overhead low (the
-        // scheduler still drains several slices per turn for cheap append load, so
-        // normal throughput is unchanged).
+        // many bytes in a single, uninterruptible mEmulator.append() call.
+        // Upstream reads 64 KB per message; a 16 KB slice of clear-heavy
+        // alt-screen content (an agent's full-viewport redraw: ESC[H + 30x ESC[K
+        // per chunk) does ~4000 blockClear/allocateFullLineIfNecessary ops and on
+        // a swiftshader emulator pinned the looper for >1 s (the #796 ANR). 2 KB
+        // keeps the worst-case single atomic append well under the responsiveness
+        // budget. The poster (app2's TerminalPtyBridge) writes the remote stream
+        // in slices of exactly this size and posts one message per slice.
         private static final int PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES = 2 * 1024;
 
         final byte[] mReceiveBuffer = new byte[PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES];
@@ -375,16 +358,11 @@ public final class TerminalSession extends TerminalOutput {
         public void handleMessage(Message msg) {
             if (msg.what == MSG_NEW_INPUT) {
                 // PocketShell #803/#796: one MSG_NEW_INPUT dispatch drains exactly
-                // ONE 2 KB slice (PROCESS_TO_TERMINAL_DRAIN_SLICE_BYTES; #796 shrank
-                // it from 16 KB) and does NOT self-re-post. Continuation across the
-                // rest of the queue is owned by the PocketShell
-                // MainThreadDrainScheduler, which applies a per-frame byte budget
-                // and yields the main looper between budgeted turns so a dense
-                // colored-diff burst cannot pin the thread in one unbounded
-                // back-to-back parse run (the #803 ANR). The scheduler is the SOLE
-                // poster of MSG_NEW_INPUT in PocketShell (the upstream local-PTY
-                // input reader in initializeEmulator is never started — the bridge
-                // pre-installs the emulator).
+                // ONE slice and does NOT self-re-post; the bridge posts one message
+                // per slice it writes, so the queue is drained message by message
+                // with the looper free to run other work in between (the upstream
+                // local-PTY input reader in initializeEmulator is never started —
+                // the bridge pre-installs the emulator).
                 drainProcessOutputSlice();
             }
 
@@ -426,7 +404,6 @@ public final class TerminalSession extends TerminalOutput {
             if (bytesRead <= 0) return bytesRead;
 
             mEmulator.append(mReceiveBuffer, bytesRead);
-            mClient.onProcessOutputDrained(TerminalSession.this, bytesRead);
             notifyScreenUpdate();
             return bytesRead;
         }

--- a/shared/core-terminal/src/main/java/com/termux/terminal/TerminalSessionClient.java
+++ b/shared/core-terminal/src/main/java/com/termux/terminal/TerminalSessionClient.java
@@ -12,9 +12,6 @@ public interface TerminalSessionClient {
 
     void onTextChanged(@NonNull TerminalSession changedSession);
 
-    default void onProcessOutputDrained(@NonNull TerminalSession session, int bytes) {
-    }
-
     void onTitleChanged(@NonNull TerminalSession changedSession);
 
     void onSessionFinished(@NonNull TerminalSession finishedSession);

--- a/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
+++ b/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
@@ -7,8 +7,6 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Handler;
@@ -28,7 +26,6 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewTreeObserver;
-import android.view.Window;
 import android.view.accessibility.AccessibilityManager;
 import android.view.autofill.AutofillManager;
 import android.view.autofill.AutofillValue;
@@ -39,14 +36,12 @@ import android.widget.Scroller;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
-import androidx.annotation.VisibleForTesting;
 
 import com.pocketshell.core.terminal.input.BracketedPaste;
 import com.termux.terminal.KeyHandler;
 import com.termux.terminal.TerminalEmulator;
 import com.termux.terminal.TerminalSession;
 import com.termux.view.textselection.TextSelectionCursorController;
-
 
 /** View displaying and interacting with a {@link TerminalSession}. */
 public final class TerminalView extends View {

--- a/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
+++ b/shared/core-terminal/src/main/java/com/termux/view/TerminalView.java
@@ -6,15 +6,12 @@ import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
-import android.content.ContextWrapper;
-import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Handler;
-import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.text.Editable;
@@ -28,7 +25,6 @@ import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MotionEvent;
-import android.view.PixelCopy;
 import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewTreeObserver;
@@ -51,8 +47,6 @@ import com.termux.terminal.TerminalEmulator;
 import com.termux.terminal.TerminalSession;
 import com.termux.view.textselection.TextSelectionCursorController;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 /** View displaying and interacting with a {@link TerminalSession}. */
 public final class TerminalView extends View {
@@ -72,24 +66,6 @@ public final class TerminalView extends View {
     public TerminalRenderer mRenderer;
 
     public TerminalViewClient mClient;
-
-    /**
-     * Issue #1192 — reports, per painted frame, whether {@link #onDraw} painted the
-     * emulator content or the BLACK fallback (the {@code mEmulator == null} window or a
-     * render that threw). PocketShell's tmux ViewModel wires this to the pane's
-     * {@code TerminalSurfaceState} so its EXISTING gated stale-render watchdog can
-     * fingerprint a surface-only-black (model intact, on-screen surface black) — the one
-     * black-screen class the model-vs-tmux heal oracle cannot see. Null is a no-op.
-     */
-    public interface FramePaintObserver {
-        void onFramePainted(boolean paintedEmulatorContent, long atElapsedRealtimeMs);
-    }
-
-    private FramePaintObserver mFramePaintObserver;
-
-    public void setFramePaintObserver(FramePaintObserver observer) {
-        mFramePaintObserver = observer;
-    }
 
     private TextSelectionCursorController mTextSelectionCursorController;
 
@@ -203,259 +179,6 @@ public final class TerminalView extends View {
         }
         invalidate();
     }
-
-    /**
-     * Issue #1203 — force a SURFACE-level repaint that recovers a
-     * surface-only-black: the on-screen surface is black while the MODEL grid
-     * (the session/bridge emulator) still holds the frame. This is the sixth
-     * {@code black_frame_observed} class (#1192, {@code surface_black_model_intact}),
-     * the ONE the model-vs-tmux heal oracle cannot see — the model never diverges
-     * from tmux, so a model reseed (the manual Redraw / stale-render heal) restores
-     * NOTHING and the surface stays black.
-     *
-     * <p>{@link #forceFullRepaint()} (#721) CANNOT recover this class either: it
-     * only resets the renderer's dirty cache and issues {@code invalidate()}. When
-     * the surface is black because {@link #mEmulator} is {@code null} (the
-     * {@link #onDraw} BLACK fallback), a plain {@code invalidate()} just re-runs
-     * {@code onDraw}, finds {@code mEmulator == null} again, and paints the black
-     * fallback AGAIN. The View lost its emulator binding even though the session
-     * still holds a live emulator with the full grid — no amount of model reseeding
-     * repaints the surface.
-     *
-     * <p>This re-binds {@link #mEmulator} from the live {@link #mTermSession} (so the
-     * next {@code onDraw} takes the CONTENT path instead of {@code drawColor(black)}),
-     * then resets the renderer's dirty cache and forces a full-clip repaint of the
-     * whole surface straight from the buffer — covering both the {@code mEmulator ==
-     * null} case AND the case where the surface holds a stale black hardware buffer
-     * whose #469 dirty cache still thinks every row is painted.
-     */
-    public void forceSurfaceRepaint() {
-        // Re-bind the emulator the View paints from. When the View lost it
-        // (mEmulator == null → the onDraw BLACK fallback) but the session still
-        // holds a live emulator, re-fetch it so the next onDraw takes the content
-        // path instead of drawColor(black) — the surface_black_model_intact fix.
-        if (mEmulator == null && mTermSession != null) {
-            TerminalEmulator sessionEmulator = mTermSession.getEmulator();
-            if (sessionEmulator != null) {
-                mEmulator = sessionEmulator;
-                if (mTerminalCursorBlinkerRunnable != null) {
-                    mTerminalCursorBlinkerRunnable.setEmulator(mEmulator);
-                }
-            }
-        }
-        // Reset the renderer's dirty cache (a stale surface may hold a black
-        // hardware buffer whose cache still thinks every row is painted) and force
-        // a full-clip repaint straight from the buffer.
-        if (mRenderer != null) {
-            mRenderer.invalidateDirtyCache();
-        }
-        invalidate();
-    }
-
-    /**
-     * Issue #1443 — DIAGNOSTIC pixel-truth sample of the on-screen surface, for the
-     * one black-screen class the MODEL-derived detectors are blind to.
-     *
-     * <p>Every other surface-black signal (the #1192 paint-confirmation seam →
-     * {@link com.pocketshell.core.terminal.ui.TerminalSurfaceState#surfaceIsBlackWhileModelHasContent})
-     * is derived from the emulator MODEL: {@link #onDraw} reports
-     * {@code paintedEmulatorContent} from {@code hasNonBlankVisibleRow()}, a MODEL
-     * check with NO pixel readback (the explicit #1296 non-goal). A GENUINE
-     * pixel/GPU-layer black — the composited surface is black while the model still
-     * carries the frame (a lost HWUI hardware layer, a RenderNode that stopped
-     * compositing, a Compose layer that dropped this View's buffer) — is invisible
-     * to all of them. This bounded {@link PixelCopy} of the actual window surface is
-     * the only way to see it.
-     *
-     * <p><b>This is called ONLY on a suspicion trigger</b> — the app's stale-render
-     * watchdog tick when the MODEL reports content-present, via
-     * {@link com.pocketshell.core.terminal.ui.TerminalSurfaceState#probePixelBlackWhileModelHasContent}
-     * (itself rate-bounded). It is NEVER called from {@link #onDraw} / the per-frame
-     * render loop, so it does NOT reinstate the per-frame PixelCopy cost #1296
-     * rejected. It samples the whole view region SCALED into a small fixed
-     * {@value #PIXEL_SAMPLE_DIM}×{@value #PIXEL_SAMPLE_DIM} bitmap, so the readback
-     * cost is O({@value #PIXEL_SAMPLE_DIM}²) regardless of the view size.
-     *
-     * <p><b>Diagnostics only</b>: this NEVER heals/reseeds/reattaches anything and
-     * NEVER throws into a caller — any failure returns {@code null} ("no evidence").
-     *
-     * @return {@code Boolean.TRUE} when the sampled surface pixels are
-     *   (near-)uniformly the default background colour (a dead/black surface),
-     *   {@code Boolean.FALSE} when they carry visible content (a healthy surface),
-     *   and {@code null} when the surface could not be sampled (no host window,
-     *   0-size, PixelCopy error/timeout) — never fingerprinted by the caller.
-     */
-    @Nullable
-    public Boolean sampleSurfaceNearUniformBlack() {
-        return sampleSurfaceNearUniformBlack(PIXEL_SAMPLE_TIMEOUT_MS);
-    }
-
-    /**
-     * Issue #2003 — the timeout-parameterised body of {@link #sampleSurfaceNearUniformBlack()}.
-     *
-     * <p>The parameter exists ONLY so
-     * {@code TerminalViewPixelProbeAbandonedCopyInstrumentedTest} can force the
-     * abandon-while-in-flight path deterministically (a 0 ms wait always leaves the
-     * {@link PixelCopy} request queued on the HWUI RenderThread). Production always
-     * calls the no-arg overload with {@value #PIXEL_SAMPLE_TIMEOUT_MS} ms.
-     */
-    @VisibleForTesting
-    @Nullable
-    Boolean sampleSurfaceNearUniformBlack(long timeoutMs) {
-        try {
-            final int width = getWidth();
-            final int height = getHeight();
-            if (width <= 0 || height <= 0) return null;
-            final Window window = findHostWindow();
-            if (window == null || window.peekDecorView() == null) return null;
-
-            final int[] loc = new int[2];
-            getLocationInWindow(loc);
-            final Rect src = new Rect(loc[0], loc[1], loc[0] + width, loc[1] + height);
-
-            // PixelCopy scales srcRect INTO the destination bitmap, so a fixed small
-            // dest bounds the whole readback to O(dim^2) pixels regardless of the
-            // view's on-screen size — never a per-pixel full-surface scan (#1296/#1164).
-            final Bitmap dest =
-                Bitmap.createBitmap(PIXEL_SAMPLE_DIM, PIXEL_SAMPLE_DIM, Bitmap.Config.ARGB_8888);
-            // Issue #2003 — RenderThread OWNERSHIP of `dest`, not "always recycle".
-            //
-            // `PixelCopy.request` is ASYNCHRONOUS: it hands `dest` to HWUI, which
-            // resolves it on the RenderThread inside `Readback::copySurfaceInto` ->
-            // `CopyRequestAdapter::getDestinationBitmap` -> `android::bitmap::toBitmap`.
-            // `toBitmap` is `LOG_ALWAYS_FATAL` on a recycled bitmap ("Error, cannot
-            // access an invalid/free'd bitmap here!"), so recycling `dest` while the
-            // request is still queued ABORTS THE WHOLE APP PROCESS (SIGABRT on
-            // RenderThread) — a diagnostic probe killing the app, the exact inverse of
-            // "must NEVER destabilise the terminal". That is what the #2003 tombstone
-            // (`tombstone_16`, pid 9555 tid 9598 RenderThread) recorded, reached via
-            // the 250 ms `latch.await` timing out on a loaded device while the copy was
-            // still in flight.
-            //
-            // The callback firing is the ONLY signal that HWUI is done with `dest`
-            // (`Readback::copySurfaceInto` invokes it after the readback, on every
-            // result including errors). So recycle IF AND ONLY IF the latch was
-            // counted down. On the timeout / interrupt paths we simply drop the
-            // reference: the in-flight `CopyRequest` holds its own ref, so the GC frees
-            // the (1 KB, PIXEL_SAMPLE_DIM^2 ARGB_8888) sample only once HWUI is truly
-            // finished with it. `Bitmap.recycle()` is documented as not normally
-            // needed; a 1 KB deferred free is not worth a process abort.
-            boolean copyFinished = false;
-            try {
-                final CountDownLatch latch = new CountDownLatch(1);
-                final int[] status = {PixelCopy.ERROR_UNKNOWN};
-                // Reuse ONE process-wide handler thread for every probe (rate-limited to
-                // ≤1 per watchdog cycle) instead of spinning a HandlerThread up per call.
-                PixelCopy.request(window, src, dest, copyResult -> {
-                    status[0] = copyResult;
-                    latch.countDown();
-                }, pixelProbeHandler());
-                copyFinished = latch.await(timeoutMs, TimeUnit.MILLISECONDS);
-                if (!copyFinished) {
-                    return null;
-                }
-                if (status[0] != PixelCopy.SUCCESS) {
-                    return null;
-                }
-                return Boolean.valueOf(isBitmapNearUniformBackground(dest));
-            } finally {
-                if (copyFinished) dest.recycle();
-            }
-        } catch (Throwable t) {
-            // A diagnostic probe must NEVER destabilise the terminal: any failure
-            // (no window, permission, driver refusal, interruption) is "no evidence".
-            return null;
-        }
-    }
-
-    /** Issue #1443 — one shared, lazily-started handler thread for all pixel probes. */
-    private static volatile Handler sPixelProbeHandler;
-
-    private static Handler pixelProbeHandler() {
-        Handler handler = sPixelProbeHandler;
-        if (handler == null) {
-            synchronized (TerminalView.class) {
-                handler = sPixelProbeHandler;
-                if (handler == null) {
-                    final HandlerThread thread = new HandlerThread("ps-pixel-probe");
-                    thread.start();
-                    handler = new Handler(thread.getLooper());
-                    sPixelProbeHandler = handler;
-                }
-            }
-        }
-        return handler;
-    }
-
-    /**
-     * Issue #1443 — walk the View's context chain to the hosting {@link Activity}'s
-     * {@link Window}, needed by {@link PixelCopy#request} (a plain HWUI View has no
-     * Surface of its own; the composited pixels live on the window surface). Returns
-     * {@code null} when the View is not hosted by an Activity window.
-     */
-    @Nullable
-    private Window findHostWindow() {
-        Context ctx = getContext();
-        while (ctx instanceof ContextWrapper) {
-            if (ctx instanceof Activity) {
-                return ((Activity) ctx).getWindow();
-            }
-            ctx = ((ContextWrapper) ctx).getBaseContext();
-        }
-        return null;
-    }
-
-    /**
-     * Issue #1443 — true when (near-)all sampled pixels are within
-     * {@value #PIXEL_BG_CHANNEL_TOLERANCE} per channel of the default background
-     * colour, i.e. the surface is (near-)uniformly the background (a dead/black
-     * surface) rather than carrying rendered glyphs.
-     *
-     * <p>The threshold ({@value #PIXEL_BG_UNIFORM_PERMILLE}‰) is deliberately very
-     * high: a genuine GPU-layer black is 100% background, while even a sparse but
-     * HEALTHY terminal frame lights up several of the {@value #PIXEL_SAMPLE_DIM}²
-     * sampled cells with glyph coverage. It is a conservative first cut for on-device
-     * tuning — a false positive here only emits a diagnostic event (never a heal), and
-     * the model-content gate in the caller already excludes the ordinary blank pane.
-     */
-    private boolean isBitmapNearUniformBackground(Bitmap bmp) {
-        final int bg = mDefaultBackgroundColor;
-        final int bgR = Color.red(bg);
-        final int bgG = Color.green(bg);
-        final int bgB = Color.blue(bg);
-        final int w = bmp.getWidth();
-        final int h = bmp.getHeight();
-        final int total = w * h;
-        if (total <= 0) return false;
-        int backgroundPixels = 0;
-        for (int y = 0; y < h; y++) {
-            for (int x = 0; x < w; x++) {
-                final int p = bmp.getPixel(x, y);
-                if (Math.abs(Color.red(p) - bgR) <= PIXEL_BG_CHANNEL_TOLERANCE
-                        && Math.abs(Color.green(p) - bgG) <= PIXEL_BG_CHANNEL_TOLERANCE
-                        && Math.abs(Color.blue(p) - bgB) <= PIXEL_BG_CHANNEL_TOLERANCE) {
-                    backgroundPixels++;
-                }
-            }
-        }
-        return (long) backgroundPixels * 1000L >= (long) total * PIXEL_BG_UNIFORM_PERMILLE;
-    }
-
-    /** Issue #1443 — the fixed downscaled dimension the surface is PixelCopy'd into. */
-    private static final int PIXEL_SAMPLE_DIM = 16;
-
-    /** Issue #1443 — max wait for the single-shot async PixelCopy callback. */
-    private static final long PIXEL_SAMPLE_TIMEOUT_MS = 250L;
-
-    /** Issue #1443 — per-channel tolerance for "this pixel equals the background". */
-    private static final int PIXEL_BG_CHANNEL_TOLERANCE = 16;
-
-    /**
-     * Issue #1443 — the ‰ of sampled pixels that must match the background for the
-     * surface to count as (near-)uniformly black. 990‰ (99%) targets a genuine
-     * full-black surface while leaving headroom for antialiasing fringe.
-     */
-    private static final int PIXEL_BG_UNIFORM_PERMILLE = 990;
 
     float mScaleFactor = 1.f;
     final GestureAndScaleRecognizer mGestureRecognizer;
@@ -1671,12 +1394,6 @@ public final class TerminalView extends View {
 
     @Override
     protected void onDraw(Canvas canvas) {
-        // Issue #1192: track whether THIS frame painted emulator content (the normal
-        // render path) or the BLACK fallback (mEmulator == null, or a render that threw
-        // — the catch below). Reported to the paint-confirmation observer at the end so
-        // the tmux watchdog can fingerprint a surface-only-black (model intact, surface
-        // black). Defaults to false; only the successful render path sets it true.
-        boolean paintedEmulatorContent = false;
         try {
             if (mEmulator == null) {
                 canvas.drawColor(mDefaultBackgroundColor);
@@ -1691,21 +1408,6 @@ public final class TerminalView extends View {
 
                 // render the text selection handles
                 renderTextSelection();
-
-                // Issue #1296: only count this frame as a CONTENT paint when it
-                // actually rendered non-black glyph coverage. `mEmulator != null` is
-                // NOT enough: after forceSurfaceRepaint() (#1203) re-binds mEmulator,
-                // the NEXT onDraw on a 0-size / offscreen / still-blank surface would
-                // otherwise record a bogus content paint, flipping
-                // surfaceIsBlackWhileModelHasContent() false and silencing BOTH the
-                // heal oracle's surface-black detector AND the %output suspect-wake path
-                // while the pane sits visually black. Require nonzero view dimensions
-                // AND the emulator screen carrying at least one non-blank VISIBLE row
-                // (a model-level check — no PixelCopy/pixel readback, #1296 non-goal). A
-                // bound emulator that paints zero-size or fully-blank output records a
-                // BLANK paint so the watchdog/wake path stays armed and keeps retrying.
-                paintedEmulatorContent =
-                    getWidth() > 0 && getHeight() > 0 && mEmulator.getScreen().hasNonBlankVisibleRow();
             }
         } catch (Throwable t) {
             // Issues #966/#967: widen from RuntimeException to Throwable. An
@@ -1721,14 +1423,6 @@ public final class TerminalView extends View {
             // dirty-region cache (#469) no longer reflects what is on screen, so
             // force the next frame to repaint every row.
             if (mRenderer != null) mRenderer.invalidateDirtyCache();
-        }
-        // Issue #1192: report this frame's paint outcome to the surface-paint seam.
-        // `paintedEmulatorContent` is false for both the mEmulator == null fallback and
-        // a render that threw (the catch above). Cheap, best-effort; never throws into
-        // the draw path.
-        final FramePaintObserver observer = mFramePaintObserver;
-        if (observer != null) {
-            observer.onFramePainted(paintedEmulatorContent, android.os.SystemClock.elapsedRealtime());
         }
     }
 

--- a/shared/core-terminal/src/test/java/com/termux/terminal/TerminalTest.java
+++ b/shared/core-terminal/src/test/java/com/termux/terminal/TerminalTest.java
@@ -367,80 +367,21 @@ public class TerminalTest extends TerminalTestCase {
 				.assertLinesAre("abc     ", "next    ");
 	}
 
-	public void testSuppressQueryResponsesXTWINOPS() {
+	public void testQueryResponsesAreAnswered() {
+		// PocketShell: the emulator is the REAL terminal a remote program talks to
+		// (app2 attaches over a PTY), so every query it asks must be answered on
+		// the wire. The pre-0.5.0 client had a suppression flag for tmux control
+		// mode; with one PTY source there is nothing to suppress.
 		withTerminalSized(5, 5);
 		assertEnteringStringGivesResponse("\033[14t", "\033[4;75;65t");
 		assertEnteringStringGivesResponse("\033[18t", "\033[8;5;5t");
-
-		mTerminal.setSuppressQueryResponses(true);
-		enterString("\033[14t");
-		assertEquals("", mOutput.getOutputAndClear());
-		enterString("\033[18t");
-		assertEquals("", mOutput.getOutputAndClear());
-		enterString("\033[11t");
-		assertEquals("", mOutput.getOutputAndClear());
-		enterString("\033[13t");
-		assertEquals("", mOutput.getOutputAndClear());
-		enterString("\033[16t");
-		assertEquals("", mOutput.getOutputAndClear());
-		enterString("\033[19t");
-		assertEquals("", mOutput.getOutputAndClear());
-		enterString("\033[20t");
-		assertEquals("", mOutput.getOutputAndClear());
-		enterString("\033[21t");
-		assertEquals("", mOutput.getOutputAndClear());
-
-		mTerminal.setSuppressQueryResponses(false);
-		assertEnteringStringGivesResponse("\033[14t", "\033[4;75;65t");
-		assertEnteringStringGivesResponse("\033[18t", "\033[8;5;5t");
-	}
-
-	public void testSuppressQueryResponsesDA() {
-		withTerminalSized(5, 5);
 		assertEnteringStringGivesResponse("\033[c", "\033[?64;1;2;6;9;15;18;21;22c");
 		assertEnteringStringGivesResponse("\033[>c", "\033[>41;320;0c");
-
-		mTerminal.setSuppressQueryResponses(true);
-		enterString("\033[c");
-		assertEquals("", mOutput.getOutputAndClear());
-		enterString("\033[>c");
-		assertEquals("", mOutput.getOutputAndClear());
-
-		mTerminal.setSuppressQueryResponses(false);
-		assertEnteringStringGivesResponse("\033[c", "\033[?64;1;2;6;9;15;18;21;22c");
-		assertEnteringStringGivesResponse("\033[>c", "\033[>41;320;0c");
-	}
-
-	public void testSuppressQueryResponsesDSRAndCPR() {
-		withTerminalSized(5, 5);
 		assertEnteringStringGivesResponse("\033[5n", "\033[0n");
 		assertEnteringStringGivesResponse("\033[6n", "\033[1;1R");
 
-		mTerminal.setSuppressQueryResponses(true);
-		enterString("\033[5n");
-		assertEquals("", mOutput.getOutputAndClear());
-		enterString("\033[6n");
-		assertEquals("", mOutput.getOutputAndClear());
-
-		mTerminal.setSuppressQueryResponses(false);
-		assertEnteringStringGivesResponse("\033[5n", "\033[0n");
-		assertEnteringStringGivesResponse("\033[6n", "\033[1;1R");
-	}
-
-	public void testSuppressQueryResponsesOSC11() {
-		withTerminalSized(5, 5);
 		enterString("\033]11;?\033\\");
 		String response = mOutput.getOutputAndClear();
-		assertTrue(response.startsWith("\033]11;rgb:"));
-		assertTrue(response.endsWith("\033\\"));
-
-		mTerminal.setSuppressQueryResponses(true);
-		enterString("\033]11;?\033\\");
-		assertEquals("", mOutput.getOutputAndClear());
-
-		mTerminal.setSuppressQueryResponses(false);
-		enterString("\033]11;?\033\\");
-		response = mOutput.getOutputAndClear();
 		assertTrue(response.startsWith("\033]11;rgb:"));
 		assertTrue(response.endsWith("\033\\"));
 	}


### PR DESCRIPTION
Closes #2557.

## What the rewrite missed

Compared app2's `TerminalHostView`/`TerminalPtyBridge` with the pre-0.5.0 `TerminalSurface`/`SshTerminalBridge`. Most of the old 5k lines existed for two racing tmux sources and stay gone. Two behaviours are still needed with one PTY:

1. **Palette after a reset.** The rewrite wrote PocketShell's colours onto the live emulator in `onEmulatorSet`; `ESC c`, `OSC 104`, `OSC 110-112` reset to the vendored default scheme (pure black/white) and nothing put ours back. The old client re-patched on every `onColorsChanged`, which also undid colours an app set. Fix: `installTerminalPalette()` makes the ui-kit tokens the emulator's *default* scheme before the emulator is built; the view's own background now follows the palette on `onColorsChanged` so an app's `OSC 11` colour is actually visible.
2. **Copy / Paste / OSC 52.** The vendored selection action mode's Copy and Paste, and a remote `OSC 52`, all go through `TerminalSessionClient`, which the rewrite left as no-ops. `HostedSessionClient` now copies to the system clipboard and pastes through the emulator's `paste()` (bracketed when the remote enabled `DECSET 2004`).

## Removed

Vendored PocketShell patches whose only caller was the deleted tmux bridge: `setSuppressQueryResponses` (20 guard sites), `availableProcessOutputBytes` / `onProcessOutputDrained`, `FramePaintObserver` / `forceSurfaceRepaint` / the PixelCopy surface-black probe (#1192/#1203/#1296/#1443/#2003), `hasNonBlankVisibleRow`. Net −360 lines. `PATCHES.md`/`VENDORED.md` corrected: they claimed `TerminalView`/`TerminalSession` were byte-identical.

## Evidence

- `TerminalHostViewSessionClientTest` (new, 10 tests): **8 red on base** (palette lands on `0xff000000`, clipboard `null`, paste writes nothing), all green with the change. The two that stay green on base are the inert/no-crash guards.
- `:shared:core-terminal:testDebugUnitTest` 395/395 incl. the new `testQueryResponsesAreAnswered`; `:app2:testDebugUnitTest --tests 'com.pocketshell.next.terminal.*'` 126/126; `:app2:compileDebugAndroidTestKotlin` and `:shared:core-terminal:compileDebugAndroidTestKotlin` green; `check-tests-referenced`, `check-test-validity`, `check-file-size-hygiene` OK; `git diff --check` clean.
- Not yet verified on the emulator; reviewer dispatched.