### PR TITLE
fix: stop listing dead aplexer records as attachable sessions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,9 +200,83 @@ terminated with `--`.
 
 `sessions list --json` schema 2 rows carry `{name, manager, id, workspace, tag,
 engine, profile, agent_state, agent_state_source, attached, created_epoch,
-activity_epoch}` plus a first-class `errors[]` array. A backend that fails to
-enumerate **must** appear in `errors` rather than silently shortening the list;
-the tree renders that as a "some sessions may be missing" banner.
+activity_epoch, phase, alive}` plus a first-class `errors[]` array. A backend
+that fails to enumerate **must** appear in `errors` rather than silently
+shortening the list; the tree renders that as a "some sessions may be missing"
+banner.
+
+`phase`/`alive` are the liveness pair (#2554). aplexer keeps a session record
+after the session dies — a killed one stays at `phase: exited` forever, and a
+worker that died without recording an exit leaves `phase: running` with
+`worker_alive: false`, which `a prune` (0.1.3) cannot reap. Those records used
+to list as ordinary rows, so the tree offered sessions whose attach answered
+`a: session … has already exited` and exited 1. The host now filters them out
+of the listing (`session_enum.aplexer_record_is_alive`), so every row it emits
+is `alive: true`; the pair is on the wire so the truth is explicit rather than
+implied by a filter the client cannot see. `phase` is `null` for tmux rows,
+which have no such vocabulary.
+
+A record counts as dead on exactly two shapes: a terminal `phase`
+(`exited`/`failed`), or a `worker_pid` that is set while `worker_alive` is
+false (it *had* a worker and lost it). Everything else fails OPEN, and two of
+those exemptions are load-bearing rather than defensive:
+
+- `phase: exiting` with a live worker is the window right after `a kill`, where
+  `a attach` still works.
+- **A RECENT non-terminal phase with no `worker_pid` is a session being
+  CREATED.** aplexer persists the record before the worker registers its pid,
+  and `SessionRecord::worker_alive` returns false for a `None` pid, so every
+  `a start` emits `phase: starting` / `worker_alive: false` for tens of
+  milliseconds. Treating that as dead blanks the session the user is watching
+  appear (the #2547 symptom), refuses to attach to it, and makes a retried
+  create force-forget an in-flight worker. `worker_alive: false` with no pid is
+  absence of evidence, not evidence of death — aplexer's own `display_state`
+  calls it "broken" (indeterminate), never "exited".
+
+  That exemption is **bounded by `APLEXER_STARTING_GRACE_MS` (60 s)**, because
+  an `a start` killed inside the pre-PID window leaves the identical shape
+  *forever*. The two are indistinguishable in one snapshot but not in time: a
+  real create is tens of milliseconds old, a crashed one ages without bound.
+  60 s is deliberately generous in the safe direction — >1000x the measured
+  26–46 ms window, 6x aplexer's own 10 s `--startup-timeout-ms`, and 3x this
+  CLI's 20 s `a start` timeout — because calling a slow spawn dead is the
+  #2547 regression, while calling a corpse alive for one more minute is only a
+  stale row. A pre-PID record whose `updated_at_ms` is missing or unreadable
+  fails open (no age, no verdict).
+
+Deriving liveness here is a stopgap: aplexer computes the same answer and, as
+of `355db6e`, emits it as `state` on every `a list --json` row (`broken` for
+exactly the crashed-start record above). This CLI pins aplexer 0.1.3, where
+that field does not exist, so the predicate stays local until a release carries
+it — see #2556's sibling follow-up, which replaces it outright rather than
+adding a fallback (D22). `sessions kill` on an aplexer row reaps the record with
+`a forget --force <id>` (retried while the worker winds down) so Stop removes
+the row instead of leaving a dead one, and `sessions attach` on a stale dead
+name says what happened instead of relaying aplexer's exit 1.
+
+A dead record also **holds its workspace+tag hostage** — aplexer keys a session
+by that pair and refuses `a start` with "workspace+tag already belongs to
+session `<id>`" for a corpse just as firmly as for a live session, which is the
+"can't create an agent session" half of #2554. `sessions create`'s aplexer arm
+therefore reuses the same liveness predicate (a record with no live worker is
+not an existing session) and reaps whatever dead record holds the target pair
+before calling `a start`. A live record is still reused, never reaped — the
+`created: false` idempotency contract is unchanged. If the reap cannot win, the
+create error names the blocking record and the `a forget --force <id>` that
+clears it, rather than relaying aplexer's "rename it" advice about a session
+the listing no longer shows.
+
+The reap is gated on the workload, not just the record. `a forget --force`
+forgets a record explicitly *without* claiming its workloads stopped, so a
+record whose `workload_pid` is still alive is never reaped — the create fails
+instead, naming that pid, mirroring `a prune`'s own retention rule
+(`a.rs::cmd_prune`). `a kill` is not an alternative on that shape: for a record
+whose worker died it answers "no authoritative containment locator" and changes
+nothing. When a reap does proceed and aplexer reports
+`workload_may_survive: true` (containment never proven empty — a setsid'd
+grandchild outlives its worker), both `sessions kill` and `sessions create`
+print that on stderr instead of swallowing it; after an ordinary `a kill` the
+verdict is `false`, so the warning stays silent on the normal path.
 
 ### Session tree
 

--- a/tools/pocketshell/src/pocketshell/session_enum.py
+++ b/tools/pocketshell/src/pocketshell/session_enum.py
@@ -60,6 +60,31 @@ AGENT_STATES = (AGENT_STATE_IDLE, AGENT_STATE_WAITING, AGENT_STATE_WORKING)
 AGENT_STATE_SOURCE_REPORTED = "reported"
 AGENT_STATE_SOURCE_HEURISTIC = "heuristic"
 
+#: aplexer phases that mean the session is over (``Phase::Exited`` /
+#: ``Phase::Failed`` in aplexer's ``src/lib.rs``). ``starting``/``running``/
+#: ``exiting`` are all still-live phases.
+APLEXER_TERMINAL_PHASES = frozenset({"exited", "failed"})
+
+#: How long a record with no ``worker_pid`` yet is still credited as "being
+#: created" (issue #2554). See :func:`aplexer_record_is_alive`: a session
+#: mid-``a start`` and an ``a start`` that was killed inside the pre-PID
+#: window are the SAME record shape and differ only in age.
+#:
+#: 60 s is chosen to be generous in the safe direction, because calling a
+#: slow spawn dead is the #2547 regression while calling a corpse alive for
+#: another minute is a stale row. Three independent anchors, all measured or
+#: read off source rather than guessed:
+#:
+#: * the real pre-PID window on the dev box is 26-46 ms (polled through two
+#:   separate ``a start`` runs) — 60 s is >1000x that;
+#: * aplexer itself gives up on a worker after ``--startup-timeout-ms``,
+#:   default 10_000 (``aplexer/src/bin/a.rs``) — 60 s is 6x its own patience;
+#: * this CLI abandons ``a start`` after ``sessions._APLEXER_START_TIMEOUT_S``
+#:   (20 s) — 60 s is 3x that.
+#:
+#: A record older than all three cannot still be legitimately starting.
+APLEXER_STARTING_GRACE_MS = 60_000
+
 # Both constants mirror aplexer's ``a watch`` (aplexer/src/watch.rs):
 # ACTIVITY_THRESHOLD_MS is how long a PTY must stay quiet before the
 # recency heuristic calls a session "waiting"; REPORTED_STATE_STALE_MS is
@@ -102,6 +127,14 @@ class LiveSession:
     agent_state_source: Optional[str] = None
     attached: bool = False
     activity_epoch: Optional[int] = None
+    #: aplexer's lifecycle phase for this record (``starting``/``running``/
+    #: ``exiting``/``exited``/``failed``), or ``None`` for a tmux row, which
+    #: has no such vocabulary. Descriptive only — ``alive`` is the decision.
+    phase: Optional[str] = None
+    #: Whether this session can actually be attached. A tmux row only exists
+    #: because ``tmuxctl list`` just listed it, so it defaults to ``True``;
+    #: an aplexer row gets :func:`aplexer_record_is_alive`'s verdict.
+    alive: bool = True
     extra: Mapping[str, Any] = field(default_factory=dict)
 
     def to_payload(self, schema: int = 1) -> dict[str, Any]:
@@ -125,6 +158,13 @@ class LiveSession:
                 "attached": bool(self.attached),
                 "created_epoch": self.created_epoch,
                 "activity_epoch": self.activity_epoch,
+                # Issue #2554: liveness travels on the wire. The host already
+                # filters dead records out of the listing, so a client seeing
+                # ``alive: false`` means it asked for the dead projection on
+                # purpose — but the field is emitted on EVERY row, dead or
+                # live, tmux or aplexer, per schema 2's "every key, always".
+                "phase": self.phase,
+                "alive": bool(self.alive),
             }
         payload: dict[str, Any] = {
             "name": self.name,
@@ -341,8 +381,8 @@ def aplexer_agent_state(
     """
     if now_ms is None:
         now_ms = int(time.time() * 1000)
-    phase = str(raw.get("phase") or "").strip().lower()
-    if phase in {"exited", "failed"}:
+    phase = aplexer_phase(raw)
+    if phase in APLEXER_TERMINAL_PHASES:
         return None, None
     if phase == "starting":
         return AGENT_STATE_WORKING, AGENT_STATE_SOURCE_HEURISTIC
@@ -369,9 +409,119 @@ def _coerce_ms(value: Any) -> Optional[int]:
     return ms if ms > 0 else None
 
 
-def sessions_from_aplexer_snapshot(
-    payload: Any, *, now_ms: Optional[int] = None
-) -> list[LiveSession]:
+def aplexer_phase(raw: Mapping[str, Any]) -> Optional[str]:
+    """Normalised aplexer lifecycle phase, or ``None`` when absent."""
+    phase = str(raw.get("phase") or "").strip().lower()
+    return phase or None
+
+
+def aplexer_record_is_alive(
+    raw: Mapping[str, Any], now_ms: Optional[int] = None
+) -> bool:
+    """Whether an ``a list --json`` record is still an attachable session.
+
+    Issue #2554. aplexer keeps a record after its session dies, and nothing
+    ever removed those: a killed session stays at ``phase: exited`` forever,
+    and a worker that died without recording an exit leaves ``phase:
+    running`` with ``worker_alive: false`` (``a prune`` in 0.1.3 cannot reap
+    that shape at all — verified on the dev box, three such records were ten
+    days old). Listing them made the tree offer rows whose attach answers
+    "session ... has already exited" and exits 1.
+
+    A record is DEAD when either:
+
+    * its ``phase`` is terminal — ``exited`` or ``failed`` (aplexer's
+      ``Phase::Exited``/``Phase::Failed``). This wins over everything else:
+      aplexer's launcher writes ``failed`` with no ``worker_pid`` when a
+      worker dies before completing startup
+      (``api.rs::persist_independent_cleanup_proof``); or
+    * it HAD a worker and lost it — ``worker_pid`` is set and
+      ``worker_alive`` is false. That is the zombie: nothing serves its
+      control socket, so ``a attach`` cannot succeed.
+
+    Everything else is alive, including two shapes that are deliberately NOT
+    dead:
+
+    * **``exiting`` with a live worker** — the real window right after
+      ``a kill``, where ``a attach`` still works.
+    * **a RECENT non-terminal phase with NO ``worker_pid``** — the record
+      aplexer writes at the very start of ``a start``, before the worker
+      registers its pid. ``SessionRecord::worker_alive``
+      (``aplexer/src/lib.rs``) returns false for a ``None`` pid, so EVERY
+      create passes through ``phase: starting`` / ``worker_alive: false``
+      for tens of milliseconds. Reading that as a corpse blanks the session
+      the user is watching appear (the #2547 symptom), refuses to attach to
+      it, and makes a retried create force-forget an in-flight worker. With
+      no pid, ``worker_alive: false`` is not evidence of death — it is
+      absence of evidence, which aplexer's own ``display_state`` calls
+      "broken" (indeterminate), not "exited".
+
+      That exemption is bounded by :data:`APLEXER_STARTING_GRACE_MS`,
+      because an ``a start`` KILLED inside the pre-PID window leaves exactly
+      this shape forever. The two are indistinguishable in one snapshot but
+      not in time: a real create is tens of milliseconds old, while a
+      crashed one keeps its original ``updated_at_ms`` and ages without
+      bound. Without the bound, that permanent corpse is listed as an
+      attachable row whose attach exits 1 and is handed back by
+      ``sessions create`` as an existing session — this issue's two reported
+      symptoms, through a different door.
+
+    Fails OPEN on every indeterminate shape: a record carrying no liveness
+    keys at all, and a pre-PID record whose ``updated_at_ms`` is missing or
+    unreadable (no age, no verdict). The cost of a stale row is a confusing
+    tap, while the cost of a wrong "dead" verdict is a live session the user
+    cannot reach — and, on the create path, one that gets force-forgotten.
+    """
+    if aplexer_phase(raw) in APLEXER_TERMINAL_PHASES:
+        return False
+    if _aplexer_worker_alive_flag(raw):
+        return True
+    # Only a worker that registered a pid can have provably lost it.
+    if aplexer_worker_pid(raw) is not None:
+        return False
+    return _aplexer_within_starting_grace(raw, now_ms)
+
+
+def _aplexer_within_starting_grace(
+    raw: Mapping[str, Any], now_ms: Optional[int]
+) -> bool:
+    """Whether a pre-PID record is young enough to still be starting."""
+    updated = _coerce_ms(raw.get("updated_at_ms"))
+    if updated is None:
+        return True  # no age, no verdict
+    if now_ms is None:
+        now_ms = int(time.time() * 1000)
+    # A clock skew that puts the record in the future reads as brand new,
+    # which is the fail-open direction.
+    return now_ms - updated <= APLEXER_STARTING_GRACE_MS
+
+
+def aplexer_worker_pid(raw: Mapping[str, Any]) -> Optional[int]:
+    """The record's worker pid, or ``None`` when it has not registered one.
+
+    Absent and ``null`` mean the same thing here: aplexer omits the key
+    entirely on a record whose worker has not started yet (verified on a
+    real mid-``a start`` capture, ``snapshot-mid-create.json``).
+    """
+    try:
+        pid = int(raw["worker_pid"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def _aplexer_worker_alive_flag(raw: Mapping[str, Any]) -> bool:
+    """``worker_alive`` as a bool; a missing key reads as alive (fail open)."""
+    worker_alive = raw.get("worker_alive")
+    if isinstance(worker_alive, bool):
+        return worker_alive
+    if isinstance(worker_alive, int):
+        return worker_alive > 0
+    return True
+
+
+def _aplexer_rows(payload: Any, now_ms: Optional[int]) -> list[LiveSession]:
+    """Every snapshot record as a :class:`LiveSession`, liveness included."""
     if not isinstance(payload, list):
         return []
     if now_ms is None:
@@ -411,9 +561,37 @@ def sessions_from_aplexer_snapshot(
                 agent_state_source=state_source,
                 attached=_aplexer_attached(raw),
                 activity_epoch=_created_epoch_from_ms(raw.get("last_activity_ms")),
+                phase=aplexer_phase(raw),
+                alive=aplexer_record_is_alive(raw, now_ms),
             )
         )
     return rows
+
+
+def sessions_from_aplexer_snapshot(
+    payload: Any, *, now_ms: Optional[int] = None
+) -> list[LiveSession]:
+    """The ATTACHABLE aplexer rows of a snapshot (issue #2554).
+
+    A dead record is not a session with a flag on it — it is a leftover, and
+    presenting it as an ordinary row is what put an un-attachable
+    `pocketshell:pocketshell` in the maintainer's tree. Use
+    :func:`dead_sessions_from_aplexer_snapshot` when the leftovers are the
+    point (explaining a stale attach, say).
+    """
+    return [row for row in _aplexer_rows(payload, now_ms) if row.alive]
+
+
+def dead_sessions_from_aplexer_snapshot(
+    payload: Any, *, now_ms: Optional[int] = None
+) -> list[LiveSession]:
+    """The rows :func:`sessions_from_aplexer_snapshot` refuses to list.
+
+    Each carries its ``phase`` and ``alive=False``, so a caller can say what
+    happened to a name instead of handing it to ``a attach`` and relaying a
+    bare exit 1.
+    """
+    return [row for row in _aplexer_rows(payload, now_ms) if not row.alive]
 
 
 # ---------------------------------------------------------------------------
@@ -614,6 +792,11 @@ def enumerate_live_sessions(
     ``enrich_tmux`` additionally asks each tmux session's own server for
     workspace/attached/activity (schema 2's tmux fields); the human-table
     path leaves it off so it costs nothing there.
+
+    Only LIVE aplexer records are unioned in: aplexer keeps a record after
+    its session dies, and listing those made the tree offer rows that attach
+    with exit 1 (issue #2554, :func:`aplexer_record_is_alive`). Every row
+    this returns is therefore ``alive``.
     """
     errors: list[dict[str, str]] = []
     tmux_rows = (

--- a/tools/pocketshell/src/pocketshell/sessions.py
+++ b/tools/pocketshell/src/pocketshell/sessions.py
@@ -44,6 +44,7 @@ import shutil
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence
 
@@ -767,18 +768,20 @@ def aplexer_start_argv(
     return argv
 
 
-def _aplexer_existing_record(
+def _aplexer_records_holding(
     payload: Any, *, workspace: str, tag: str
-) -> Optional[Mapping[str, Any]]:
-    """Find a live aplexer session already holding ``workspace`` + ``tag``.
+) -> list[Mapping[str, Any]]:
+    """Every snapshot record holding the ``workspace`` + ``tag`` pair.
 
-    aplexer keys a session by exactly that pair (`a start` refuses a second
-    one), so it is the identity to match on. A finished session does not
-    count: `a start` reclaims that pair, i.e. it really does create.
+    aplexer keys a session by exactly that pair, so it is the identity to
+    match on — and, critically, a DEAD record keeps holding it: `a start`
+    answers "workspace+tag already belongs to session <id>" and exits 1
+    (verified against aplexer 0.1.3). Liveness is the caller's split.
     """
     if not isinstance(payload, list):
-        return None
+        return []
     target = os.path.realpath(workspace)
+    held: list[Mapping[str, Any]] = []
     for raw in payload:
         if not isinstance(raw, Mapping):
             continue
@@ -787,10 +790,117 @@ def _aplexer_existing_record(
         raw_workspace = raw.get("workspace") or raw.get("cwd") or ""
         if os.path.realpath(str(raw_workspace)) != target:
             continue
-        if str(raw.get("phase") or "").strip().lower() in {"exited", "failed"}:
-            continue
-        return raw
+        held.append(raw)
+    return held
+
+
+def _aplexer_existing_record(
+    payload: Any, *, workspace: str, tag: str
+) -> Optional[Mapping[str, Any]]:
+    """Find a LIVE aplexer session already holding ``workspace`` + ``tag``.
+
+    A finished session does not count: `a start` reclaims that pair once the
+    record is gone, i.e. it really does create. Liveness is
+    :func:`session_enum.aplexer_record_is_alive` — the one implementation of
+    that rule (issue #2554). The local copy this replaced only skipped
+    ``exited``/``failed``, so the ``phase: running`` / ``worker_alive:
+    false`` zombie was reported as an already-existing session and the app
+    attached to a corpse.
+    """
+    for raw in _aplexer_records_holding(payload, workspace=workspace, tag=tag):
+        if _session_enum.aplexer_record_is_alive(raw):
+            return raw
     return None
+
+
+def _process_alive(pid: int) -> bool:
+    """Whether ``pid`` names a live process.
+
+    The same pessimistic check aplexer's ``process_alive`` makes: existence,
+    not identity. A recycled pid reads as alive, which errs toward NOT
+    destroying a record — the safe direction here.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists, owned by someone else.
+        return True
+    except OSError:
+        return True
+    return True
+
+
+def _aplexer_live_workload_pid(raw: Mapping[str, Any]) -> Optional[int]:
+    """The record's ``workload_pid`` if that process is still running."""
+    try:
+        pid = int(raw["workload_pid"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+    return pid if _process_alive(pid) else None
+
+
+@dataclass(frozen=True)
+class _BlockerReap:
+    """Outcome of clearing the dead records holding one workspace+tag."""
+
+    #: ``(id, workload_pid)`` for records NOT reaped because their workload
+    #: is still running. Reaping one destroys the only handle onto it.
+    workload_alive: tuple[tuple[str, int], ...] = ()
+    #: Records that were reaped but whose containment aplexer could not
+    #: prove empty — something may have outlived them.
+    may_survive: tuple[str, ...] = ()
+    #: Dead records the reap could not clear at all.
+    unreaped: tuple[str, ...] = ()
+
+
+def _reap_aplexer_blockers(
+    payload: Any, *, aplexer_path: str, workspace: str, tag: str
+) -> _BlockerReap:
+    """Reap the dead records holding ``workspace`` + ``tag``.
+
+    Called only after :func:`_aplexer_existing_record` came back empty, and
+    each record is re-checked with the same predicate here, so a live
+    session is never a candidate however this is called.
+
+    A record whose ``workload_pid`` is still ALIVE is deliberately left
+    alone: ``a forget --force`` is documented as forgetting a record
+    "without claiming its workloads stopped", so reaping one destroys the
+    only handle onto a running process. aplexer's own ``a prune`` refuses
+    exactly this case (``a.rs::cmd_prune`` retains any record with a live
+    ``workload_pid``); this mirrors that rule rather than inventing a
+    laxer one.
+
+    Reaping still discards the record's durable history — the same trade
+    `sessions kill` makes, and the user is explicitly asking for this exact
+    pair back.
+    """
+    workload_alive: list[tuple[str, int]] = []
+    may_survive: list[str] = []
+    unreaped: list[str] = []
+    for raw in _aplexer_records_holding(payload, workspace=workspace, tag=tag):
+        ident = str(raw.get("id") or "").strip()
+        if not ident:
+            continue
+        if _session_enum.aplexer_record_is_alive(raw):
+            continue
+        pid = _aplexer_live_workload_pid(raw)
+        if pid is not None:
+            workload_alive.append((ident, pid))
+            continue
+        outcome = _reap_aplexer_record(aplexer_path, ident)
+        if not outcome.reaped:
+            unreaped.append(ident)
+        elif outcome.workload_may_survive:
+            may_survive.append(ident)
+    return _BlockerReap(
+        workload_alive=tuple(workload_alive),
+        may_survive=tuple(may_survive),
+        unreaped=tuple(unreaped),
+    )
 
 
 def _create_on_aplexer(
@@ -832,9 +942,8 @@ def _create_on_aplexer(
         )
     workspace = cwd or os.getcwd()
 
-    existing = _aplexer_existing_record(
-        _aplexer_snapshot(), workspace=workspace, tag=name
-    )
+    snapshot = _aplexer_snapshot()
+    existing = _aplexer_existing_record(snapshot, workspace=workspace, tag=name)
     if existing is not None:
         return {
             "name": _session_enum.aplexer_display_name(existing) or name,
@@ -842,6 +951,36 @@ def _create_on_aplexer(
             "id": str(existing.get("id") or "") or None,
             "created": False,
         }
+
+    # Nothing LIVE holds the pair — but a dead record still holds it hostage:
+    # aplexer refuses `a start` with "workspace+tag already belongs to session
+    # <id>" for a corpse just as firmly as for a running session, and since
+    # #2554 that corpse is not even in the listing for the user to see. Clear
+    # it first (issue #2554: "can't create an agent session").
+    blockers = _reap_aplexer_blockers(
+        snapshot, aplexer_path=aplexer_path, workspace=workspace, tag=name
+    )
+    if blockers.workload_alive:
+        # Refuse rather than orphan. `a forget --force` would reclaim the
+        # pair and report a clean create while an untracked process kept
+        # running with nothing left pointing at it. aplexer's own `a prune`
+        # refuses this exact case; `a kill` cannot help either — on a record
+        # whose worker died it answers "no authoritative containment
+        # locator" and changes nothing (both verified against `a 0.1.3`).
+        detail = "; ".join(
+            f"record {ident} still has workload pid {pid} running"
+            for ident, pid in blockers.workload_alive
+        )
+        manual = " ".join(
+            f"`kill {pid}` then `a forget --force {ident}`"
+            for ident, pid in blockers.workload_alive
+        )
+        raise _CreateError(
+            f"pocketshell: cannot create {name!r} in {workspace!r}: a dead "
+            f"aplexer record still holds that workspace+tag and its workload "
+            f"is still running ({detail}); reclaiming the pair would leave "
+            f"that process untracked. Stop it first — {manual} — and retry."
+        )
 
     argv = aplexer_start_argv(
         aplexer_path=aplexer_path,
@@ -852,9 +991,25 @@ def _create_on_aplexer(
     )
     code, stdout, stderr = _run_aplexer(argv)
     if code != 0:
+        detail = stderr.strip() or stdout.strip() or "no output"
+        if blockers.unreaped:
+            # Never relay aplexer's bare "rename it or choose a different
+            # tag": the session it names is a corpse the listing no longer
+            # shows, so that advice sends the user hunting for something
+            # invisible. Name the record and the command that clears it.
+            stuck = ", ".join(blockers.unreaped)
+            manual = " ".join(
+                f"`a forget --force {ident}`" for ident in blockers.unreaped
+            )
+            raise _CreateError(
+                f"pocketshell: cannot create {name!r} in {workspace!r}: a dead "
+                f"aplexer record ({stuck}) still holds that workspace+tag "
+                f"and could not be reaped; run {manual} and retry "
+                f"(`a start` exited {code}: {detail})",
+                exit_code=code,
+            )
         raise _CreateError(
-            f"pocketshell: `a start --tag {name}` exited {code}: "
-            f"{stderr.strip() or stdout.strip() or 'no output'}",
+            f"pocketshell: `a start --tag {name}` exited {code}: {detail}",
             exit_code=code,
         )
     try:
@@ -868,6 +1023,12 @@ def _create_on_aplexer(
             "pocketshell: `a --json start` returned "
             f"{type(record).__name__}, expected a session record"
         )
+    for ident in blockers.may_survive:
+        # aplexer could not prove the reclaimed record's containment was
+        # empty. The create succeeded — the pair IS ours now — but something
+        # may have outlived it (a setsid'd grandchild survives the worker),
+        # and this is the last moment anyone knows the id it belonged to.
+        click.echo(_workload_survivor_warning(name, ident), err=True)
     return {
         "name": _session_enum.aplexer_display_name(record) or name,
         "manager": _session_enum.MANAGER_APLEXER,
@@ -1215,6 +1376,41 @@ def _attach_live_rows() -> tuple[list[_session_enum.LiveSession], list[dict[str,
     )
 
 
+def _dead_row_detail(row: _session_enum.LiveSession) -> str:
+    """One clause saying what actually happened to a dead aplexer record."""
+    phase = row.phase or "unknown"
+    if phase == "exited":
+        return f"it has already exited (aplexer phase: {phase})"
+    if phase == "failed":
+        return f"it failed to start (aplexer phase: {phase})"
+    # The zombie: the record still claims a live phase, but nothing serves
+    # its control socket, so `a attach` cannot succeed.
+    return (
+        f"it has no live worker (aplexer phase: {phase}, worker_alive: false)"
+    )
+
+
+def _not_attachable_message(name: str) -> str:
+    """Why NAME cannot be attached — naming the state when it is a corpse.
+
+    Issue #2554: the listing no longer offers dead aplexer records, so the
+    only way to reach one is a name the caller kept from an older listing.
+    Passing it to `a attach` anyway produces "session ... has already
+    exited" on aplexer's stderr and exit 1, which the phone rendered as a
+    bare `Session "..." ended (exit 1).` — a crash-shaped message for an
+    ordinary "this is gone". A genuinely unknown name keeps the plain
+    not-found wording.
+    """
+    dead = _session_enum.dead_sessions_from_aplexer_snapshot(_aplexer_snapshot())
+    for row in _match_attach_target(dead, name):
+        return (
+            f"pocketshell: aplexer session {row.name!r} is no longer running: "
+            f"{_dead_row_detail(row)}. It cannot be attached; "
+            "run `pocketshell sessions list` for the live ones."
+        )
+    return f"no session named {name!r}"
+
+
 def _describe_candidate(row: _session_enum.LiveSession) -> str:
     if row.manager == _session_enum.MANAGER_APLEXER and row.aplexer_id:
         return f"  {row.name}  ({row.manager} {row.aplexer_id})"
@@ -1253,7 +1449,7 @@ def sessions_attach(ctx: click.Context, name: str, hide_status: bool) -> None:
     rows, _errors = _attach_live_rows()
     matches = _match_attach_target(rows, name)
     if not matches:
-        click.echo(f"no session named {name!r}", err=True)
+        click.echo(_not_attachable_message(name), err=True)
         ctx.exit(ATTACH_EXIT_NOT_FOUND)
         return
     if len(matches) > 1:
@@ -1369,13 +1565,139 @@ def _emit_kill_failure(
 
 
 def _run_session_kill(argv: list[str]) -> subprocess.CompletedProcess[str]:
-    """Run one kill argv (tmux kill-session or ``a kill``). Never kill-server."""
+    """Run one kill/reap argv (``tmux kill-session``, ``a kill``, ``a forget``).
+
+    Never ``tmux kill-server``.
+    """
     return subprocess.run(
         argv,
         check=False,
         capture_output=True,
         text=True,
         timeout=_TMUX_TIMEOUT_S,
+    )
+
+
+# ---------------------------------------------------------------------------
+# reaping an aplexer record after a kill (issue #2554)
+# ---------------------------------------------------------------------------
+#
+# `a kill` signals the workload; it does NOT remove the session record.
+# aplexer keeps it at `phase: exited` indefinitely, and the tree used to
+# render that leftover as an ordinary, tappable row whose attach answered
+# "session ... has already exited" and exited 1. Stop therefore left a corpse
+# behind every single time.
+#
+# Why `a forget --force <id>` and not `a prune` (both measured on the dev box
+# against the shipped aplexer 0.1.3):
+#
+#   * `a prune` only removes records aplexer considers reclaimable. A record
+#     whose worker died without recording an exit (`phase: running`,
+#     `worker_alive: false`) is NOT reclaimable: prune answered
+#     `{"removed": [], "retained_count": 2}` and left it in place. That is
+#     the same zombie class this fix filters out of the listing, so a
+#     prune-based reap would be structurally unable to clean up after itself.
+#   * `a prune` is host-wide. Reaping one stopped session must not also
+#     delete the durable history of every other dead session on the box.
+#   * `a forget --force <id>` is targeted and unconditional once the worker
+#     is gone, and its refusal is precise enough to retry on.
+#
+# Both paths share one race: immediately after `a kill` the record is
+# terminal but its worker is still winding down, and aplexer refuses
+# ("session ... still has a live worker; refusing to forget it"). A single
+# fire-and-forget attempt loses that window and silently leaves the row. So
+# the reap retries until the worker is gone or the budget runs out.
+
+#: Substring of aplexer's refusal while the worker is still winding down
+#: (aplexer/src/api.rs::forget_session).
+_REAP_WORKER_STILL_LIVE = "still has a live worker"
+#: Substring of aplexer's answer when the record is already gone. The goal
+#: state, so it counts as reaped rather than as a failure.
+_REAP_ALREADY_GONE = "no matching session"
+_REAP_MAX_ATTEMPTS = 30
+_REAP_POLL_S = 0.1
+_REAP_BUDGET_S = 3.0
+
+
+def _reap_wait() -> None:
+    """Pause between reap attempts.
+
+    Its own seam so the unit suite can exercise the retry window at full
+    speed instead of wall-clock.
+    """
+    time.sleep(_REAP_POLL_S)
+
+
+@dataclass(frozen=True)
+class _ReapOutcome:
+    """What one ``a forget --force`` attempt actually achieved.
+
+    ``workload_may_survive`` is aplexer's OWN verdict, read off
+    ``a --json forget``'s payload rather than guessed: ``a forget`` never
+    claims the workload stopped, and reports
+    ``containment_proven_empty: false`` when processes may have outlived the
+    record. Swallowing that (it goes to stderr in human mode) is how a reap
+    can silently orphan a running process.
+    """
+
+    reaped: bool
+    workload_may_survive: bool = False
+
+
+def _reap_aplexer_record(aplexer_path: str, aplexer_id: str) -> _ReapOutcome:
+    """Remove the aplexer record for a session that was just killed.
+
+    Best effort by design: the workload is already dead, so a stuck reap must
+    never turn a successful kill into a reported failure — it only means the
+    row survives until the next `a prune`/manual `a forget`.
+
+    ``--json`` is passed so the containment verdict comes back as data on
+    stdout (the human warning goes to stderr) instead of having to be
+    string-matched.
+    """
+    deadline = time.monotonic() + _REAP_BUDGET_S
+    argv = [aplexer_path, "--json", "forget", "--force", str(aplexer_id)]
+    for attempt in range(_REAP_MAX_ATTEMPTS):
+        try:
+            completed = _run_session_kill(argv)
+        except (subprocess.TimeoutExpired, OSError):
+            return _ReapOutcome(reaped=False)
+        if completed.returncode == 0:
+            return _ReapOutcome(
+                reaped=True,
+                workload_may_survive=_reap_workload_may_survive(completed.stdout),
+            )
+        detail = f"{completed.stderr or ''}{completed.stdout or ''}"
+        if _REAP_ALREADY_GONE in detail:
+            # A newer aplexer may reap inside `a kill`; nothing left to do.
+            return _ReapOutcome(reaped=True)
+        if _REAP_WORKER_STILL_LIVE not in detail:
+            # Any other refusal is not something waiting will fix.
+            return _ReapOutcome(reaped=False)
+        if attempt + 1 >= _REAP_MAX_ATTEMPTS or time.monotonic() >= deadline:
+            return _ReapOutcome(reaped=False)
+        _reap_wait()
+    return _ReapOutcome(reaped=False)
+
+
+def _reap_workload_may_survive(stdout: Optional[str]) -> bool:
+    """Read ``workload_may_survive`` off ``a --json forget``'s payload.
+
+    Unreadable output means "no claim made", not "may survive": a warning
+    nobody can act on, fired on every ordinary Stop, stops being read.
+    """
+    try:
+        payload = json.loads(stdout or "")
+    except ValueError:
+        return False
+    return isinstance(payload, Mapping) and bool(payload.get("workload_may_survive"))
+
+
+def _workload_survivor_warning(name: str, aplexer_id: str) -> str:
+    return (
+        f"pocketshell: reclaimed {name!r} from aplexer record {aplexer_id}, but "
+        "aplexer could not prove its containment was empty — its workload "
+        "processes may still be running and are no longer tracked."
     )
 
 
@@ -1391,7 +1713,7 @@ def _run_session_kill(argv: list[str]) -> subprocess.CompletedProcess[str]:
     default=False,
     help=(
         "Emit the schema-2 kill envelope "
-        '{"schema","name","manager","id","killed"} on stdout.'
+        '{"schema","name","manager","id","killed","reaped"} on stdout.'
     ),
 )
 @click.pass_context
@@ -1406,7 +1728,9 @@ def sessions_kill(ctx: click.Context, name: str, as_json: bool) -> None:
 
     tmux sessions are killed with `tmux -S <socket> kill-session -t '=NAME'`
     on the socket `_find_tmux_socket` located. aplexer sessions are killed
-    with `a kill <id>`. This never runs `tmux kill-server`.
+    with `a kill <id>` and then REAPED with `a forget --force <id>`, because
+    `a kill` alone leaves the record behind and the tree would keep offering
+    a dead row (#2554). This never runs `tmux kill-server`.
 
     Exit 3 = no such session, 4 = ambiguous, 5 = tmux session found but its
     socket could not be located, 127 = the kill binary is missing.
@@ -1488,6 +1812,25 @@ def sessions_kill(ctx: click.Context, name: str, as_json: bool) -> None:
                 as_json=as_json,
             )
             return
+        # The kill only signalled the workload; the record still has to go,
+        # or the very next listing hands the tree a dead, tappable row
+        # (issue #2554).
+        outcome = _reap_aplexer_record(resolution.path, str(aplexer_id))
+        reaped = outcome.reaped
+        if outcome.workload_may_survive:
+            click.echo(
+                _workload_survivor_warning(row.name, str(aplexer_id)), err=True
+            )
+        if not reaped:
+            # Never fatal — the session IS dead, only its record survives.
+            # Said out loud so a lingering row is explained rather than
+            # looking like the kill silently failed.
+            click.echo(
+                f"pocketshell: killed {row.name!r}, but its aplexer record "
+                f"could not be reaped; run `a forget --force {aplexer_id}` "
+                "if it keeps showing up.",
+                err=True,
+            )
         if as_json:
             click.echo(
                 json.dumps(
@@ -1497,6 +1840,7 @@ def sessions_kill(ctx: click.Context, name: str, as_json: bool) -> None:
                         "manager": row.manager,
                         "id": aplexer_id,
                         "killed": True,
+                        "reaped": reaped,
                     },
                     indent=2,
                 )
@@ -1562,6 +1906,9 @@ def sessions_kill(ctx: click.Context, name: str, as_json: bool) -> None:
                     "manager": row.manager,
                     "id": row.aplexer_id,
                     "killed": True,
+                    # tmux keeps no record of a killed session: kill-session
+                    # IS the removal, so the row is always gone (#2554).
+                    "reaped": True,
                 },
                 indent=2,
             )

--- a/tools/pocketshell/tests/fixtures/aplexer/snapshot-crashed-start.json
+++ b/tools/pocketshell/tests/fixtures/aplexer/snapshot-crashed-start.json
@@ -1,0 +1,25 @@
+[
+  {
+    "command": [
+      "/bin/bash",
+      "-l"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788686781148,
+    "cwd": "/tmp/i2554r4/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/i2554r4/state/aplexer/sessions/6b1ddabb-1b5c-4a76-b46b-1f7e70d78a9a/history.bin",
+    "id": "6b1ddabb-1b5c-4a76-b46b-1f7e70d78a9a",
+    "limits": {},
+    "phase": "starting",
+    "schema_version": 1,
+    "socket_path": "/tmp/i2554r4/rt/aplexer/sessions/6b1ddabb-1b5c-4a76-b46b-1f7e70d78a9a/control.sock",
+    "tag": "crashed1",
+    "updated_at_ms": 1788686781148,
+    "worker_alive": false,
+    "workspace": "/tmp/i2554r4/ws"
+  }
+]

--- a/tools/pocketshell/tests/fixtures/aplexer/snapshot-liveness-mix.json
+++ b/tools/pocketshell/tests/fixtures/aplexer/snapshot-liveness-mix.json
@@ -1,0 +1,113 @@
+[
+  {
+    "command": [
+      "/bin/bash",
+      "-l"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788681984137,
+    "cwd": "/tmp/i2554cap/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/i2554cap/state/aplexer/sessions/b3351d63-dce8-49cd-aab3-32e200901863/history.bin",
+    "id": "b3351d63-dce8-49cd-aab3-32e200901863",
+    "last_activity_ms": 1788681984453,
+    "limits": {},
+    "phase": "running",
+    "schema_version": 1,
+    "socket_path": "/tmp/i2554cap/rt/aplexer/sessions/b3351d63-dce8-49cd-aab3-32e200901863/control.sock",
+    "tag": "live",
+    "updated_at_ms": 1788681984811,
+    "worker_alive": true,
+    "worker_pid": 3574746,
+    "workload_pid": 3574747,
+    "workspace": "/tmp/i2554cap/ws"
+  },
+  {
+    "command": [
+      "/bin/bash",
+      "-l"
+    ],
+    "containment_empty": true,
+    "created_at_ms": 1788682048925,
+    "cwd": "/tmp/i2554cap/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "exit": {
+      "code": null,
+      "exited_at_ms": 1788682051080,
+      "oom_killed": false,
+      "signal": 9
+    },
+    "history_bytes": 4194304,
+    "history_path": "/tmp/i2554cap/state/aplexer/sessions/dcef0eda-b4cf-4bde-9289-db45a11eea01/history.bin",
+    "id": "dcef0eda-b4cf-4bde-9289-db45a11eea01",
+    "last_activity_ms": 1788682049110,
+    "limits": {},
+    "phase": "exited",
+    "schema_version": 1,
+    "socket_path": "/tmp/i2554cap/rt/aplexer/sessions/dcef0eda-b4cf-4bde-9289-db45a11eea01/control.sock",
+    "tag": "doomed",
+    "updated_at_ms": 1788682051080,
+    "worker_alive": false,
+    "worker_pid": 3588676,
+    "workload_pid": 3588687,
+    "workspace": "/tmp/i2554cap/ws"
+  },
+  {
+    "command": [
+      "/bin/bash",
+      "-l"
+    ],
+    "containment_empty": true,
+    "created_at_ms": 1788682048925,
+    "cwd": "/tmp/i2554cap/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "error": "worker did not complete startup; launcher independently emptied containment",
+    "exit": null,
+    "history_bytes": 4194304,
+    "history_path": "/tmp/i2554cap/state/aplexer/sessions/f1a11ed0-0000-4000-8000-000000000001/history.bin",
+    "id": "f1a11ed0-0000-4000-8000-000000000001",
+    "last_activity_ms": 1788682049110,
+    "limits": {},
+    "phase": "failed",
+    "schema_version": 1,
+    "socket_path": "/tmp/i2554cap/rt/aplexer/sessions/f1a11ed0-0000-4000-8000-000000000001/control.sock",
+    "tag": "failed-start",
+    "updated_at_ms": 1788682051080,
+    "worker_alive": false,
+    "worker_pid": null,
+    "workload_pid": null,
+    "workspace": "/tmp/i2554cap/ws"
+  },
+  {
+    "command": [
+      "/bin/bash",
+      "-l"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788682048805,
+    "cwd": "/tmp/i2554cap/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/i2554cap/state/aplexer/sessions/c06513a5-ee94-4081-b4b1-6d4d39d22ac5/history.bin",
+    "id": "c06513a5-ee94-4081-b4b1-6d4d39d22ac5",
+    "limits": {},
+    "phase": "running",
+    "schema_version": 1,
+    "socket_path": "/tmp/i2554cap/rt/aplexer/sessions/c06513a5-ee94-4081-b4b1-6d4d39d22ac5/control.sock",
+    "tag": "zombie",
+    "updated_at_ms": 1788682048886,
+    "worker_alive": false,
+    "worker_pid": 3588610,
+    "workload_pid": 3588621,
+    "workspace": "/tmp/i2554cap/ws"
+  }
+]

--- a/tools/pocketshell/tests/fixtures/aplexer/snapshot-mid-create.json
+++ b/tools/pocketshell/tests/fixtures/aplexer/snapshot-mid-create.json
@@ -1,0 +1,25 @@
+[
+  {
+    "command": [
+      "/bin/bash",
+      "-l"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788684999294,
+    "cwd": "/tmp/i2554r3/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/i2554r3/state/aplexer/sessions/078e2bf5-8e37-44e6-b1cf-8f72e261495e/history.bin",
+    "id": "078e2bf5-8e37-44e6-b1cf-8f72e261495e",
+    "limits": {},
+    "phase": "starting",
+    "schema_version": 1,
+    "socket_path": "/tmp/i2554r3/rt/aplexer/sessions/078e2bf5-8e37-44e6-b1cf-8f72e261495e/control.sock",
+    "tag": "midcreate",
+    "updated_at_ms": 1788684999294,
+    "worker_alive": false,
+    "workspace": "/tmp/i2554r3/ws"
+  }
+]

--- a/tools/pocketshell/tests/fixtures/aplexer/snapshot-post-kill-window.json
+++ b/tools/pocketshell/tests/fixtures/aplexer/snapshot-post-kill-window.json
@@ -1,0 +1,79 @@
+[
+  {
+    "command": [
+      "/bin/bash",
+      "-l"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788682048925,
+    "cwd": "/tmp/i2554cap/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/i2554cap/state/aplexer/sessions/dcef0eda-b4cf-4bde-9289-db45a11eea01/history.bin",
+    "id": "dcef0eda-b4cf-4bde-9289-db45a11eea01",
+    "last_activity_ms": 1788682049110,
+    "limits": {},
+    "phase": "exiting",
+    "schema_version": 1,
+    "socket_path": "/tmp/i2554cap/rt/aplexer/sessions/dcef0eda-b4cf-4bde-9289-db45a11eea01/control.sock",
+    "tag": "doomed",
+    "updated_at_ms": 1788682051052,
+    "worker_alive": true,
+    "worker_pid": 3588676,
+    "workload_pid": 3588687,
+    "workspace": "/tmp/i2554cap/ws"
+  },
+  {
+    "command": [
+      "/bin/bash",
+      "-l"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788682048805,
+    "cwd": "/tmp/i2554cap/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/i2554cap/state/aplexer/sessions/c06513a5-ee94-4081-b4b1-6d4d39d22ac5/history.bin",
+    "id": "c06513a5-ee94-4081-b4b1-6d4d39d22ac5",
+    "limits": {},
+    "phase": "running",
+    "schema_version": 1,
+    "socket_path": "/tmp/i2554cap/rt/aplexer/sessions/c06513a5-ee94-4081-b4b1-6d4d39d22ac5/control.sock",
+    "tag": "zombie",
+    "updated_at_ms": 1788682048886,
+    "worker_alive": false,
+    "worker_pid": 3588610,
+    "workload_pid": 3588621,
+    "workspace": "/tmp/i2554cap/ws"
+  },
+  {
+    "command": [
+      "/bin/bash",
+      "-l"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788681984137,
+    "cwd": "/tmp/i2554cap/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/i2554cap/state/aplexer/sessions/b3351d63-dce8-49cd-aab3-32e200901863/history.bin",
+    "id": "b3351d63-dce8-49cd-aab3-32e200901863",
+    "last_activity_ms": 1788681984453,
+    "limits": {},
+    "phase": "running",
+    "schema_version": 1,
+    "socket_path": "/tmp/i2554cap/rt/aplexer/sessions/b3351d63-dce8-49cd-aab3-32e200901863/control.sock",
+    "tag": "live",
+    "updated_at_ms": 1788681984811,
+    "worker_alive": true,
+    "worker_pid": 3574746,
+    "workload_pid": 3574747,
+    "workspace": "/tmp/i2554cap/ws"
+  }
+]

--- a/tools/pocketshell/tests/test_session_enum_schema2.py
+++ b/tools/pocketshell/tests/test_session_enum_schema2.py
@@ -15,6 +15,36 @@ The aplexer fixtures under ``tests/fixtures/aplexer/`` are REAL captures of
   started for the capture, one of which really ran ``a state-report
   waiting`` inside itself, so ``reported_state``/``reported_state_at_ms``
   are genuine aplexer output rather than invented keys.
+- ``snapshot-liveness-mix.json`` — a second isolated instance (issue #2554)
+  holding one live session, one killed session (``phase: exited``) and one
+  whose worker was ``SIGKILL``ed out from under it (``phase: running``,
+  ``worker_alive: false`` — the zombie class that sat in the maintainer's
+  tree for ten days). The fourth row, ``phase: failed``, is the ONE derived
+  record in these fixtures: a failed worker startup leaves no record behind
+  to capture (verified on the dev box), so it is the real ``exited`` capture
+  with aplexer's other terminal phase (``Phase::Failed``,
+  ``aplexer/src/lib.rs``) and its startup-failure ``error`` substituted in.
+- ``snapshot-post-kill-window.json`` — the same instance captured in the
+  window right after ``a kill``: the killed record is ``phase: exiting``
+  with ``worker_alive: true`` (the worker is still winding down). This is
+  the window that makes a fire-and-forget reap a no-op.
+- ``snapshot-mid-create.json`` — a record captured DURING ``a start``, by
+  polling ``a --json list`` through a real create: ``phase: starting`` with
+  no ``worker_pid`` yet and therefore ``worker_alive: false``, because
+  aplexer persists the record before the worker registers its pid
+  (``SessionRecord::worker_alive`` returns false for a ``None`` pid). Every
+  ``a start`` passes through this shape for tens of milliseconds. Calling it
+  dead hides a session that is being created — the #2547 symptom.
+- ``snapshot-crashed-start.json`` — the OTHER side of that boundary,
+  captured by SIGKILLing a real ``a start``'s process group inside the
+  pre-PID window: byte-identical in shape (``starting`` / no ``worker_pid``
+  / ``worker_alive: false``) and it never changes again. aplexer's own
+  ``a list`` renders it ``✗ broken``. The two fixtures differ only in age,
+  which is why age is the discriminator.
+
+Both were captured with the maintainer's ``a 0.1.3``; the key set was
+compared against the copy PINNED in this package's venv and is identical,
+and neither carries a ``state`` field (that is unreleased — see #2556).
 """
 
 from __future__ import annotations
@@ -47,12 +77,25 @@ SCHEMA2_ROW_KEYS = {
     "attached",
     "created_epoch",
     "activity_epoch",
+    # Issue #2554: the wire carries liveness explicitly, so a client never has
+    # to infer "is this row attachable" from the absence of a filter.
+    "phase",
+    "alive",
 }
 
 # ids from the real captures
 REPORTED_ID = "7813f1ca-891d-4b43-829f-aca6ee182f10"
 HEURISTIC_ID = "b95a85e9-6f71-4b33-b34a-a2344da72910"
 PLAIN_SHELL_ID = "97d6e5f9-3a92-41c5-bbe4-d367b5017415"
+# ids from snapshot-liveness-mix.json (issue #2554)
+LIVE_ID = "b3351d63-dce8-49cd-aab3-32e200901863"
+KILLED_ID = "dcef0eda-b4cf-4bde-9289-db45a11eea01"
+FAILED_ID = "f1a11ed0-0000-4000-8000-000000000001"
+ZOMBIE_ID = "c06513a5-ee94-4081-b4b1-6d4d39d22ac5"
+# id from snapshot-mid-create.json (real capture during `a start`)
+MID_CREATE_ID = "078e2bf5-8e37-44e6-b1cf-8f72e261495e"
+# id from snapshot-crashed-start.json (real capture of a killed `a start`)
+CRASHED_START_ID = "6b1ddabb-1b5c-4a76-b46b-1f7e70d78a9a"
 # Captured values, read back from the fixture rather than restated here.
 
 
@@ -137,10 +180,15 @@ def test_aplexer_only_host_emits_schema_2_rows() -> None:
 
 
 def test_both_managers_are_listed_together() -> None:
+    """Both managers contribute rows — from the LIVE records only (#2554).
+
+    ``snapshot-liveness-mix.json`` holds four aplexer records and exactly one
+    live one, so this also pins the union path against the dead-row leak.
+    """
     sessions, errors = session_enum.enumerate_live_sessions(
         tmuxctl_stdout=_tmuxctl_table(),
-        aplexer_payload=_load("snapshot.json"),
-        now_ms=1_788_409_006_000,
+        aplexer_payload=_load("snapshot-liveness-mix.json"),
+        now_ms=1_788_682_060_000,
     )
     payload = session_enum.json_payload(sessions, errors)
 
@@ -149,7 +197,7 @@ def test_both_managers_are_listed_together() -> None:
     assert payload["errors"] == []
     managers = [row["manager"] for row in payload["sessions"]]
     assert managers.count("tmux") == 2
-    assert managers.count("aplexer") == 4
+    assert managers.count("aplexer") == 1
     for row in payload["sessions"]:
         assert set(row) == SCHEMA2_ROW_KEYS
 
@@ -305,32 +353,369 @@ def test_plain_shell_session_reports_a_null_engine() -> None:
 
 
 def test_exited_session_has_no_agent_state() -> None:
+    """A terminal-phase record has no agent state — checked on the DEAD list.
+
+    Since #2554 an exited record never reaches the live listing, so the
+    assertion moved onto the dead projection, which is where such a row is
+    now visible.
+    """
     snapshot = _load("snapshot.json")
     exited = [row for row in snapshot if row["phase"] == "exited"]
     assert exited, "fixture must contain a terminal-phase row"
 
-    sessions = session_enum.sessions_from_aplexer_snapshot(
+    dead = session_enum.dead_sessions_from_aplexer_snapshot(
         snapshot, now_ms=1_788_409_006_000
     )
-    row = _by_name(sessions, "zcode-acp:zcodex-test")
+    row = _by_name(dead, "zcode-acp:zcodex-test")
     assert row.agent_state is None
     assert row.agent_state_source is None
+    assert row.phase == "exited"
+    assert row.alive is False
 
 
 def test_aplexer_rows_are_not_attached_without_a_snapshot_field() -> None:
-    """aplexer 0.1.1 exposes no attached-client count; the row says False."""
-    snapshot = _load("snapshot.json")
+    """aplexer 0.1.3 exposes no attached-client count; the row says False."""
+    snapshot = _load("snapshot-liveness-mix.json")
     assert all("attached_clients" not in row for row in snapshot)
     sessions = session_enum.sessions_from_aplexer_snapshot(
-        snapshot, now_ms=1_788_409_006_000
+        snapshot, now_ms=1_788_682_060_000
     )
+    assert sessions, "fixture must contain a live row"
     assert all(row.attached is False for row in sessions)
 
     # ...and starts telling the truth the moment aplexer grows the field.
-    grown = [dict(snapshot[0], attached_clients=2)]
+    live = _row(snapshot, LIVE_ID)
+    grown = [dict(live, attached_clients=2)]
     assert session_enum.sessions_from_aplexer_snapshot(
-        grown, now_ms=1_788_409_006_000
+        grown, now_ms=1_788_682_060_000
     )[0].attached is True
+
+
+# ---------------------------------------------------------------------------
+# liveness — a dead aplexer record is never an attachable row (issue #2554)
+# ---------------------------------------------------------------------------
+#
+# Reported from the phone: the tree kept offering `pocketshell:pocketshell`,
+# a record aplexer had already reaped the worker for. Tapping it ran
+# `a attach <id>`, which answers "session … has already exited" and exits 1,
+# so the app showed `Session "…" ended (exit 1)`.
+
+
+def test_only_the_live_record_is_listed_from_a_mixed_snapshot() -> None:
+    """exited + failed + zombie + live -> one row (the live one)."""
+    snapshot = _load("snapshot-liveness-mix.json")
+    assert {row["id"] for row in snapshot} == {
+        LIVE_ID,
+        KILLED_ID,
+        FAILED_ID,
+        ZOMBIE_ID,
+    }
+    # The four states this filter has to tell apart, straight off the capture.
+    assert (_row(snapshot, KILLED_ID)["phase"], _row(snapshot, KILLED_ID)["worker_alive"]) == ("exited", False)
+    assert (_row(snapshot, FAILED_ID)["phase"], _row(snapshot, FAILED_ID)["worker_alive"]) == ("failed", False)
+    assert (_row(snapshot, ZOMBIE_ID)["phase"], _row(snapshot, ZOMBIE_ID)["worker_alive"]) == ("running", False)
+    assert (_row(snapshot, LIVE_ID)["phase"], _row(snapshot, LIVE_ID)["worker_alive"]) == ("running", True)
+
+    sessions = session_enum.sessions_from_aplexer_snapshot(
+        snapshot, now_ms=1_788_682_060_000
+    )
+
+    assert [row.aplexer_id for row in sessions] == [LIVE_ID]
+    assert [row.name for row in sessions] == ["ws:live"]
+    assert sessions[0].alive is True
+    assert sessions[0].phase == "running"
+
+
+def test_a_snapshot_of_only_dead_records_renders_zero_aplexer_sessions() -> None:
+    """The maintainer's actual tree state (issue #2554), replayed.
+
+    ``snapshot.json`` is a REAL host-wide capture in which every one of the
+    four records is dead: one killed session (``zcode-acp:zcodex-test``)
+    plus three ~10-day-old zombies whose workers died without recording an
+    exit (``aplexer-follow:{yolo,zsp,live}``). Before the fix all four
+    listed as ordinary, tappable rows — the same class as the
+    ``pocketshell:pocketshell`` row in the report's screenshot, which came
+    from the same host at a different moment and is not in this capture.
+    """
+    snapshot = _load("snapshot.json")
+    assert len(snapshot) == 4
+    assert all(
+        row["phase"] in {"exited", "failed"} or row["worker_alive"] is False
+        for row in snapshot
+    )
+
+    sessions, errors = session_enum.enumerate_live_sessions(
+        tmuxctl_stdout=_tmuxctl_table(),
+        aplexer_payload=snapshot,
+        now_ms=1_788_409_006_000,
+    )
+    payload = session_enum.json_payload(sessions, errors)
+
+    assert [row["manager"] for row in payload["sessions"]] == ["tmux", "tmux"]
+    assert payload["managers"] == ["tmux"]
+    # Not an enumeration failure — aplexer answered, it just has nothing live.
+    assert payload["errors"] == []
+    # Gone by NAME, not merely by count: every dead row in the capture, named.
+    listed = {row["name"] for row in payload["sessions"]}
+    for gone in (
+        "zcode-acp:zcodex-test",
+        "aplexer-follow:yolo",
+        "aplexer-follow:zsp",
+        "aplexer-follow:live",
+    ):
+        assert gone not in listed
+
+
+def test_a_record_winding_down_after_a_kill_is_still_listed() -> None:
+    """``phase: exiting`` + a live worker is a live session, not a corpse.
+
+    Captured in the real window right after ``a kill``. Filtering it here
+    would make Stop look instant while ``a attach`` still works, and would
+    make the reap's retry loop untestable.
+    """
+    snapshot = _load("snapshot-post-kill-window.json")
+    winding_down = [row for row in snapshot if row["phase"] == "exiting"]
+    assert len(winding_down) == 1
+    assert winding_down[0]["worker_alive"] is True
+
+    sessions = session_enum.sessions_from_aplexer_snapshot(
+        snapshot, now_ms=1_788_682_060_000
+    )
+    assert sorted(row.name for row in sessions) == ["ws:doomed", "ws:live"]
+
+
+def test_a_session_being_created_is_listed_not_hidden() -> None:
+    """The real mid-create shape must stay visible (#2547's symptom class).
+
+    aplexer writes the record before the worker registers its pid, and
+    ``worker_alive`` is derived from that pid — so ``a --json list`` really
+    emits ``phase: starting`` / no ``worker_pid`` / ``worker_alive: false``
+    for tens of milliseconds on EVERY create. A predicate that reads
+    ``worker_alive: false`` as "dead" blanks the session the user is
+    watching appear, refuses to attach to it, and — worse — makes it an
+    `a forget --force` target for a retried create.
+
+    ``worker_alive: false`` is only a corpse when the worker had a pid to
+    lose. With no pid the record is INDETERMINATE, and this filter fails
+    open on indeterminate by design.
+    """
+    snapshot = _load("snapshot-mid-create.json")
+    record = _row(snapshot, MID_CREATE_ID)
+    # The capture really is the shape the fix has to survive.
+    assert record["phase"] == "starting"
+    assert record.get("worker_pid") is None
+    assert record["worker_alive"] is False
+
+    # Replayed at the age it really had: the record was observed in this
+    # shape from t+29 ms to t+46 ms of a real `a start` before the pid
+    # appeared, so the whole measured window must read alive.
+    for age_ms in (0, 29, 46, 100):
+        now_ms = record["updated_at_ms"] + age_ms
+        assert session_enum.aplexer_record_is_alive(record, now_ms) is True, age_ms
+        sessions = session_enum.sessions_from_aplexer_snapshot(snapshot, now_ms=now_ms)
+        assert [row.name for row in sessions] == ["ws:midcreate"]
+        assert sessions[0].alive is True
+        assert sessions[0].phase == "starting"
+        # ...and it is never offered up as something to reap.
+        assert (
+            session_enum.dead_sessions_from_aplexer_snapshot(snapshot, now_ms=now_ms)
+            == []
+        )
+
+
+def test_a_start_killed_in_the_pre_pid_window_does_not_stay_alive_forever() -> None:
+    """The other side of the boundary — a REAL crashed start (issue #2554 r3).
+
+    SIGKILLing an ``a start`` inside the pre-PID window leaves a record at
+    ``phase: starting`` / no ``worker_pid`` / ``worker_alive: false``
+    PERMANENTLY — byte-identical in shape to the mid-create record above,
+    and aplexer's own ``a list`` renders it ``✗ broken``. Exempting the
+    pre-PID shape unconditionally therefore re-opened both halves of this
+    issue through a different door: the tree offered it as a tappable row
+    whose attach exits 1, and ``sessions create`` handed its id back as an
+    existing session.
+
+    Age is the discriminator. It is the same record shape; it is not the
+    same age.
+    """
+    snapshot = _load("snapshot-crashed-start.json")
+    record = _row(snapshot, CRASHED_START_ID)
+    assert record["phase"] == "starting"
+    assert record.get("worker_pid") is None
+    assert record["worker_alive"] is False
+    # A crashed start never writes again, so created == updated forever.
+    assert record["updated_at_ms"] == record["created_at_ms"]
+
+    stale = record["updated_at_ms"] + session_enum.APLEXER_STARTING_GRACE_MS + 1
+    assert session_enum.aplexer_record_is_alive(record, stale) is False
+    assert session_enum.sessions_from_aplexer_snapshot(snapshot, now_ms=stale) == []
+    dead = session_enum.dead_sessions_from_aplexer_snapshot(snapshot, now_ms=stale)
+    assert [(row.name, row.phase, row.alive) for row in dead] == [
+        ("ws:crashed1", "starting", False)
+    ]
+
+
+def test_the_starting_grace_is_the_only_thing_between_the_two_captures() -> None:
+    """Both real fixtures, one predicate, one boundary.
+
+    Nothing but ``updated_at_ms`` distinguishes them — asserted here rather
+    than described, so a future change that finds some other discriminator
+    has to update this test on purpose.
+    """
+    mid = _load("snapshot-mid-create.json")[0]
+    crashed = _load("snapshot-crashed-start.json")[0]
+    differing = {
+        key
+        for key in set(mid) | set(crashed)
+        if mid.get(key) != crashed.get(key)
+    }
+    # Identity/paths/timestamps differ; the LIVENESS fields do not.
+    assert differing.isdisjoint({"phase", "worker_pid", "worker_alive"})
+
+    grace = session_enum.APLEXER_STARTING_GRACE_MS
+    for record in (mid, crashed):
+        base = record["updated_at_ms"]
+        assert session_enum.aplexer_record_is_alive(record, base) is True
+        assert session_enum.aplexer_record_is_alive(record, base + grace) is True
+        assert session_enum.aplexer_record_is_alive(record, base + grace + 1) is False
+
+
+def test_the_starting_grace_leaves_orders_of_magnitude_of_headroom() -> None:
+    """The threshold must stay far above a real spawn and above aplexer's own patience.
+
+    Measured pre-PID window on the dev box: 26-46 ms. aplexer gives up on a
+    worker after ``--startup-timeout-ms`` (default 10 s, ``a.rs``), and this
+    CLI abandons `a start` after ``_APLEXER_START_TIMEOUT_S``. A record older
+    than both cannot still be legitimately starting.
+    """
+    from pocketshell import sessions as _sessions
+
+    assert session_enum.APLEXER_STARTING_GRACE_MS >= 1_000 * 46  # >=1000x measured
+    assert session_enum.APLEXER_STARTING_GRACE_MS >= 6 * 10_000  # >=6x aplexer's own
+    assert (
+        session_enum.APLEXER_STARTING_GRACE_MS
+        >= 3 * 1000 * _sessions._APLEXER_START_TIMEOUT_S
+    )
+
+
+def test_a_pre_pid_record_without_a_usable_timestamp_fails_open() -> None:
+    """No age, no verdict: an un-aged pre-PID record stays listed."""
+    record = _load("snapshot-crashed-start.json")[0]
+    ancient = record["updated_at_ms"] + session_enum.APLEXER_STARTING_GRACE_MS + 1
+
+    missing = {k: v for k, v in record.items() if k != "updated_at_ms"}
+    assert session_enum.aplexer_record_is_alive(missing, ancient) is True
+
+    for junk in ("", None, "soon", 0, -1):
+        assert (
+            session_enum.aplexer_record_is_alive(
+                dict(record, updated_at_ms=junk), ancient
+            )
+            is True
+        ), junk
+
+
+def test_a_worker_that_had_a_pid_and_lost_it_is_still_dead() -> None:
+    """The correction must not swallow the zombie it was written to catch."""
+    snapshot = _load("snapshot-liveness-mix.json")
+    zombie = _row(snapshot, ZOMBIE_ID)
+    assert zombie["phase"] == "running"
+    assert zombie["worker_alive"] is False
+    assert isinstance(zombie["worker_pid"], int)  # it HAD a worker
+
+    assert session_enum.aplexer_record_is_alive(zombie) is False
+
+
+def test_a_pre_pid_record_in_a_terminal_phase_is_still_dead() -> None:
+    """A pid never arriving does not outrank an explicitly recorded ending.
+
+    aplexer's own launcher writes ``Phase::Failed`` with no ``worker_pid``
+    when a worker dies before completing startup
+    (``api.rs::persist_independent_cleanup_proof``), so the terminal-phase
+    test has to win over the pre-PID exemption.
+    """
+    record = _load("snapshot-mid-create.json")[0]
+    failed = dict(record, phase="failed", error="worker did not complete startup")
+    assert session_enum.aplexer_record_is_alive(failed) is False
+
+    exited = dict(record, phase="exited")
+    assert session_enum.aplexer_record_is_alive(exited) is False
+
+
+def test_a_record_with_no_liveness_keys_is_kept() -> None:
+    """Fail OPEN: an unknown/older record shape must never lose its row.
+
+    Only an explicit terminal phase or an explicit ``worker_alive: false``
+    means dead. A snapshot that carries neither key (a hand-rolled fixture, a
+    future aplexer that renames them) still lists — the failure mode of this
+    filter must be "shows a stale row", never "hides a live session".
+    """
+    minimal = [{"id": "abc123", "tag": "codex", "workspace": "/home/a/git/toy"}]
+    sessions = session_enum.sessions_from_aplexer_snapshot(minimal)
+    assert [row.name for row in sessions] == ["toy:codex"]
+    assert sessions[0].alive is True
+    assert sessions[0].phase is None
+
+
+def test_dead_projection_reports_every_dead_record_with_its_state() -> None:
+    """``sessions attach`` needs the dead rows to explain itself."""
+    snapshot = _load("snapshot-liveness-mix.json")
+    dead = session_enum.dead_sessions_from_aplexer_snapshot(
+        snapshot, now_ms=1_788_682_060_000
+    )
+    assert {row.aplexer_id: row.phase for row in dead} == {
+        KILLED_ID: "exited",
+        FAILED_ID: "failed",
+        ZOMBIE_ID: "running",
+    }
+    assert all(row.alive is False for row in dead)
+
+
+def test_schema_2_carries_liveness_on_every_row() -> None:
+    """Schema 2's "every key, always" contract covers the new pair too."""
+    sessions, errors = session_enum.enumerate_live_sessions(
+        tmuxctl_stdout=_tmuxctl_table(),
+        aplexer_payload=_load("snapshot-liveness-mix.json"),
+        now_ms=1_788_682_060_000,
+    )
+    payload = session_enum.json_payload(sessions, errors)
+
+    for row in payload["sessions"]:
+        assert set(row) == SCHEMA2_ROW_KEYS
+        assert row["alive"] is True
+
+    tmux_row = next(row for row in payload["sessions"] if row["manager"] == "tmux")
+    # tmux has no aplexer phase vocabulary; explicit null, not an absent key.
+    assert tmux_row["phase"] is None
+
+    aplexer_row = next(
+        row for row in payload["sessions"] if row["manager"] == "aplexer"
+    )
+    assert aplexer_row["phase"] == "running"
+
+    # A dead row still serialises the pair truthfully when one is asked for.
+    dead = session_enum.dead_sessions_from_aplexer_snapshot(
+        _load("snapshot-liveness-mix.json"), now_ms=1_788_682_060_000
+    )
+    dead_payload = _by_name(dead, "ws:doomed").to_payload(schema=2)
+    assert set(dead_payload) == SCHEMA2_ROW_KEYS
+    assert (dead_payload["phase"], dead_payload["alive"]) == ("exited", False)
+
+
+def test_cli_list_json_hides_dead_aplexer_records(install_fake_a) -> None:
+    """End to end through the CLI: the tree cannot be offered a dead row."""
+    install_fake_a(snapshot=_load("snapshot.json"))
+
+    result = _invoke_list_json(tmuxctl_stdout=_tmuxctl_table())
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["errors"] == []
+    assert [row["name"] for row in payload["sessions"]] == [
+        "git-pocketshell",
+        "git-aplexer",
+    ]
+    assert all(row["manager"] == "tmux" for row in payload["sessions"])
 
 
 # ---------------------------------------------------------------------------

--- a/tools/pocketshell/tests/test_sessions_attach.py
+++ b/tools/pocketshell/tests/test_sessions_attach.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import time
 from pathlib import Path
 from typing import Any, Callable, Optional, Sequence
 from unittest.mock import patch
@@ -29,6 +30,7 @@ import pytest
 from click.testing import CliRunner
 
 from pocketshell import aplexer as _aplexer
+from pocketshell import session_enum
 from pocketshell.sessions import sessions_group
 
 FAKE_TMUXCTL = "/fake/tmuxctl"
@@ -484,3 +486,167 @@ def test_exec_seam_calls_execvp() -> None:
     execvp.assert_called_once_with(
         "tmux", ["tmux", "-S", "/tmp/sock", "attach-session"]
     )
+
+
+# ---------------------------------------------------------------------------
+# dead aplexer records (issue #2554)
+# ---------------------------------------------------------------------------
+#
+# The listing no longer offers a dead record, so attach can only reach one
+# through a stale name the caller kept. It must then SAY what happened
+# instead of handing the name to `a attach`, which answers
+# "session … has already exited" on stderr and exits 1 — the bare
+# `Session "…" ended (exit 1).` the phone showed.
+
+
+# Every entry carries a `worker_pid`, because every real dead record does:
+# aplexer only reports `worker_alive: false` for a worker that HAD a pid, and
+# a record with no pid yet is a session being created, not a corpse (#2554
+# round 3). A pid-less zombie is not a shape `a --json list` can emit.
+DEAD_STATES = [
+    ("exited", False, "has already exited", "phase: exited"),
+    ("failed", False, "failed to start", "phase: failed"),
+    ("running", False, "has no live worker", "worker_alive: false"),
+]
+
+
+@pytest.mark.parametrize("phase,worker_alive,summary,detail", DEAD_STATES)
+def test_attach_to_a_dead_record_names_the_state(
+    install_fake_a, socket_dir, phase, worker_alive, summary, detail
+) -> None:
+    install_fake_a(
+        snapshot=[
+            {
+                "id": "sess-abc12345",
+                "tag": "codex",
+                "engine": "codex",
+                "workspace": "/home/alexey/git/toyaikit",
+                "created_at_ms": 1_700_000_000_000,
+                "phase": phase,
+                "worker_pid": 4_151_890,
+                "worker_alive": worker_alive,
+            }
+        ]
+    )
+    harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
+
+    result = _invoke(harness, ["attach", "toyaikit:codex"])
+
+    assert result.exit_code == 3, result.output
+    assert summary in result.output
+    assert detail in result.output
+    assert "toyaikit:codex" in result.output
+    # The load-bearing part: `a attach` is never handed a corpse.
+    assert harness.exec_calls == []
+
+
+def test_attach_to_a_dead_record_by_id_prefix_names_the_state(
+    install_fake_a, socket_dir
+) -> None:
+    install_fake_a(
+        snapshot=[
+            {
+                "id": "abcdef0123456789",
+                "tag": "codex",
+                "workspace": "/home/alexey/git/toyaikit",
+                "phase": "exited",
+                "worker_pid": 4_151_890,
+                "worker_alive": False,
+            }
+        ]
+    )
+    harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
+
+    result = _invoke(harness, ["attach", "abcdef01"])
+
+    assert result.exit_code == 3, result.output
+    assert "has already exited" in result.output
+    assert harness.exec_calls == []
+
+
+def test_attach_to_a_genuinely_unknown_name_keeps_the_plain_message(
+    install_fake_a, socket_dir
+) -> None:
+    """The dead-row explanation must not swallow the ordinary not-found path."""
+    install_fake_a(snapshot=[])
+    harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
+
+    result = _invoke(harness, ["attach", "nope-session"])
+
+    assert result.exit_code == 3, result.output
+    assert "no session named 'nope-session'" in result.output
+    assert "exited" not in result.output
+    assert harness.exec_calls == []
+
+
+def test_attach_to_a_session_being_created_is_not_refused(
+    install_fake_a, socket_dir
+) -> None:
+    """The real mid-create shape must still attach (#2547's class).
+
+    aplexer writes the record before the worker registers its pid, so
+    `a --json list` reports `phase: starting` with no `worker_pid` and
+    therefore `worker_alive: false` for tens of milliseconds on EVERY
+    create. Reading that as a corpse turns a session the user is watching
+    appear into an exit-3 "it has no live worker".
+    """
+    script = install_fake_a(
+        snapshot=[
+            {
+                "id": "sess-abc12345",
+                "tag": "codex",
+                "engine": "codex",
+                "workspace": "/home/alexey/git/toyaikit",
+                "created_at_ms": 1_700_000_000_000,
+                # Verbatim shape of tests/fixtures/aplexer/snapshot-mid-create.json:
+                # phase starting, `worker_pid` absent, worker_alive false —
+                # and written just now, because a create in progress is by
+                # definition happening now.
+                "phase": "starting",
+                "worker_alive": False,
+                "updated_at_ms": int(time.time() * 1000),
+            }
+        ]
+    )
+    harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
+
+    result = _invoke(harness, ["attach", "toyaikit:codex"])
+
+    assert result.exit_code == 0, result.output
+    assert harness.exec_calls == [[str(script), "attach", "sess-abc12345"]]
+
+
+def test_attach_to_a_crashed_start_names_the_state(install_fake_a, socket_dir) -> None:
+    """A pre-PID record that never progressed is a corpse, not a create.
+
+    An `a start` SIGKILLed inside the pre-PID window leaves this shape
+    forever (captured: tests/fixtures/aplexer/snapshot-crashed-start.json).
+    Handing it to `a attach` is the reported symptom verbatim — aplexer
+    answers "worker is not running (state: broken)" and exits 1.
+    """
+    install_fake_a(
+        snapshot=[
+            {
+                "id": "sess-abc12345",
+                "tag": "codex",
+                "engine": "codex",
+                "workspace": "/home/alexey/git/toyaikit",
+                "created_at_ms": 1_700_000_000_000,
+                "phase": "starting",
+                "worker_alive": False,
+                # Same shape as the mid-create record above; only older than
+                # any create could still be running.
+                "updated_at_ms": int(time.time() * 1000)
+                - session_enum.APLEXER_STARTING_GRACE_MS
+                - 1,
+            }
+        ]
+    )
+    harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
+
+    result = _invoke(harness, ["attach", "toyaikit:codex"])
+
+    assert result.exit_code == 3, result.output
+    assert "has no live worker" in result.output
+    assert "phase: starting" in result.output
+    assert harness.exec_calls == []

--- a/tools/pocketshell/tests/test_sessions_create_routing.py
+++ b/tools/pocketshell/tests/test_sessions_create_routing.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
@@ -31,6 +32,7 @@ import pytest
 from click.testing import CliRunner
 
 from pocketshell import config as psconfig
+from pocketshell import session_enum
 from pocketshell import sessions
 from pocketshell.sessions import _route_backend, sessions_group
 
@@ -134,6 +136,65 @@ class AplexerStub:
         return 0, json.dumps(self.record or {}), ""
 
 
+class ForgetStub:
+    """Stub for `sessions._run_session_kill` — here, the reap's `a forget`.
+
+    Issue #2554: a dead aplexer record holds its workspace+tag hostage, so
+    `_create_on_aplexer` reaps it before `a start`. This stubs the process
+    call, NOT `_reap_aplexer_record`, so the real retry/refusal handling is
+    the code under test.
+    """
+
+    def __init__(
+        self,
+        *,
+        refusals: int = 0,
+        always_refuses: bool = False,
+        workload_may_survive: bool = False,
+    ):
+        self.refusals = refusals
+        self.always_refuses = always_refuses
+        # `a --json forget` reports whether the record's containment was
+        # proven empty; false means processes may have outlived it.
+        self.workload_may_survive = workload_may_survive
+        self.calls: list[list[str]] = []
+
+    @property
+    def forgotten_ids(self) -> list[str]:
+        return [argv[-1] for argv in self.calls if "forget" in argv]
+
+    def __call__(self, argv: Sequence[str]) -> Any:
+        args = [str(item) for item in argv]
+        self.calls.append(args)
+        attempts = sum(1 for call in self.calls if call[-1] == args[-1])
+        if self.always_refuses or attempts <= self.refusals:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=1,
+                stdout="",
+                # aplexer/src/api.rs::forget_session, verbatim.
+                stderr=(
+                    f"a: session {args[-1]} still has a live worker; "
+                    "refusing to forget it\n"
+                ),
+            )
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "id": args[-1],
+                    "forgotten": True,
+                    "signalled": False,
+                    "containment_proven_empty": not self.workload_may_survive,
+                    "workload_may_survive": self.workload_may_survive,
+                }
+            )
+            + "\n",
+            stderr="",
+        )
+
+
 def use_tmux_backend(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -150,6 +211,7 @@ def use_aplexer_backend(
     *,
     start: AplexerStub,
     snapshot: Any = None,
+    forget: Optional[ForgetStub] = None,
 ) -> None:
     monkeypatch.setattr(
         sessions._aplexer,
@@ -161,6 +223,10 @@ def use_aplexer_backend(
     monkeypatch.setattr(sessions._aplexer, "which_a", lambda env=None: "/fake/a")
     monkeypatch.setattr(sessions, "_aplexer_snapshot", lambda: snapshot)
     monkeypatch.setattr(sessions, "_run_aplexer", start)
+    # The reap seam is always stubbed so no test can reach a real `a`, and
+    # its retry pause is stubbed so the refusal window costs no wall-clock.
+    monkeypatch.setattr(sessions, "_run_session_kill", forget or ForgetStub())
+    monkeypatch.setattr(sessions, "_reap_wait", lambda: None)
 
 
 def envelope(result) -> dict:
@@ -754,6 +820,367 @@ def test_aplexer_arm_other_workspace_same_tag_still_creates(
     assert result.exit_code == 0, result.output
     assert envelope(result)["created"] is True
     assert len(start.calls) == 1
+
+
+# ----- a dead record holds its workspace+tag hostage (issue #2554) ----
+#
+# Reported from the phone alongside the dead-row symptom: "can't create an
+# agent session". aplexer keys a session by workspace+tag, and a DEAD record
+# keeps holding that pair — verified against real aplexer 0.1.3:
+#
+#   $ a --json start --workspace /tmp/ws --tag zt
+#   a: workspace+tag already belongs to session 57e5a6ba-...; rename it or
+#      choose a different tag
+#   exit=1
+#
+# `_aplexer_existing_record` used to skip only `exited`/`failed`, so the
+# `phase: running` / `worker_alive: false` zombie was reported as an
+# already-existing session and the app attached to a corpse. Skipping it
+# alone would only swap pocketshell's wrong answer for aplexer's refusal
+# above, so the blocking record is REAPED before `a start`.
+
+
+def _zombie(ident: str = "zombie-0001") -> dict:
+    """A record whose worker died without recording an exit.
+
+    ``worker_pid`` is set on purpose: aplexer only reports ``worker_alive:
+    false`` for a worker that HAD a pid to lose. A record with no pid in a
+    non-terminal phase is a session being CREATED, not a corpse — see
+    ``test_aplexer_arm_session_being_created_is_existing_not_reaped``.
+    """
+    return dict(
+        _record(ident), phase="running", worker_pid=4_151_890, worker_alive=False
+    )
+
+
+def _live(ident: str = "live-0001") -> dict:
+    return dict(
+        _record(ident), phase="running", worker_pid=4_151_890, worker_alive=True
+    )
+
+
+def test_aplexer_arm_zombie_held_pair_is_reaped_and_recreated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reported failure: a zombie must not block (or impersonate) a create."""
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub()
+    use_aplexer_backend(
+        monkeypatch, start=start, snapshot=[_zombie()], forget=forget
+    )
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = envelope(result)
+    # A NEW session, not the corpse's id handed back as "already exists".
+    assert payload["created"] is True
+    assert payload["id"] == "fresh-0002"
+    # ...because the record holding the pair was reaped first.
+    assert forget.calls == [
+        # `--json` so aplexer's containment verdict comes back as data.
+        ["/fake/a", "--json", "forget", "--force", "zombie-0001"]
+    ]
+    assert len(start.calls) == 1
+    # Reap BEFORE start, or `a start` would still collide.
+    assert start.calls[0][0] == "/fake/a"
+
+
+def test_aplexer_arm_exited_held_pair_is_reaped_and_recreated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The record `a kill` leaves behind blocks the same pair the same way."""
+    exited = dict(
+        _record("exited-0001"), phase="exited", worker_pid=4_151_890, worker_alive=False
+    )
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub()
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[exited], forget=forget)
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = envelope(result)
+    assert payload["created"] is True
+    assert payload["id"] == "fresh-0002"
+    assert forget.forgotten_ids == ["exited-0001"]
+
+
+def test_aplexer_arm_live_record_is_never_reaped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The idempotency contract, unchanged: a live pair is reused, not destroyed.
+
+    Green both before and after the fix. A reap here would kill the user's
+    running session and hand back a different one.
+    """
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub()
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[_live()], forget=forget)
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = envelope(result)
+    assert payload["created"] is False
+    assert payload["id"] == "live-0001"
+    assert start.calls == []
+    assert forget.calls == []
+
+
+def test_aplexer_arm_session_being_created_is_existing_not_reaped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retried create must not force-forget the in-flight session (#2547).
+
+    aplexer persists the record before the worker registers its pid, so a
+    real `a --json list` reports `phase: starting` / no `worker_pid` /
+    `worker_alive: false` for tens of milliseconds on every create. Reading
+    that as dead makes a double-tapped or retried create reap the session
+    the first tap is still starting — and `a forget` fences exactly that
+    case by taking the worker lock, so the starting worker is aborted.
+    """
+    mid_create = {
+        "id": "starting-0001",
+        "workspace": "/home/me/proj",
+        "tag": "work",
+        "engine": "shell",
+        "phase": "starting",
+        # `worker_pid` ABSENT, exactly as the real capture has it, and
+        # written just now — a create in progress is happening now.
+        "worker_alive": False,
+        "updated_at_ms": int(time.time() * 1000),
+    }
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub()
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[mid_create], forget=forget)
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = envelope(result)
+    assert payload["created"] is False
+    assert payload["id"] == "starting-0001"
+    assert start.calls == []
+    # The load-bearing one: no `a forget --force` against a starting worker.
+    assert forget.calls == []
+
+
+def test_aplexer_arm_crashed_start_is_reaped_not_reused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-PID record that never progressed holds the pair like any corpse.
+
+    Same shape as the in-flight record above, but older than any create
+    could still be running (an `a start` SIGKILLed inside the pre-PID
+    window leaves it forever). Returning its id as an existing session is
+    "can't create an agent session" verbatim — the app then attaches to a
+    corpse.
+    """
+    crashed = {
+        "id": "crashed-0001",
+        "workspace": "/home/me/proj",
+        "tag": "work",
+        "engine": "shell",
+        "phase": "starting",
+        "worker_alive": False,
+        "updated_at_ms": int(time.time() * 1000)
+        - session_enum.APLEXER_STARTING_GRACE_MS
+        - 1,
+    }
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub()
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[crashed], forget=forget)
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = envelope(result)
+    assert payload["created"] is True
+    assert payload["id"] == "fresh-0002"
+    assert forget.forgotten_ids == ["crashed-0001"]
+
+
+def test_aplexer_arm_reap_only_touches_the_pair_being_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blast radius: another workspace's corpse is none of this create's business."""
+    elsewhere = dict(_zombie("elsewhere-0001"), workspace="/home/me/elsewhere")
+    other_tag = dict(_zombie("othertag-0001"), tag="notwork")
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub()
+    use_aplexer_backend(
+        monkeypatch,
+        start=start,
+        snapshot=[elsewhere, other_tag, _zombie()],
+        forget=forget,
+    )
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert envelope(result)["created"] is True
+    assert forget.forgotten_ids == ["zombie-0001"]
+
+
+def test_aplexer_arm_reap_survives_the_winding_down_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """aplexer refuses to forget a record whose worker is still winding down."""
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub(refusals=2)
+    use_aplexer_backend(
+        monkeypatch, start=start, snapshot=[_zombie()], forget=forget
+    )
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert envelope(result)["created"] is True
+    assert len(forget.calls) == 3
+    assert len(start.calls) == 1
+
+
+def test_aplexer_arm_refuses_to_reap_a_record_whose_workload_is_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`a forget --force` does not claim the workload stopped — so check it.
+
+    aplexer's own `a prune` retains any record whose `workload_pid` is still
+    alive. Forgetting one destroys the only handle onto a running process:
+    the create looks clean while an unreachable workload keeps running.
+    """
+    holder = dict(
+        _zombie("workload-0001"),
+        # This process, so the liveness probe is answering about something
+        # genuinely alive rather than a pid that happens to be free.
+        workload_pid=os.getpid(),
+    )
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub()
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[holder], forget=forget)
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code != 0
+    message = envelope(result)["error"]
+    assert "workload-0001" in message
+    assert str(os.getpid()) in message
+    assert "still running" in message
+    # Neither destroyed nor blindly retried.
+    assert forget.calls == []
+    assert start.calls == []
+
+
+def test_aplexer_arm_warns_when_the_reaped_record_may_have_survivors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """aplexer's `workload_may_survive` must reach the user, not be swallowed.
+
+    The dangerous shape is a setsid'd grandchild: the recorded
+    `workload_pid` is already dead, so the pid gate above says nothing, but
+    aplexer reports `containment_proven_empty: false`. Reproduced against
+    real `a 0.1.3` — a detached `sleep` outlived its record.
+    """
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub(workload_may_survive=True)
+    use_aplexer_backend(
+        monkeypatch, start=start, snapshot=[_zombie()], forget=forget
+    )
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    # The create still succeeds — the pair WAS reclaimed.
+    assert result.exit_code == 0, result.output
+    assert envelope(result)["created"] is True
+    # ...but the user is told, on stderr, that something may have outlived it.
+    warning = result.stderr
+    assert "zombie-0001" in warning
+    assert "may still be running" in warning
+
+
+def test_aplexer_arm_quiet_when_containment_was_proven_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No warning for the ordinary case, or the real one stops being read."""
+    start = AplexerStub(record=_record("fresh-0002"))
+    forget = ForgetStub()  # workload_may_survive defaults to False
+    use_aplexer_backend(
+        monkeypatch, start=start, snapshot=[_zombie()], forget=forget
+    )
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert envelope(result)["created"] is True
+    assert "may still be running" not in result.stderr
+
+
+def test_aplexer_arm_failed_reap_is_explained_not_disguised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reap that never wins must say WHY the create then failed.
+
+    Relaying only aplexer's "workspace+tag already belongs to session X"
+    tells the user to rename a session they cannot see, since the listing no
+    longer shows the dead record. The error has to name the corpse and the
+    command that clears it.
+    """
+    start = AplexerStub(
+        returncode=1,
+        stderr=(
+            "a: workspace+tag already belongs to session zombie-0001; "
+            "rename it or choose a different tag"
+        ),
+    )
+    forget = ForgetStub(always_refuses=True)
+    use_aplexer_backend(
+        monkeypatch, start=start, snapshot=[_zombie()], forget=forget
+    )
+
+    result = CliRunner().invoke(
+        sessions_group,
+        ["create", "work", "--cwd", "/home/me/proj", "--backend", "aplexer", "--json"],
+    )
+
+    assert result.exit_code != 0
+    message = envelope(result)["error"]
+    assert "zombie-0001" in message
+    assert "could not be reaped" in message
+    assert "a forget --force zombie-0001" in message
+    # aplexer's own words are still there, not swallowed.
+    assert "already belongs" in message
+    assert len(forget.calls) > 1
 
 
 def test_aplexer_arm_start_failure_json_error_envelope(

--- a/tools/pocketshell/tests/test_sessions_kill.py
+++ b/tools/pocketshell/tests/test_sessions_kill.py
@@ -48,11 +48,24 @@ class Harness:
         *,
         kill_fails: bool = False,
         a_kill_fails: bool = False,
+        forget_refusals: int = 0,
+        forget_always_refuses: bool = False,
+        workload_may_survive: bool = False,
     ):
         self.table = table
         self.has_session = has_session
         self.kill_fails = kill_fails
         self.a_kill_fails = a_kill_fails
+        # Issue #2554: aplexer refuses to forget a record whose worker is
+        # still winding down. `forget_refusals` replays that window for N
+        # attempts before the record becomes forgettable, exactly like the
+        # real `a forget --force` does (message copied verbatim from
+        # aplexer/src/api.rs::forget_session).
+        self.forget_refusals = forget_refusals
+        self.forget_always_refuses = forget_always_refuses
+        # `a --json forget` says whether containment was proven empty; false
+        # means processes may have outlived the record (issue #2554 round 3).
+        self.workload_may_survive = workload_may_survive
         self.events: list[tuple[str, list[str]]] = []
 
     @property
@@ -62,6 +75,10 @@ class Harness:
     @property
     def a_kill_calls(self) -> list[list[str]]:
         return [argv for kind, argv in self.events if kind == "a-kill"]
+
+    @property
+    def a_forget_calls(self) -> list[list[str]]:
+        return [argv for kind, argv in self.events if kind == "a-forget"]
 
     def run(self, argv: Sequence[str], **_kwargs: Any) -> Any:
         args = [str(item) for item in argv]
@@ -93,6 +110,30 @@ class Harness:
             if self.a_kill_fails:
                 return _completed(returncode=1, stderr="no such session\n")
             return _completed()
+        if Path(args[0]).name in {"a", "fake-a"} and "forget" in args:
+            self.events.append(("a-forget", args))
+            attempt = len(self.a_forget_calls)
+            if self.forget_always_refuses or attempt <= self.forget_refusals:
+                session_id = args[-1]
+                return _completed(
+                    returncode=1,
+                    stderr=(
+                        f"a: session {session_id} still has a live worker; "
+                        "refusing to forget it\n"
+                    ),
+                )
+            return _completed(
+                stdout=json.dumps(
+                    {
+                        "id": args[-1],
+                        "forgotten": True,
+                        "signalled": False,
+                        "containment_proven_empty": not self.workload_may_survive,
+                        "workload_may_survive": self.workload_may_survive,
+                    }
+                )
+                + "\n"
+            )
         raise AssertionError(f"unexpected subprocess call: {args}")
 
 
@@ -118,6 +159,11 @@ def _invoke(
     with patch(
         "pocketshell.sessions._resolve_tmuxctl_binary", return_value=FAKE_TMUXCTL
     ), patch("pocketshell.sessions.subprocess.run", harness.run), patch(
+        # The reap's inter-attempt pause; stubbed so the retry window is
+        # exercised at full speed instead of wall-clock.
+        "pocketshell.sessions._reap_wait",
+        lambda: None,
+    ), patch(
         "pocketshell.sessions.shutil.which",
         which if which is not None else (lambda name, *a, **k: f"/usr/bin/{name}"),
     ):
@@ -358,3 +404,345 @@ def test_kill_ambiguous_id_prefix_exits_4(install_fake_a, socket_dir) -> None:
     assert "ambiguous session name 'abcdef01'" in result.output
     assert harness.a_kill_calls == []
     assert harness.kill_calls == []
+
+
+# ---------------------------------------------------------------------------
+# the reap: Stop must remove the row, not leave a dead one (issue #2554)
+# ---------------------------------------------------------------------------
+#
+# `a kill` only signals the workload; aplexer keeps the record at
+# `phase: exited` forever, and `session_enum` used to list it as an ordinary
+# attachable row. So a successful Stop left a tappable corpse in the tree
+# that answered `a: session … has already exited` with exit 1.
+#
+# The reap is `a forget --force <id>`, not `a prune`, and it RETRIES:
+# immediately after `a kill` the worker is still winding down, and aplexer
+# refuses to forget a record with a live worker (verified on the dev box
+# against aplexer 0.1.3).
+
+
+def _aplexer_snapshot(session_id: str = "sess-abc12345") -> list[dict[str, Any]]:
+    return [
+        {
+            "id": session_id,
+            "tag": "codex",
+            "engine": "codex",
+            "workspace": "/home/alexey/git/toyaikit",
+            "created_at_ms": 1_700_000_000_000,
+            "phase": "running",
+            "worker_alive": True,
+        }
+    ]
+
+
+def test_kill_aplexer_reaps_the_record_with_forget(install_fake_a, socket_dir) -> None:
+    script = install_fake_a(snapshot=_aplexer_snapshot())
+    harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
+
+    result = _invoke(harness, ["kill", "toyaikit:codex"])
+
+    assert result.exit_code == 0, result.output
+    assert harness.a_kill_calls == [[str(script), "kill", "sess-abc12345"]]
+    # The reap is targeted at the id just killed, and unconditional —
+    # `a prune` (0.1.3) cannot reap a record whose worker died without
+    # recording an exit, and skips one whose worker is still winding down.
+    assert harness.a_forget_calls == [
+        # `--json` so the containment verdict comes back as data, not a
+        # stderr line that has to be string-matched (#2554 round 3).
+        [str(script), "--json", "forget", "--force", "sess-abc12345"]
+    ]
+    # ...and it happens AFTER the kill, never instead of it.
+    kinds = [kind for kind, _argv in harness.events]
+    assert kinds.index("a-kill") < kinds.index("a-forget")
+    assert all("prune" not in argv for _kind, argv in harness.events)
+
+
+def test_kill_reap_retries_while_the_worker_is_still_winding_down(
+    install_fake_a, socket_dir
+) -> None:
+    """The window a fire-and-forget reap silently loses to.
+
+    Right after `a kill` the record is terminal but `worker_alive` is still
+    true, so aplexer answers "still has a live worker; refusing to forget
+    it". A single attempt would leave the corpse behind and report success.
+    """
+    script = install_fake_a(snapshot=_aplexer_snapshot())
+    harness = Harness(
+        _table("git-tmuxcli"), lambda sock, name: False, forget_refusals=3
+    )
+
+    result = _invoke(harness, ["kill", "--json", "toyaikit:codex"])
+
+    assert result.exit_code == 0, result.output
+    assert len(harness.a_forget_calls) == 4
+    assert all(
+        argv == [str(script), "--json", "forget", "--force", "sess-abc12345"]
+        for argv in harness.a_forget_calls
+    )
+    assert json.loads(result.output)["reaped"] is True
+
+
+def test_kill_json_reports_the_reap(install_fake_a, socket_dir) -> None:
+    install_fake_a(snapshot=_aplexer_snapshot())
+    harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
+
+    result = _invoke(harness, ["kill", "--json", "toyaikit:codex"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["manager"] == "aplexer"
+    assert payload["killed"] is True
+    assert payload["reaped"] is True
+
+
+def test_kill_still_succeeds_when_the_reap_never_wins(
+    install_fake_a, socket_dir
+) -> None:
+    """A stuck reap must not turn a successful kill into a failure.
+
+    The workload IS dead; all that survives is a record. Reporting the kill
+    as failed would make the app retry a kill that already worked.
+    """
+    install_fake_a(snapshot=_aplexer_snapshot())
+    harness = Harness(
+        _table("git-tmuxcli"), lambda sock, name: False, forget_always_refuses=True
+    )
+
+    result = _invoke(harness, ["kill", "--json", "toyaikit:codex"])
+
+    assert result.exit_code == 0, result.output
+    # The warning goes to stderr; the envelope on stdout stays parseable.
+    payload = json.loads(result.stdout)
+    assert payload["killed"] is True
+    assert payload["reaped"] is False
+    assert len(harness.a_forget_calls) > 1
+
+
+def test_a_stuck_reap_is_said_out_loud_on_the_human_path(
+    install_fake_a, socket_dir
+) -> None:
+    """A row that survives a Stop must be explained, not silent."""
+    install_fake_a(snapshot=_aplexer_snapshot())
+    harness = Harness(
+        _table("git-tmuxcli"), lambda sock, name: False, forget_always_refuses=True
+    )
+
+    result = _invoke(harness, ["kill", "toyaikit:codex"])
+
+    assert result.exit_code == 0, result.output
+    assert "could not be reaped" in result.output
+    assert "a forget --force sess-abc12345" in result.output
+
+
+def test_kill_reap_treats_an_already_gone_record_as_reaped(
+    install_fake_a, socket_dir
+) -> None:
+    """A newer aplexer may reap inside `a kill`; "no matching session" is done."""
+    install_fake_a(snapshot=_aplexer_snapshot())
+
+    class _AlreadyGone(Harness):
+        def run(self, argv: Sequence[str], **kwargs: Any) -> Any:
+            args = [str(item) for item in argv]
+            if Path(args[0]).name in {"a", "fake-a"} and "forget" in args:
+                self.events.append(("a-forget", args))
+                return _completed(returncode=1, stderr="a: no matching session\n")
+            return super().run(argv, **kwargs)
+
+    harness = _AlreadyGone(_table("git-tmuxcli"), lambda sock, name: False)
+
+    result = _invoke(harness, ["kill", "--json", "toyaikit:codex"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["reaped"] is True
+    assert len(harness.a_forget_calls) == 1  # no pointless retry loop
+
+
+def test_tmux_kill_never_runs_a_forget(socket_dir) -> None:
+    derived = socket_dir / "tmuxctl-api"
+    derived.touch()
+    harness = Harness(
+        _table("api"), lambda sock, name: sock == str(derived) and name == "api"
+    )
+
+    result = _invoke(harness, ["kill", "--json", "api"])
+
+    assert result.exit_code == 0, result.output
+    assert harness.a_forget_calls == []
+    # tmux has no record to reap: killing the session IS the removal.
+    assert json.loads(result.output)["reaped"] is True
+
+
+def test_failed_a_kill_does_not_reap(install_fake_a, socket_dir) -> None:
+    """No record is discarded for a session that may still be running."""
+    install_fake_a(snapshot=_aplexer_snapshot())
+    harness = Harness(
+        _table("git-tmuxcli"), lambda sock, name: False, a_kill_fails=True
+    )
+
+    result = _invoke(harness, ["kill", "toyaikit:codex"])
+
+    assert result.exit_code != 0
+    assert harness.a_forget_calls == []
+
+
+# ---------------------------------------------------------------------------
+# end to end: kill, then list again — against a real, stateful `a` stub
+# ---------------------------------------------------------------------------
+
+
+STATEFUL_A = '''\
+#!/usr/bin/env python3
+"""A stub `a` that keeps real state, so `kill` is observable in a later `list`.
+
+Mirrors aplexer 0.1.3 exactly where it matters:
+  kill    -> phase becomes "exited" but worker_alive stays true (winding down)
+  forget  -> refused while worker_alive is true; the SECOND call finds the
+             worker gone and removes the record
+  prune   -> only removes records aplexer considers reclaimable; a record
+             whose worker is still winding down is retained (a no-op here)
+"""
+import json, sys
+from pathlib import Path
+
+STATE = Path(__file__).with_name("a-state.json")
+args = [a for a in sys.argv[1:] if a != "--json"]
+records = json.loads(STATE.read_text())
+cmd = args[0] if args else ""
+
+if cmd in ("snapshot", "list"):
+    print(json.dumps(records))
+elif cmd == "kill":
+    for record in records:
+        if record["id"] == args[1]:
+            record["phase"] = "exited"
+            record["worker_alive"] = True
+    STATE.write_text(json.dumps(records))
+elif cmd == "forget":
+    ident = args[-1]
+    match = [r for r in records if r["id"] == ident]
+    if not match:
+        sys.stderr.write("a: no matching session\\n")
+        sys.exit(1)
+    if match[0]["worker_alive"]:
+        match[0]["worker_alive"] = False  # the worker finishes winding down
+        STATE.write_text(json.dumps(records))
+        sys.stderr.write(
+            "a: session %s still has a live worker; refusing to forget it\\n" % ident
+        )
+        sys.exit(1)
+    STATE.write_text(json.dumps([r for r in records if r["id"] != ident]))
+    print(json.dumps({"id": ident, "forgotten": True}))
+elif cmd == "prune":
+    print(json.dumps({"removed": [], "retained_count": len(records)}))
+else:
+    sys.exit(2)
+'''
+
+
+@pytest.fixture
+def stateful_a(tmp_path, monkeypatch):
+    """Install the stateful `a` stub above and seed its record list."""
+
+    def _install(records: list[dict[str, Any]]):
+        script = tmp_path / "fake-a"
+        script.write_text(STATEFUL_A, encoding="utf-8")
+        script.chmod(0o755)
+        (tmp_path / "a-state.json").write_text(json.dumps(records), encoding="utf-8")
+        monkeypatch.setenv("APLEXER_BIN", str(script))
+        monkeypatch.setenv("POCKETSHELL_APLEXER", "1")
+        return script
+
+    return _install
+
+
+@pytest.fixture
+def empty_tmuxctl(tmp_path):
+    """A real `tmuxctl` stub printing an empty listing (no tmux rows)."""
+    script = tmp_path / "fake-tmuxctl"
+    script.write_text(
+        "#!/bin/sh\necho 'IDX  SESSION               CREATED'\n", encoding="utf-8"
+    )
+    script.chmod(0o755)
+    return str(script)
+
+
+def test_kill_then_list_no_longer_shows_the_row(stateful_a, empty_tmuxctl) -> None:
+    """The reported symptom, end to end: Stop removes the row.
+
+    No `subprocess.run` stub here — `sessions kill` really executes the
+    stateful `a`, and the second `sessions list --json` really re-enumerates
+    from the state that kill left behind.
+    """
+    stateful_a(
+        [
+            {
+                "id": "sess-abc12345",
+                "tag": "codex",
+                "engine": "codex",
+                "workspace": "/home/alexey/git/toyaikit",
+                "created_at_ms": 1_700_000_000_000,
+                "phase": "running",
+                "worker_alive": True,
+            }
+        ]
+    )
+    runner = CliRunner()
+    with patch(
+        "pocketshell.sessions._resolve_tmuxctl_binary", return_value=empty_tmuxctl
+    ), patch("pocketshell.sessions._reap_wait", lambda: None):
+        before = runner.invoke(sessions_group, ["list", "--json"])
+        assert before.exit_code == 0, before.output
+        assert [row["name"] for row in json.loads(before.output)["sessions"]] == [
+            "toyaikit:codex"
+        ]
+
+        killed = runner.invoke(sessions_group, ["kill", "--json", "toyaikit:codex"])
+        assert killed.exit_code == 0, killed.output
+
+        after = runner.invoke(sessions_group, ["list", "--json"])
+
+    # The load-bearing assertion, first: the row the user just stopped is
+    # gone from the very next listing the tree would render.
+    assert after.exit_code == 0, after.output
+    payload = json.loads(after.output)
+    assert payload["sessions"] == []
+    # An empty list because the record is GONE, not because a probe broke.
+    assert payload["errors"] == []
+    assert json.loads(killed.output)["reaped"] is True
+
+
+def test_kill_warns_when_the_reap_could_not_prove_containment(
+    install_fake_a, socket_dir
+) -> None:
+    """`a forget` never claims the workload stopped; say so when it didn't.
+
+    After a normal `a kill` aplexer reports `containment_proven_empty: true`
+    (measured against real `a 0.1.3`), so this warning stays silent on the
+    ordinary Stop and only fires when something really may have outlived
+    the record.
+    """
+    install_fake_a(snapshot=_aplexer_snapshot())
+    harness = Harness(
+        _table("git-tmuxcli"),
+        lambda sock, name: False,
+        workload_may_survive=True,
+    )
+
+    result = _invoke(harness, ["kill", "--json", "toyaikit:codex"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["reaped"] is True
+    assert "may still be running" in result.stderr
+    assert "sess-abc12345" in result.stderr
+
+
+def test_kill_is_quiet_when_containment_was_proven_empty(
+    install_fake_a, socket_dir
+) -> None:
+    install_fake_a(snapshot=_aplexer_snapshot())
+    harness = Harness(_table("git-tmuxcli"), lambda sock, name: False)
+
+    result = _invoke(harness, ["kill", "--json", "toyaikit:codex"])
+
+    assert result.exit_code == 0, result.output
+    assert "may still be running" not in result.stderr


### PR DESCRIPTION
Closes PocketShell-io/pocketshell#2554.

Reported from the phone: *"can't create an agent session ... sessions that don't exist anymore stay in the tree."* Both symptoms, one root cause — a dead aplexer record was shown as an ordinary attachable row **and** held its `workspace+tag` hostage so `a start` refused to create a new session in that folder.

## What changed

- `sessions_from_aplexer_snapshot` emits only live records; schema 2 gains `phase` + `alive` on every row.
- `sessions kill` reaps the record after `a kill` (retried through the winding-down window, where a single attempt always loses).
- `sessions create` reaps a dead record holding the target pair before `a start`, and refuses — naming the pid — when its workload is still alive.
- `sessions attach` on a dead row names the state and exits 3.

## Four review rounds, four predicate defects

Worth recording, because the liveness rule turned out to be genuinely subtle and every defect was found by a human reading aplexer's Rust against a hand-captured record — never by a test:

1. Dead records shown as attachable (the original report).
2. A record 26–46 ms into `a start` classified dead — a resurrection of PocketShell-io/pocketshell#2547, which had landed one commit earlier.
3. An `a start` killed inside the pre-PID window leaves that *same shape permanently*, so the round-3 fix called a broken record alive forever.
4. The create-path reap could orphan a still-running workload.

The predicate now fails **open**: dead only on a terminal phase, or `worker_pid` set with `worker_alive` false, with that exemption bounded by a 60 s grace.

The bound is structural rather than a guess: `worker.rs:1706` sets `worker_pid` **before** `spawn_workload` at :1736, so the pre-PID window covers fork/exec only — a cold venv, slow engine binary or loaded box all happen after the pid exists and cannot widen it. 60 s is >1000× the measured 26–46 ms window, 6× aplexer's 10 s `--startup-timeout-ms`, 3× this CLI's 20 s `a start` timeout, and those ratios are an executable assertion so lowering the constant goes red.

## Evidence

Both boundary shapes ship as records **captured from a real `a 0.1.3`** (the pinned one in the package venv), differing only in age — verified field-by-field against raw JSON by the reviewer.

- Reviewer-run red→green: 4 red → 149 green, md5-verified restore, no `git checkout`.
- Full suite 1314 passed / 4 skipped; `:shared:core-hostapi:test --rerun-tasks` 105/0/0.
- Reviewer's own PocketShell-io/pocketshell#2547 guard: 12 real creates, 292 live mid-create samples, 97 pre-PID, **zero hidden**.
- Boundary walked in real time: listed at 1/20/45/58 s, hidden at 62/70 s.
- Emulator tree package: executed=9, failures=0.
- Hygiene, CI-lock, test-validity, `git diff --check` all clean.

## Known gap

AC5 (emulator tree-after-Stop) is **not** proven: `J14StopSessionJourney` drives a fixture JSON and the test image predates the change, so that lane structurally cannot exercise this. Tracked as PocketShell-io/pocketshell#2556. Not blocking — D34 real-transport proof exists and the reviewer reproduced it — and round 4 lands both boundary shapes in the always-running Python gate, which is the first automated coverage this failure mode has ever had.

## Follow-ups filed

PocketShell-io/pocketshell#2556 (lane can't validate host-derived liveness), PocketShell-io/pocketshell-cli#7 (consume aplexer's `state` and delete this predicate — blocked on aplexer#9, since `observed_state` currently calls a healthy mid-create session `broken`).