### PR TITLE
fix: make a mutation's tree refresh authoritative, and fail loud on a worker-less `a`

### DIFF
--- a/app2/src/main/java/com/pocketshell/next/tree/SessionTreeViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/SessionTreeViewModel.kt
@@ -163,6 +163,13 @@ data class CreateSessionState(
  * collapse: a refresh arriving while one is in flight is dropped rather than
  * queued, so a user who pulls during the `ON_START` load gets one listing, not
  * two, and cannot stack execs on the connection.
+ *
+ * The ONE exception is a refresh that follows a mutation this screen just made
+ * — a create, a stop, and any future one. That listing carries information the
+ * in-flight read cannot have (it was snapshotted on the host before the
+ * mutation landed), so it is queued instead of dropped; see
+ * `refreshAfterMutation` for the mechanism and issue #2553 for the bug that
+ * dropping it caused.
  */
 @HiltViewModel
 class SessionTreeViewModel @Inject constructor(
@@ -185,18 +192,83 @@ class SessionTreeViewModel @Inject constructor(
     private var stopInFlight: Job? = null
 
     /**
+     * Set when a mutation finished while [inFlight] was still reading, and
+     * cleared by the read loop that honours it. See [refreshAfterMutation].
+     *
+     * A plain `var` is enough because every writer and reader runs on the
+     * ViewModel's confined dispatcher (`Dispatchers.Main.immediate` in
+     * production, one test dispatcher under `runTest`): a mutation coroutine
+     * can only observe/set it at a point where the read loop is suspended, so
+     * there is no window between the loop's last check and the job completing
+     * in which a set could be lost.
+     */
+    private var mutationRefreshPending = false
+
+    /**
      * Re-reads the host's session list. Safe to call from `ON_START` and from
      * the pull gesture; a call made while a read is in flight is ignored.
      */
     fun refresh() {
         if (inFlight?.isActive == true) return
+        markReading()
+        inFlight = viewModelScope.launch { readUntilSettled() }
+    }
+
+    /**
+     * A refresh that MUST reflect a mutation this ViewModel just made — the
+     * one case where [refresh]'s de-duplication is wrong (issue #2553).
+     *
+     * The ordinary collapse is correct: two `ON_START`/pull refreshes want one
+     * listing, not two. But a listing that was already in flight when a kill
+     * (or create, or rename) landed took its snapshot on the host BEFORE the
+     * mutation, so letting it be the last word repaints PRE-mutation truth —
+     * a stopped session stays on screen and stays tappable, and a successful
+     * destructive action looks like it failed.
+     *
+     * So a mutation's refresh is never dropped: if nothing is reading it
+     * starts one, and if a read is in flight it raises [mutationRefreshPending],
+     * which [readUntilSettled] re-checks after the stale read completes and
+     * answers with one more listing. Restarting after, rather than cancelling
+     * mid-read, keeps the connection's exec accounting simple — the stale
+     * answer is allowed to arrive, it just stops being the final one.
+     *
+     * Every mutation goes through here, so a new one (rename, #2567) needs no
+     * new machinery: call this instead of [refresh] on its success path.
+     */
+    private fun refreshAfterMutation() {
+        if (inFlight?.isActive == true) {
+            mutationRefreshPending = true
+            return
+        }
+        refresh()
+    }
+
+    /**
+     * Reads the listing, then reads it again for as long as a mutation asked
+     * for a fresh one while the previous read was running.
+     *
+     * Terminates: [mutationRefreshPending] is only ever raised by
+     * [refreshAfterMutation], i.e. by a completed user-driven mutation, and is
+     * cleared before each read — so the loop runs at most once per mutation
+     * and cannot spin.
+     */
+    private suspend fun readUntilSettled() {
+        while (true) {
+            mutationRefreshPending = false
+            load()
+            if (!mutationRefreshPending) return
+            markReading()
+        }
+    }
+
+    /** Flags the read as in progress: first load vs. refresh over content. */
+    private fun markReading() {
         _state.update { current ->
             current.copy(
                 loading = !current.loaded,
                 refreshing = current.loaded,
             )
         }
-        inFlight = viewModelScope.launch { load() }
     }
 
     // --- create (task U-6) -------------------------------------------------
@@ -372,7 +444,10 @@ class SessionTreeViewModel @Inject constructor(
                             openRequest = created.name,
                         )
                     }
-                    refresh()
+                    // Same reason as the kill path: the new session must not
+                    // be missing from the tree because a pre-create listing
+                    // was in flight when the create returned (#2553).
+                    refreshAfterMutation()
                 },
                 onFailure = { error ->
                     failCreate(userMessage(error, "Could not create the session on the host: "))
@@ -394,7 +469,10 @@ class SessionTreeViewModel @Inject constructor(
             }
         }
         clients.create(connection).killSession(name).fold(
-            onSuccess = { refresh() },
+            // Not `refresh()`: a listing already in flight when the kill
+            // landed would otherwise be the last word and put the dead
+            // session back on screen (#2553).
+            onSuccess = { refreshAfterMutation() },
             onFailure = { error ->
                 fail(userMessage(error, "Could not stop the session on the host: "))
             },

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeViewModelTest.kt
@@ -14,6 +14,7 @@ import com.pocketshell.next.connect.TestConnectStack
 import com.pocketshell.next.hostcli.HostCliClientFactory
 import com.pocketshell.next.hostcli.asRemoteExec
 import com.pocketshell.next.nav.Destination
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -814,7 +815,187 @@ class SessionTreeViewModelTest {
         )
     }
 
+    // --- post-mutation refresh must win (issue #2553 gap 2) ---------------
+
+    @Test
+    fun `a Stop confirmed during an in-flight listing still drops the row`() =
+        runTest(dispatcher) {
+            val hostId = stack.seedHost()
+            val listing = GatedListing()
+            answerGatedListAndKill(listing)
+            val viewModel = viewModel(hostId)
+
+            // 1. A first, ungated listing so the tree is `loaded` and painted.
+            viewModel.refresh()
+            advanceUntilIdle()
+            assertTrue(
+                "precondition: claude-main is on the tree",
+                rowNames(viewModel).contains("claude-main"),
+            )
+
+            // 2. A second listing (an ON_START / pull refresh) that PARKS on
+            //    the host, having already taken its pre-kill snapshot.
+            listing.gateCallNumber = 2
+            viewModel.refresh()
+            advanceUntilIdle()
+            assertTrue("the second listing must be parked", listing.isParked)
+
+            // 3. The user confirms Stop WHILE that listing is in flight. The
+            //    kill reaches the host and succeeds.
+            viewModel.requestStopSession("claude-main")
+            viewModel.confirmStopSession()
+            advanceUntilIdle()
+            assertEquals(
+                "pocketshell sessions kill -- 'claude-main'",
+                connection().executedCommands.single { "kill" in it },
+            )
+
+            // 4. Only now does the parked listing answer — with its PRE-kill
+            //    payload, which still contains the session that was just
+            //    killed. Before #2553 the post-kill refresh was swallowed by
+            //    `refresh()`'s in-flight guard, so this stale answer was the
+            //    LAST word and the dead session stayed on screen and tappable.
+            listing.release()
+            advanceUntilIdle()
+
+            assertFalse(
+                "a successful Stop must not leave the killed session on the " +
+                    "tree just because a listing was in flight when it landed",
+                rowNames(viewModel).contains("claude-main"),
+            )
+            assertEquals(
+                "the post-kill refresh must actually reach the host",
+                3,
+                listing.listCalls,
+            )
+            assertNull(viewModel.state.value.failure)
+            assertFalse(
+                "the tree must settle, not stay stuck on a spinner",
+                viewModel.state.value.refreshing,
+            )
+        }
+
+    @Test
+    fun `a create finishing during an in-flight listing still shows the new session`() =
+        runTest(dispatcher) {
+            val hostId = stack.seedHost()
+            val listing = GatedListing(
+                before = LISTING_WITHOUT_CLAUDE,
+                after = HEALTHY_LISTING,
+                mutationPrefix = "pocketshell sessions create",
+                mutationStdout = """{"schema": 2, "name": "claude-main", "manager": "tmux", "id": null, "created": true}""",
+            )
+            answerGatedListAndKill(listing)
+            val viewModel = viewModel(hostId)
+
+            viewModel.refresh()
+            advanceUntilIdle()
+            assertFalse(rowNames(viewModel).contains("claude-main"))
+
+            listing.gateCallNumber = 2
+            viewModel.refresh()
+            advanceUntilIdle()
+            assertTrue(listing.isParked)
+
+            viewModel.createSession(CreateSessionRequest(name = "claude-main", cwd = null))
+            advanceUntilIdle()
+            listing.release()
+            advanceUntilIdle()
+
+            assertTrue(
+                "a create is a mutation too: its refresh must outlive a stale " +
+                    "listing that was already in flight",
+                rowNames(viewModel).contains("claude-main"),
+            )
+        }
+
+    @Test
+    fun `an ordinary refresh during an in-flight listing is still collapsed`() =
+        runTest(dispatcher) {
+            val hostId = stack.seedHost()
+            val listing = GatedListing()
+            answerGatedListAndKill(listing)
+            val viewModel = viewModel(hostId)
+
+            listing.gateCallNumber = 1
+            viewModel.refresh()
+            advanceUntilIdle()
+            assertTrue(listing.isParked)
+
+            // Pull-to-refresh, twice, while the first read is parked.
+            viewModel.refresh()
+            viewModel.refresh()
+            advanceUntilIdle()
+            listing.release()
+            advanceUntilIdle()
+
+            assertEquals(
+                "the ordinary de-duplication is deliberate and must stay: " +
+                    "only a MUTATION's refresh overrides it (#2553 non-goal)",
+                1,
+                listing.listCalls,
+            )
+        }
+
     // --- helpers ----------------------------------------------------------
+
+    private fun rowNames(viewModel: SessionTreeViewModel): List<String> =
+        viewModel.state.value.roots.flatMap { it.folders }.flatMap { it.rows }.map { it.name }
+
+    /**
+     * A scripted listing whose Nth answer PARKS until the test releases it.
+     *
+     * The park is a [CompletableDeferred], not a delay: the whole race is
+     * driven by explicit, virtual-time-free hand-offs, so the test is
+     * deterministic rather than a timing band that happens to pass.
+     *
+     * The payload is chosen BEFORE the park, which is the point — a real host
+     * that answered `sessions list` before the kill landed sends PRE-kill
+     * bytes, however late they arrive. Deciding it after the park would make
+     * the test pass against the unfixed ViewModel.
+     */
+    private class GatedListing(
+        val before: String = HEALTHY_LISTING,
+        val after: String = LISTING_WITHOUT_CLAUDE,
+        val mutationPrefix: String = "pocketshell sessions kill",
+        val mutationStdout: String = "",
+    ) {
+        /** Which `sessions list` call parks; 0 (default) parks none. */
+        var gateCallNumber: Int = 0
+        var listCalls: Int = 0
+            private set
+
+        private var mutated = false
+        private var gate: CompletableDeferred<Unit>? = null
+
+        val isParked: Boolean get() = gate?.isActive == true
+
+        fun release() {
+            gate?.complete(Unit)
+        }
+
+        suspend fun answer(command: String): ExecResult {
+            if (command.startsWith(mutationPrefix)) {
+                mutated = true
+                return ExecResult(0, mutationStdout, "", false)
+            }
+            listCalls += 1
+            val payload = if (mutated) after else before
+            if (listCalls == gateCallNumber) {
+                CompletableDeferred<Unit>().also { gate = it }.await()
+            }
+            return ExecResult(0, payload, "", false)
+        }
+    }
+
+    private fun answerGatedListAndKill(listing: GatedListing) {
+        stack.factory.script = { connection ->
+            connection.onExecMatching("gated list + mutation", once = false, { true }) { command ->
+                listing.answer(command)
+            }
+        }
+    }
+
 
     private fun viewModel(hostId: Long) = SessionTreeViewModel(
         savedStateHandle = SavedStateHandle(mapOf(Destination.ARG_HOST_ID to hostId)),

--- a/tools/pocketshell/src/pocketshell/aplexer.py
+++ b/tools/pocketshell/src/pocketshell/aplexer.py
@@ -43,6 +43,16 @@ dirs (e.g. ``~/bin/a``) was invisible, and the error said "not installed".
 ``worker_executable`` resolves it next to ``current_exe``, else bare
 ``aplexer`` on PATH). The pinned wheel always ships both into the same dir, so
 :class:`AplexerResolution` reports the worker it found next to ``a``.
+
+A BUNDLED ``a`` with no sibling worker is therefore a packaging-integrity
+failure, not a usable resolution (issue #2553): accepting it would let the
+pinned CLI start an UNPINNED worker off ``PATH`` — the same separate-install
+hazard #2543 removed, one level down. Such a candidate is skipped with a
+``tried`` entry saying why, so the caller's existing "could not resolve `a`;
+tried …" message explains it instead of a low-level worker-startup error.
+``APLEXER_BIN`` is deliberately exempt: it is the one explicit override ("run
+exactly this binary"), the reinstall advice does not apply to it, and it is
+the seam the test suite's stub ``a`` uses.
 """
 
 from __future__ import annotations
@@ -136,6 +146,8 @@ def resolve_a(env: Optional[Mapping[str, str]] = None) -> AplexerResolution:
     so a separately-installed ``a`` can never be load-bearing. Never raises —
     an unresolvable ``a`` comes back as a report whose ``path`` is ``None``
     and whose ``tried`` lists every candidate, for the caller's error message.
+    A bundled ``a`` missing its sibling ``aplexer`` worker counts as
+    unresolvable (#2553), for the reason the module docstring gives.
     """
     source = env_map(env)
     tried: list[str] = []
@@ -153,10 +165,25 @@ def resolve_a(env: Optional[Mapping[str, str]] = None) -> AplexerResolution:
     for bin_dir in _bundled_bin_dirs():
         candidate = bin_dir / "a"
         if candidate.exists():
+            worker = _sibling_worker(str(candidate))
+            if worker is None:
+                # HALF-INSTALLED BUNDLE (#2553). `a` alone is not usable:
+                # `aplexer/src/lib.rs::worker_executable` resolves the worker
+                # next to `current_exe` and, failing that, runs a BARE
+                # `aplexer` off PATH — so returning this `a` would either
+                # start an unpinned worker (the separate-install hazard #2543
+                # removed, one level down) or die with a low-level startup
+                # error. Treated exactly like an absent `a`: keep looking, and
+                # if nothing answers, fail loud with this candidate named.
+                tried.append(
+                    f"{candidate} (bundled, found; sibling `aplexer` worker "
+                    "missing — half-installed)"
+                )
+                continue
             return AplexerResolution(
                 path=str(candidate),
                 source="bundled",
-                worker=_sibling_worker(str(candidate)),
+                worker=worker,
                 tried=tuple([*tried, f"{candidate} (bundled, found)"]),
             )
         tried.append(f"{candidate} (bundled, missing)")

--- a/tools/pocketshell/tests/test_aplexer_resolution.py
+++ b/tools/pocketshell/tests/test_aplexer_resolution.py
@@ -95,16 +95,139 @@ def test_bundled_worker_ships_next_to_bundled_a(tmp_path: Path) -> None:
     assert report.worker == str(bin_dir / "aplexer")
 
 
-def test_bundled_a_without_sibling_worker_is_reported(tmp_path: Path) -> None:
-    """A half-installed bundle (``a`` only) is resolvable but worker-less."""
+def test_bundled_a_without_sibling_worker_is_a_packaging_integrity_failure(
+    tmp_path: Path,
+) -> None:
+    """A half-installed bundle (``a``, no worker) must NOT resolve (#2553 gap 1).
+
+    ``aplexer/src/lib.rs::worker_executable`` looks for the ``aplexer`` worker
+    next to ``current_exe`` and, failing that, runs a BARE ``aplexer`` off
+    ``PATH``. So handing a worker-less ``a`` back to the caller re-opens the
+    separate-install hole #2543 closed one level down: the CLI would be pinned
+    but its worker would not. The pinned wheel always ships both binaries, so
+    "``a`` without its worker" is a packaging-integrity failure and must fail
+    the same loud, candidate-naming way an absent ``a`` does.
+    """
     bin_dir = _fake_interpreter_dir(tmp_path, with_a=True)
     (bin_dir / "aplexer").unlink()
 
     with patch.object(sys, "executable", str(bin_dir / "python")):
         report = _aplexer.resolve_a({"PATH": ""})
+        resolved = _aplexer.which_a({"PATH": ""})
 
-    assert report.path == str(bin_dir / "a")
+    assert report.path is None, (
+        "an `a` whose sibling `aplexer` worker is missing must not be handed "
+        "out — it would start with an unpinned worker off PATH"
+    )
+    assert report.source is None
     assert report.worker is None
+    assert resolved is None
+    tried = " ".join(report.tried)
+    assert str(bin_dir / "a") in tried, "the failure must name the half-installed candidate"
+    assert "worker" in tried, f"the failure must say WHY it was rejected: {report.tried}"
+
+
+def test_half_installed_bundle_never_falls_back_to_a_path_copy(tmp_path: Path) -> None:
+    """The integrity failure is a hard stop, not a reason to search PATH (D22).
+
+    Rejecting the half-installed bundle must not quietly promote a complete
+    ``a``/``aplexer`` pair sitting on ``PATH`` — that separately-installed copy
+    being load-bearing is the exact bug #2543 existed to kill.
+    """
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=True)
+    (bin_dir / "aplexer").unlink()
+    path_dir = tmp_path / "elsewhere"
+    path_dir.mkdir()
+    for name in ("a", "aplexer"):
+        binary = path_dir / name
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        report = _aplexer.resolve_a({"PATH": str(path_dir)})
+
+    assert report.path is None
+    assert str(path_dir) not in " ".join(report.tried)
+
+
+def test_half_installed_second_candidate_dir_is_also_rejected(tmp_path: Path) -> None:
+    """The check covers BOTH bundled candidate dirs, not just the first.
+
+    ``_bundled_bin_dirs`` keeps a second, resolved-symlink candidate; a check
+    written into only the first branch would let the same worker-less ``a``
+    through on the venv layout where ``bin/python`` is a real file.
+    """
+    real_dir = tmp_path / "real" / "bin"
+    real_dir.mkdir(parents=True)
+    (real_dir / "python").write_text("#!/bin/sh\n")
+    (real_dir / "a").write_text("#!/bin/sh\n")
+    (real_dir / "a").chmod(0o755)
+    link_dir = tmp_path / "link" / "bin"
+    link_dir.mkdir(parents=True)
+    (link_dir / "python").symlink_to(real_dir / "python")
+
+    with patch.object(sys, "executable", str(link_dir / "python")):
+        report = _aplexer.resolve_a({"PATH": ""})
+
+    assert report.path is None, "the resolved-dir candidate needs the same worker check"
+    assert "worker" in " ".join(report.tried)
+
+
+def test_aplexer_bin_override_is_exempt_from_the_worker_check(tmp_path: Path) -> None:
+    """``APLEXER_BIN`` still resolves whatever it points at (#2553 judgment call).
+
+    The integrity check is about the BUNDLE — "the pinned wheel ships both
+    console-scripts, so one without the other means a broken install, go
+    reinstall". ``APLEXER_BIN`` is the one explicit debug/test override; its
+    whole contract is "run exactly this binary", the reinstall advice does not
+    apply to it, and the helper suite's stub ``a`` (``conftest.install_fake_a``)
+    has no sibling worker by design.
+    """
+    override = tmp_path / "custom-a"
+    override.write_text("#!/bin/sh\n")
+    override.chmod(0o755)
+
+    report = _aplexer.resolve_a({"APLEXER_BIN": str(override), "PATH": ""})
+
+    assert report.path == str(override)
+    assert report.worker is None
+
+
+# ---------------------------------------------------------------------------
+# The half-installed bundle reaching the USER (#2553 gap 1)
+# ---------------------------------------------------------------------------
+
+
+def test_half_installed_bundle_fails_create_with_the_candidate_naming_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End of the chain: a worker-less bundle must produce #2543's message.
+
+    Without the check, `sessions create --backend aplexer` would EXEC the
+    worker-less `a`, which starts a bare `aplexer` off PATH (unpinned worker)
+    or dies with a low-level worker-startup error. The user must instead get
+    the packaging-integrity message that names every candidate, so "reinstall
+    pocketshell" is an obvious next step.
+    """
+    from click.testing import CliRunner
+
+    from pocketshell.sessions import sessions_group
+
+    bin_dir = _fake_interpreter_dir(tmp_path, with_a=True)
+    (bin_dir / "aplexer").unlink()
+    monkeypatch.delenv("APLEXER_BIN", raising=False)
+
+    with patch.object(sys, "executable", str(bin_dir / "python")):
+        result = CliRunner().invoke(
+            sessions_group, ["create", "work", "--backend", "aplexer", "--json"]
+        )
+
+    assert result.exit_code == 127, result.output
+    message = json.loads(result.output)["error"]
+    assert "could not resolve the `a` (aplexer) binary" in message
+    assert "uv tool install --force pocketshell" in message
+    assert str(bin_dir / "a") in message, "the message must name the broken candidate"
+    assert "worker" in message, f"and say what was wrong with it: {message}"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/pocketshell/tests/test_profiles.py
+++ b/tools/pocketshell/tests/test_profiles.py
@@ -556,6 +556,12 @@ def test_aplexer_profile_probe_uses_the_bundled_a(fake_home, tmp_path, monkeypat
     bundled = bin_dir / "a"
     bundled.write_text(script.read_text(encoding="utf-8"), encoding="utf-8")
     bundled.chmod(bundled.stat().st_mode | stat.S_IEXEC)
+    # A COMPLETE bundle: the pinned wheel ships `a` AND the `aplexer` worker
+    # into the same bin dir, and since #2553 a bundle missing the worker is
+    # rejected as a packaging-integrity failure rather than probed.
+    worker = bin_dir / "aplexer"
+    worker.write_text("#!/bin/sh\n", encoding="utf-8")
+    worker.chmod(worker.stat().st_mode | stat.S_IEXEC)
     environment = {
         # No aplexer anywhere on PATH — only the system dirs the stub's own
         # `/bin/sh` body needs. Resolution must come from the bundled copy.


### PR DESCRIPTION
Closes PocketShell-io/pocketshell#2553. Two gaps from the v0.5.2 pre-tag review.

## Gap 2 — a mutation's refresh could be dropped

`refresh()` returns early when a listing is already in flight, and the kill/create handlers called it on success. A mutation landing during an in-flight listing lost its refresh: the listing completed with **pre-mutation** data, so a killed session stayed on screen and stayed tappable — a successful destructive action that looked like it failed.

`refreshAfterMutation()` makes the post-mutation read win. The ordinary de-duplication is **byte-for-byte unchanged** — it is correct for pull-to-refresh, and a test pins that two pull-refreshes during a parked read still produce exactly one listing.

Extended to `runCreate` past the literal AC: identical bug next door, leaving a new session off the tree. The reviewer's call was to keep it — it is what makes this class coverage (G2) rather than a single-instance pin.

## Gap 1 — a worker-less `a` was accepted

`resolve_a` accepted a bundled `a` whose sibling `aplexer` worker was missing, so `a` fell back to a bare `aplexer` on `PATH` — an unpinned worker running, or `"'a --json start' returned unreadable JSON"` at exit 1 instead of the packaging-integrity message PocketShell-io/pocketshell#2543 exists for. Now the same loud failure, listing every candidate tried. Reviewer confirmed `aplexer.py` has no `shutil.which` call at all and a planted complete pair on `PATH` is still never promoted (D22 hard cut).

## Evidence (reviewer-produced, this run)

- **The race, N=20 each way: 20/20 PASS with the fix, 20/20 RED with an identical signature on base.** Not "sometimes red".
- The `GatedListing` helper stages the real race — the payload is chosen *before* the `CompletableDeferred` park, so the parked reply carries genuinely pre-kill bytes. Deciding it after the park is the mistake that would have made it pass unfixed.
- Reverting only `SessionTreeViewModel.kt` → `34 tests, 2 failures`, and the assertions that move are the behaviour ones (killed row absent / new row present), not structural preconditions (G6).
- Reverting only `aplexer.py` → 4 red, including a CLI-level test showing the exact reported symptom.
- Emulator: `scripts/connected-test.sh --suffix i2553` → **9 executed, 0 skipped, 0 failures** (J14 stop-from-tree with its SSH `sessions list` oracle, J04 create, J02 list). Run because `refresh()` was restructured into a loop every listing now goes through.
- Python suite **1318 passed, 4 skipped**; hygiene, test-validity, CI-lock, `git diff --check` all green.

## D31 adjacency

Gap 2 is an app2 recurrence of pre-rewrite **#464** ("Killed session still shows in the folder tree"). The durable-fix gate was applied and it clears — `:app2:testDebugUnitTest` is wired into `app2.yml`'s `app2-unit` job on push and PR, with an "Assert tests actually executed" step.

## G10

No new device journey. The defect came from a pre-tag model review rather than an on-device report, and the race cannot be staged against a real host without a production test seam SEAM1 forbids. Reviewer ruled explicitly; the emulator lane was run anyway for the `refresh()` restructure.

## Sequencing

**#2567 must rebase onto this**, not the other way round. It independently wrote its own `refreshAfterMutation()` with a different mechanism (`previous?.join()` chaining); merging both would give two competing definitions of the same function, a duplicate import, and overlapping insertions at the same test anchor. After rebasing, PocketShell-io/pocketshell-cli#9 keeps only `onSuccess = { refreshAfterMutation() }` in `runRename` — at which point the "one line" overlap is real.