### PR TITLE
app2: session usage pill focuses on the session's aplexer-detected agent

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/usage/J12UsagePanelJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/usage/J12UsagePanelJourney.kt
@@ -1,6 +1,7 @@
 package com.pocketshell.next.usage
 
 import android.os.SystemClock
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasTestTag
@@ -27,6 +28,12 @@ import com.pocketshell.next.tree.sessionRowTag
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.flow.first
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -206,7 +213,252 @@ class J12UsagePanelJourney {
         JourneyScreenshots.capture("04-panel-from-tree", JOURNEY)
     }
 
+    /**
+     * Issue #2579: the pill on the SESSION screen is about THAT session's
+     * agent, not about the worst provider on the box.
+     *
+     * The fixture's `pocketshell usage --json` reports Claude blocked with its
+     * 5h bucket at 98% used and its 7d one at 60%, and that 98% is also the
+     * worst reading anywhere — so the pre-#2579 pill on this screen reads
+     * "Claude 5h 98%". The focused pill must instead read "Claude 60%":
+     * Claude's LONGEST window, no window token. The two strings differ in both
+     * the number and the token, so a fallback cannot pass this test.
+     *
+     * ## The session is a REAL aplexer session running a REAL `claude`
+     *
+     * [startRealAplexerSessionRunningClaude] does, over the same SSH the app
+     * uses, exactly what the maintainer's box does: it starts an aplexer
+     * session (through the host CLI, `--backend aplexer`, which is a plain
+     * shell workload — `engine` is NOT the answer to "which agent"), then
+     * launches an agent INSIDE it. The agent is a `claude`-named executable
+     * that stays alive, so the workload has a live descendant whose `comm` and
+     * `argv[0]` are both `claude` — the state aplexer's process-tree walker
+     * classifies. `a capture --screen --plain` is the independent oracle that
+     * the launch line really ran in that session.
+     *
+     * The image's own `/usr/local/bin/claude` is deliberately NOT used: it
+     * prints one line and exits, so it leaves no descendant to detect.
+     *
+     * ## This journey is expected RED until #2581 + #2586 land
+     *
+     * Two things must ship before it can pass, and it fails on the FIRST of
+     * them by name rather than degrading into a silent fallback:
+     *
+     *  1. `a` must report the detected agent (aplexer 0.1.4, issue #2580) and
+     *     the host CLI must pass it through as `agent` on the schema-2 row
+     *     (issue #2581, which also bumps `tools/pocketshell/pyproject.toml`'s
+     *     `aplexer==` pin — the same line `Dockerfile.agents` derives the
+     *     fixture's binary download from, so the pin bump is what re-points
+     *     this fixture at a detecting `a`). Today the row carries no `agent`
+     *     key at all.
+     *  2. The fixture's `sessions list --json` arm must ENUMERATE live aplexer
+     *     sessions instead of reading `~/.pocketshell-fixture-aplexer.json`
+     *     (issue #2586; the shim says so itself). Until then the app
+     *     cannot see this session, so the UI half below cannot run either —
+     *     which is why the host-contract assertion comes first and is the one
+     *     that fails.
+     *
+     * Nothing here is stubbed to route around either gap: a journey that
+     * seeded the `agent` value itself would prove only that the client can
+     * read a value the journey wrote, which is what the JVM suite already
+     * proves without an emulator.
+     */
+    @Test
+    // Red by design today; the KDoc above names both blockers and what turns
+    // each green. Quarantined per D36(4) so it cannot freeze `main`'s journey
+    // lane while it waits — one line, because the reconciler parses it.
+    @Ignore("quarantined: #2586, expires 2026-09-20 — fixture lists no live aplexer row")
+    fun theSessionPillFocusesTheSessionsDetectedAgentAndDropsTheWindowToken() {
+        val sessionName = startRealAplexerSessionRunningClaude()
+        try {
+            assertHostReportsTheDetectedAgent(sessionName)
+
+            awaitTag(hostRowTag(hostId))
+            compose.onNodeWithTag(hostRowTag(hostId)).performClick()
+            awaitTag(SESSION_TREE_TAG)
+            awaitTag(sessionRowTag(sessionName), "the live aplexer session's row")
+            compose.onNodeWithTag(sessionRowTag(sessionName)).performClick()
+            awaitTag(SESSION_SCREEN_TAG)
+
+            awaitTag(USAGE_GLANCE_PILL_TAG, "the usage glance pill")
+            JourneyScreenshots.capture("05-focused-pill", JOURNEY)
+
+            val description = pillContentDescription()
+            assertEquals(
+                "the session's pill must be attributed to the agent the host " +
+                    "detected for THIS session, at that provider's longest " +
+                    "window, with no window token (issue #2579)",
+                "Usage Claude $CLAUDE_LONGEST_WINDOW_PERCENT%",
+                description,
+            )
+            // Spelled out separately so a failure says WHICH half broke: a pill
+            // that fell back to the cross-provider answer carries "5h" here.
+            for (token in listOf("5h", "7d", "weekly", "monthly")) {
+                assertFalse(
+                    "the focused pill must carry no window token, got: $description",
+                    description.contains(token),
+                )
+            }
+        } finally {
+            killAgentSession(sessionName)
+        }
+    }
+
     // --- helpers ------------------------------------------------------------
+
+    /**
+     * Starts a real aplexer session with a live `claude` process inside it and
+     * returns the listing name the host gave it.
+     *
+     * The launch line is SENT into the running session rather than passed as
+     * the session's own command, because that is the shape the detection has to
+     * cope with: aplexer starts a shell, the agent appears later as one of its
+     * descendants, and `engine` never mentions it.
+     */
+    private fun startRealAplexerSessionRunningClaude(): String {
+        // A `claude`-NAMED executable, so both `comm` and `argv[0]` say
+        // "claude" for the live process. A shell script would report its
+        // interpreter (`sh`) as `comm`, which is not the state being detected.
+        AgentsFixture.exec(
+            "mkdir -p $AGENT_BIN_DIR $AGENT_WORKSPACE && " +
+                "ln -sf /bin/sleep $AGENT_BIN",
+        )
+        killAgentSession(aplexerSessionName())
+
+        val created = AgentsFixture.exec(
+            "pocketshell sessions create $AGENT_TAG --backend aplexer " +
+                "--cwd $AGENT_WORKSPACE --json",
+        )
+        val envelope = JSONObject(created)
+        assertEquals(
+            "the fixture must create this session on aplexer, not tmux: $created",
+            "aplexer",
+            envelope.optString("manager"),
+        )
+        val name = envelope.optString("name")
+        assertTrue("the create envelope carried no name: $created", name.isNotEmpty())
+
+        AgentsFixture.exec(
+            "a send --workspace $AGENT_WORKSPACE --tag $AGENT_TAG --enter " +
+                "'$AGENT_BIN $AGENT_LIFETIME_SECONDS'",
+        )
+
+        // Independent oracle, on aplexer's own rendering of the live screen:
+        // the launch line really reached THIS session. Without it, a `send`
+        // that silently went nowhere would look identical to "the agent is
+        // running but was not detected".
+        awaitCondition("the launch line to appear on the session's screen") {
+            AgentsFixture.exec(
+                "a capture --screen --plain --workspace $AGENT_WORKSPACE --tag $AGENT_TAG",
+            ).contains(AGENT_BIN)
+        }
+        // ...and the process is actually alive, so there IS something to detect.
+        awaitCondition("a live `claude` process under the session's workload") {
+            AgentsFixture.exec("pgrep -f '$AGENT_BIN ' >/dev/null && echo live || echo none")
+                .trim() == "live"
+        }
+        return name
+    }
+
+    /**
+     * The load-bearing host-contract assertions, run BEFORE any UI, in the
+     * order the two blockers have to fall.
+     *
+     * They are what keep this journey honest. Without them a host that reports
+     * no `agent` would leave the pill on its cross-provider answer, and the
+     * failure would read as an unrelated UI problem instead of naming the pin
+     * that has to move.
+     */
+    private fun assertHostReportsTheDetectedAgent(sessionName: String) {
+        // 1. The CLI CONTRACT, on the unshimmed host CLI — the thing #2581
+        //    changes. This is the assertion that fails today: `a` cannot yet
+        //    report what is running inside a session, so the row has no
+        //    `agent` at all.
+        val realRow = requireNotNull(
+            aplexerRow(realCliListing(), sessionName),
+        ) { "the real host CLI did not list its own live aplexer session $sessionName" }
+        assertEquals(
+            "the host CLI must report the agent detected inside this session. " +
+                "The row carries `engine` but no usable `agent`, which means " +
+                "the fixture's `a` predates aplexer's process-tree detection " +
+                "(#2580), or the CLI does not pass it through (#2581 — whose " +
+                "`aplexer==` pin bump in tools/pocketshell/pyproject.toml is " +
+                "the same line Dockerfile.agents derives the fixture's binary " +
+                "download from, so that bump is what re-points this fixture " +
+                "at a detecting `a`). Until then the pill falls back to the " +
+                "cross-provider answer and this journey proves nothing." +
+                "\nRow:\n$realRow",
+            "claude",
+            realRow.optString("agent", ""),
+        )
+
+        // 2. The APP-FACING listing: the exact command the client runs. On the
+        //    fixture this is the deterministic shim, whose list arm still reads
+        //    aplexer rows from a seed file rather than enumerating live ones.
+        val appListing = AgentsFixture.exec("pocketshell sessions list --json")
+        val appRow = aplexerRow(appListing, sessionName)
+        assertNotNull(
+            "`pocketshell sessions list --json` — the command the app runs — " +
+                "did not list the live aplexer session $sessionName. The " +
+                "fixture's list arm still reads aplexer rows from " +
+                "~/.pocketshell-fixture-aplexer.json instead of enumerating " +
+                "them (issue #2586), so the app cannot see a real " +
+                "aplexer session yet.\nHost listing:\n$appListing",
+            appRow,
+        )
+        assertEquals(
+            "the app-facing listing must carry the same detected agent the " +
+                "host CLI reports.\nRow:\n$appRow",
+            "claude",
+            appRow!!.optString("agent", ""),
+        )
+    }
+
+    /**
+     * The REAL host CLI's own enumeration, run the way
+     * `tests/docker/agents-aplexer-selfcheck.py` runs it — `python3 -m
+     * pocketshell` off `/opt/pocketshell-real/src`, never the deterministic
+     * `agent-bin` shim, which would be asserting a fixture against itself.
+     */
+    private fun realCliListing(): String = AgentsFixture.exec(
+        "PYTHONPATH=$REAL_CLI_SRC python3 -m pocketshell sessions list --json",
+    )
+
+    private fun aplexerRow(listing: String, sessionName: String): JSONObject? {
+        val rows = JSONObject(listing).getJSONArray("sessions")
+        return (0 until rows.length())
+            .map { rows.getJSONObject(it) }
+            .firstOrNull { it.optString("name") == sessionName }
+    }
+
+    /** Best-effort teardown; a leaked aplexer record blocks the next create. */
+    private fun killAgentSession(name: String) {
+        AgentsFixture.exec("pocketshell sessions kill '$name' --json >/dev/null 2>&1 || true")
+    }
+
+    /** The listing name aplexer gives `AGENT_WORKSPACE` + `AGENT_TAG`. */
+    private fun aplexerSessionName(): String =
+        "${AGENT_WORKSPACE.substringAfterLast('/')}:$AGENT_TAG"
+
+    /** The pill's own accessibility text — "Usage Claude 60%". */
+    private fun pillContentDescription(): String {
+        val node = compose.onNodeWithTag(USAGE_GLANCE_PILL_TAG).fetchSemanticsNode()
+        return node.config[SemanticsProperties.ContentDescription].joinToString(" ")
+    }
+
+    /**
+     * Polls a HOST-side [condition] to the journey's deadline, then fails
+     * saying [what]. A slower cadence than [awaitTag]'s: each probe is its own
+     * SSH connection, not a semantics-tree read.
+     */
+    private fun awaitCondition(what: String, condition: () -> Boolean) {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (condition()) return
+            SystemClock.sleep(SSH_POLL_MS)
+        }
+        throw AssertionError("$what never happened within ${TIMEOUT_MS}ms")
+    }
 
     private fun assertCardHasDescendant(cardTag: String, text: String) {
         compose.onNode(hasTestTag(cardTag) and hasAnyDescendant(hasText(text)))
@@ -237,10 +489,37 @@ class J12UsagePanelJourney {
     private companion object {
         const val TIMEOUT_MS = 60_000L
         const val POLL_MS = 250L
+        const val SSH_POLL_MS = 1_000L
+
+        /** Where the image keeps the real, unshimmed host CLI. */
+        const val REAL_CLI_SRC = "/opt/pocketshell-real/src"
         const val JOURNEY = "j12-usage-panel"
 
         const val SESSION = "j12-shell"
         const val HOST_ID = 9_801L
+
+        /**
+         * The real aplexer session the focused-pill test drives (#2579).
+         *
+         * Its own workspace, so it can never collide with the canned fixture
+         * rows or with another journey's aplexer session — aplexer keys a
+         * session by workspace + tag.
+         */
+        const val AGENT_TAG = "j12-agent"
+        const val AGENT_WORKSPACE = "/home/testuser/j12-agent-ws"
+        const val AGENT_BIN_DIR = "/home/testuser/j12-agent-bin"
+        const val AGENT_BIN = "$AGENT_BIN_DIR/claude"
+
+        /** Long enough to outlive the journey, short enough to self-reap. */
+        const val AGENT_LIFETIME_SECONDS = 600
+
+        /**
+         * Claude's LONGEST window in `agent-fixtures/pocketshell-usage.ndjson`:
+         * `7d` at `percent_remaining: 40.0`, i.e. 60% used. Its `5h` bucket is
+         * at 98% and is the worst reading on the whole fixture, which is what
+         * the pre-#2579 pill shows — the two answers cannot collide.
+         */
+        const val CLAUDE_LONGEST_WINDOW_PERCENT = 60
 
         const val SOCKET_DIR = "\"\${TMUX_TMPDIR:-/tmp}/tmux-\$(id -u)\""
         const val SOCKET = "\"\${TMUX_TMPDIR:-/tmp}/tmux-\$(id -u)/tmuxctl-$SESSION\""

--- a/app2/src/main/java/com/pocketshell/next/terminal/SessionScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/SessionScreen.kt
@@ -107,7 +107,12 @@ fun SessionRoute(
     val stopFailure by viewModel.stopFailure.collectAsState()
 
     LaunchedEffect(hostId, sessionName) { viewModel.open(hostId, sessionName) }
-    LifecycleEventEffect(Lifecycle.Event.ON_START) { usageGlanceViewModel.refresh() }
+    // Issue #2579: the pill on THIS screen is about THIS session's agent, so
+    // the refresh names the session. The tree's Usage affordance keeps calling
+    // the no-argument overload and keeps the cross-provider meaning.
+    LifecycleEventEffect(Lifecycle.Event.ON_START) {
+        usageGlanceViewModel.refresh(hostId = hostId, sessionName = sessionName)
+    }
 
     LaunchedEffect(leaveAfterStop) {
         if (!leaveAfterStop) return@LaunchedEffect

--- a/app2/src/main/java/com/pocketshell/next/usage/UsageGlancePill.kt
+++ b/app2/src/main/java/com/pocketshell/next/usage/UsageGlancePill.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.pocketshell.core.usage.UsageProviderRecord
 import com.pocketshell.core.usage.UsageThresholdState
 import com.pocketshell.uikit.model.PillKind
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -131,12 +132,73 @@ val USAGE_GLANCE_STALE_AFTER: Duration = Duration.ofMinutes(10)
 const val USAGE_GLANCE_PILL_TAG: String = "session:usage-pill"
 
 /**
+ * Which provider THIS screen is about (issue #2579).
+ *
+ * The session screen knows something the tree does not: the agent aplexer
+ * detected running inside the session the user is looking at. "How close is
+ * the agent I am talking to right now" is a different question from "how close
+ * is the nearest limit anywhere", and on the session screen it is the one the
+ * user is asking — the maintainer's report was a Claude session whose pill
+ * read "Grok 7d 83%".
+ *
+ * [provider] is the RAW host vocabulary ("claude"), matched case-insensitively
+ * against [UsageProviderRecord.provider]. Deliberately not a display label: a
+ * future edit to [glanceProviderLabel] must not be able to break the match.
+ */
+data class GlanceFocus(
+    val hostId: Long,
+    val provider: String,
+)
+
+/** 24, 168 and 720 hours — the spans behind `Nd`, `weekly` and `monthly`. */
+private const val HOURS_PER_DAY = 24
+private const val HOURS_PER_WEEK = 168
+private const val HOURS_PER_MONTH = 720
+
+private val HOURS_WINDOW = Regex("^(\\d+)h$")
+private val DAYS_WINDOW = Regex("^(\\d+)d$")
+
+/**
+ * Span of a provider window name in hours, for "show the LONGEST window".
+ *
+ * The names are the PRODUCER's own labels (`5h`, `7d`, `weekly`, `monthly`),
+ * so this reads that vocabulary rather than inventing one. An unrecognised
+ * name scores 0: it still competes — a provider whose only window is named
+ * something new must not vanish from the pill — but never outranks a window
+ * whose span is actually known.
+ */
+internal fun windowSpanHours(name: String?): Int {
+    val trimmed = name?.trim()?.lowercase().orEmpty()
+    HOURS_WINDOW.matchEntire(trimmed)?.let { return it.groupValues[1].toIntOrNull() ?: 0 }
+    DAYS_WINDOW.matchEntire(trimmed)?.let {
+        return (it.groupValues[1].toIntOrNull() ?: 0) * HOURS_PER_DAY
+    }
+    return when (trimmed) {
+        "weekly" -> HOURS_PER_WEEK
+        "monthly" -> HOURS_PER_MONTH
+        else -> 0
+    }
+}
+
+/**
  * Derive the pill state from the [snapshots] the store last read.
  *
- * Picks the single MOST-CONSTRAINING window across every host and provider (the
- * highest percent) so the pill answers "how close am I to the nearest limit"
- * with one number. A hard-blocked provider that reports no windows still
- * surfaces as 100%, so a block is never invisible.
+ * Without a [focus] this picks the single MOST-CONSTRAINING window across
+ * every host and provider (the highest percent) so the pill answers "how close
+ * am I to the nearest limit" with one number. A hard-blocked provider that
+ * reports no windows still surfaces as 100%, so a block is never invisible.
+ *
+ * With a usable [focus] — a host present in [snapshots] that has a record for
+ * that provider — the question changes to "how close is THIS session's agent"
+ * (issue #2579) and the pill shows that provider's LONGEST window. The window
+ * token is dropped in that mode on purpose: the maintainer asked for
+ * "Claude 38%", not "Claude 7d 38%", because once the provider is the
+ * session's own agent the window name is noise, not information.
+ *
+ * A focus that resolves to nothing (a host that is not in [snapshots], a
+ * provider with no record there) falls back to the cross-provider behaviour
+ * byte-for-byte — a session whose agent has no quota data must not lose its
+ * pill.
  *
  * Returns null — the pill is HIDDEN — when there is no usable reading yet: no
  * [UsageSnapshot.Records] at all, or only records with no thresholdable window.
@@ -144,10 +206,14 @@ const val USAGE_GLANCE_PILL_TAG: String = "session:usage-pill"
 fun usageGlancePillState(
     snapshots: Map<Long, UsageSnapshot>,
     warnPercent: Double,
+    focus: GlanceFocus? = null,
     now: Instant = Instant.now(),
     staleAfter: Duration = USAGE_GLANCE_STALE_AFTER,
     zoneId: ZoneId = ZoneId.systemDefault(),
 ): UsageGlancePillState? {
+    focusedCandidate(snapshots, focus, warnPercent)
+        ?.let { return it.toPillState(now = now, staleAfter = staleAfter, zoneId = zoneId) }
+
     val worst = snapshots.values
         .filterIsInstance<UsageSnapshot.Records>()
         .flatMap { snapshot -> snapshot.records.map { snapshot to it } }
@@ -174,20 +240,74 @@ fun usageGlancePillState(
         .maxByOrNull { it.percent }
         ?: return null
 
-    val kind = when (worst.state) {
-        UsageThresholdState.Exceeded, UsageThresholdState.Critical -> PillKind.Blocked
-        UsageThresholdState.Approaching -> PillKind.Warn
-        UsageThresholdState.Ok -> PillKind.Ok
-    }
-    return UsageGlancePillState(
-        percent = worst.percent.roundToInt(),
-        provider = worst.provider,
-        window = worst.window,
-        kind = kind,
-        stale = Duration.between(worst.fetchedAt, now) > staleAfter,
-        fetchedClock = formatClock(worst.fetchedAt, zoneId),
+    return worst.toPillState(now = now, staleAfter = staleAfter, zoneId = zoneId)
+}
+
+/**
+ * The [focus]ed provider's longest window on the focused host, or null when
+ * the focus cannot be honoured and the caller must fall back.
+ *
+ * "Longest" is by [windowSpanHours], not by percent: the maintainer wants the
+ * limit that actually governs a long working session (Claude's 7d), not
+ * whichever bucket happens to be most drained right now.
+ *
+ * A blocked record with NO windows still answers, at 100% — the same "a block
+ * is never invisible" rule the cross-provider path has. A record that exists
+ * but has neither a window nor a block is NOT an answer: it carries no number
+ * to show, so the caller falls back rather than painting a fake 0%.
+ */
+private fun focusedCandidate(
+    snapshots: Map<Long, UsageSnapshot>,
+    focus: GlanceFocus?,
+    warnPercent: Double,
+): GlanceCandidate? {
+    if (focus == null) return null
+    val snapshot = snapshots[focus.hostId] as? UsageSnapshot.Records ?: return null
+    val wanted = focus.provider.trim()
+    if (wanted.isEmpty()) return null
+    val record = snapshot.records.firstOrNull { it.provider.equals(wanted, ignoreCase = true) }
+        ?: return null
+
+    val recordState = record.thresholdState(warnPercent = warnPercent)
+    // Ties keep the FIRST window, which is the producer's own order — stable
+    // across fetches, so the pill cannot flip between two equal spans.
+    val longest = record.windows.maxByOrNull { windowSpanHours(it.name) }
+    val percent = longest?.percent
+        ?: if (recordState == UsageThresholdState.Exceeded) EXCEEDED_PERCENT else return null
+
+    return GlanceCandidate(
+        percent = percent,
+        // A BLOCKED record stays blocked whatever the displayed window reads:
+        // a Claude that is hard-blocked on its 5h bucket cannot run, and a
+        // green dot over "Claude 38%" would say the opposite. Otherwise the
+        // dot describes the number next to it — an amber dot over a 38% that
+        // is nowhere near its own limit is just as misleading in reverse.
+        state = if (recordState == UsageThresholdState.Exceeded) {
+            UsageThresholdState.Exceeded
+        } else {
+            thresholdOf(percent, warnPercent)
+        },
+        fetchedAt = snapshot.fetchedAt,
+        provider = glanceProviderLabel(record.provider),
+        // No window token in focused mode (issue #2579): "Claude 38%".
+        window = null,
     )
 }
+
+/**
+ * [UsageProviderRecord.thresholdState]'s bands applied to ONE percent.
+ *
+ * The record's own method always thresholds its most-constrained window, which
+ * is the wrong window here — the focused pill displays the LONGEST one.
+ */
+private fun thresholdOf(percent: Double, warnPercent: Double): UsageThresholdState = when {
+    percent >= UsageProviderRecord.EXCEEDED_PERCENT -> UsageThresholdState.Exceeded
+    percent >= UsageProviderRecord.CRITICAL_PERCENT -> UsageThresholdState.Critical
+    percent >= warnPercent -> UsageThresholdState.Approaching
+    else -> UsageThresholdState.Ok
+}
+
+private const val EXCEEDED_PERCENT = 100.0
 
 private data class GlanceCandidate(
     val percent: Double,
@@ -195,7 +315,22 @@ private data class GlanceCandidate(
     val fetchedAt: Instant,
     val provider: String,
     val window: String?,
-)
+) {
+    /** Renders the candidate; [state] was already resolved by its producer. */
+    fun toPillState(now: Instant, staleAfter: Duration, zoneId: ZoneId): UsageGlancePillState =
+        UsageGlancePillState(
+            percent = percent.roundToInt(),
+            provider = provider,
+            window = window,
+            kind = when (state) {
+                UsageThresholdState.Exceeded, UsageThresholdState.Critical -> PillKind.Blocked
+                UsageThresholdState.Approaching -> PillKind.Warn
+                UsageThresholdState.Ok -> PillKind.Ok
+            },
+            stale = Duration.between(fetchedAt, now) > staleAfter,
+            fetchedClock = formatClock(fetchedAt, zoneId),
+        )
+}
 
 /**
  * The pill itself. A 32dp rounded elevated surface with a hairline border — the

--- a/app2/src/main/java/com/pocketshell/next/usage/UsageViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/usage/UsageViewModel.kt
@@ -2,10 +2,15 @@ package com.pocketshell.next.usage
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pocketshell.core.hostapi.Backend
 import com.pocketshell.core.usage.UsageProviderRecord
+import com.pocketshell.next.connect.ConnectionsRegistry
+import com.pocketshell.next.hostcli.HostCliClientFactory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -61,10 +66,19 @@ class UsageViewModel @Inject constructor(
  * foreground-only [UsageFetcher] round on `ON_START`; there is no shared
  * cache between the two, matching the plan's "no stale-while-revalidate"
  * call for this whole feature.
+ *
+ * Issue #2579 gave it a second, OPTIONAL input: on the session screen the
+ * caller says which session is open, and the pill then reports that session's
+ * own agent instead of the worst provider anywhere. The listing that answers
+ * "which agent" is asked for on the connection the screen already holds, in
+ * parallel with the usage round, and its failure is not the pill's failure —
+ * see [detectFocus].
  */
 @HiltViewModel
 class UsageGlanceViewModel @Inject constructor(
     private val fetcher: UsageFetcher,
+    private val connections: ConnectionsRegistry,
+    private val clients: HostCliClientFactory,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<UsageGlancePillState?>(null)
@@ -72,14 +86,61 @@ class UsageGlanceViewModel @Inject constructor(
 
     private var inFlight: Job? = null
 
-    fun refresh() {
+    /**
+     * One fetch round.
+     *
+     * With no arguments — the session tree's Usage affordance — the pill keeps
+     * its original cross-provider meaning. With both [hostId] and
+     * [sessionName] — the session screen — the round ALSO reads that host's
+     * session listing to find the open session's aplexer-detected agent, and
+     * focuses the pill on it when there is one.
+     *
+     * The two reads run concurrently: they are independent host round-trips on
+     * the same connection, and serialising them would put a second CLI
+     * round-trip in front of every session open.
+     */
+    fun refresh(hostId: Long? = null, sessionName: String? = null) {
         if (inFlight?.isActive == true) return
         inFlight = viewModelScope.launch {
-            val result = fetcher.fetchAll()
+            val (result, focus) = coroutineScope {
+                val usage = async { fetcher.fetchAll() }
+                val detected = async { detectFocus(hostId, sessionName) }
+                usage.await() to detected.await()
+            }
             _state.value = usageGlancePillState(
                 snapshots = result.snapshots,
                 warnPercent = UsageProviderRecord.DEFAULT_WARN_PERCENT,
+                focus = focus,
             )
         }
+    }
+
+    /**
+     * The open session's agent, as the HOST reported it — or null, meaning
+     * "no focus, show the ordinary pill".
+     *
+     * Null on every unremarkable path, deliberately: no session named
+     * (the tree), no live connection (D21 — the pill never dials), a tmux row
+     * (aplexer is the only manager that can see inside a session), no agent
+     * detected, or a host CLI too old to emit the field at all. The client
+     * never inspects the session itself; the ONLY source is
+     * `pocketshell sessions list --json`.
+     *
+     * A listing FAILURE is likewise not an error for the pill — it just means
+     * no focus. The usage numbers are already in hand at that point, and
+     * dropping the whole pill because a second, purely-decorative read failed
+     * would be a worse regression than showing the cross-provider number.
+     */
+    private suspend fun detectFocus(hostId: Long?, sessionName: String?): GlanceFocus? {
+        if (hostId == null || sessionName.isNullOrEmpty()) return null
+        val connection = connections.current(hostId) ?: return null
+        val listing = runCatching { clients.create(connection).listSessions() }
+            .getOrNull()
+            ?.getOrNull()
+            ?: return null
+        val row = listing.sessions.firstOrNull { it.name == sessionName } ?: return null
+        if (row.backend != Backend.APLEXER) return null
+        val agent = row.agent?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        return GlanceFocus(hostId = hostId, provider = agent)
     }
 }

--- a/app2/src/test/java/com/pocketshell/next/render/SessionTreeScreenRenders.kt
+++ b/app2/src/test/java/com/pocketshell/next/render/SessionTreeScreenRenders.kt
@@ -75,6 +75,7 @@ class SessionTreeScreenRenders {
                     tag = null,
                     engine = "claude",
                     profile = null,
+                    agent = null,
                     agentState = null,
                     agentStateSource = null,
                     attached = true,

--- a/app2/src/test/java/com/pocketshell/next/terminal/SessionScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/SessionScreenTest.kt
@@ -2,6 +2,7 @@ package com.pocketshell.next.terminal
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -123,6 +124,40 @@ class SessionScreenTest {
         composeRule.onNodeWithTag(USAGE_GLANCE_PILL_TAG).performClick()
 
         assertEquals(1, opened)
+    }
+
+    /**
+     * Issue #2579: on the session screen the pill is about THIS session's
+     * agent. A focused state carries no window, and the rendered chrome has to
+     * show exactly that — "Claude 38%", not "Claude 7d 38%". Asserting on the
+     * painted text (not on the data class) is the point: `attribution` is what
+     * the pill draws, and a regression that re-added the token would be
+     * invisible to a state-level assertion.
+     */
+    @Test
+    fun `a focused pill renders the provider and percent with no window token`() {
+        setContent(
+            SessionUiState.Connecting,
+            usagePillState = UsageGlancePillState(
+                percent = 38,
+                provider = "Claude",
+                window = null,
+                kind = PillKind.Ok,
+                stale = false,
+                fetchedClock = "13:40",
+            ),
+        )
+
+        composeRule.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("Claude").assertIsDisplayed()
+        composeRule.onNodeWithText("38%").assertIsDisplayed()
+        // The tokens the cross-provider pill would have shown must be absent.
+        composeRule.onNodeWithText("Claude 7d").assertDoesNotExist()
+        composeRule.onNodeWithText("7d").assertDoesNotExist()
+        composeRule.onNodeWithText("5h").assertDoesNotExist()
+        composeRule
+            .onNodeWithContentDescription("Usage Claude 38%")
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeScreenTest.kt
@@ -540,6 +540,7 @@ class SessionTreeScreenTest {
         tag = tag,
         engine = engine,
         profile = null,
+        agent = null,
         agentState = agentState,
         agentStateSource = agentStateSource,
         attached = attached,

--- a/app2/src/test/java/com/pocketshell/next/tree/TreeGroupingTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/TreeGroupingTest.kt
@@ -413,6 +413,7 @@ class TreeGroupingTest {
         tag = null,
         engine = null,
         profile = null,
+        agent = null,
         agentState = null as AgentState?,
         agentStateSource = null as AgentStateSource?,
         attached = false,

--- a/app2/src/test/java/com/pocketshell/next/usage/TestUsageStack.kt
+++ b/app2/src/test/java/com/pocketshell/next/usage/TestUsageStack.kt
@@ -6,11 +6,15 @@ import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.core.hostapi.HostCliClient
+import com.pocketshell.core.transport.ExecResult
 import com.pocketshell.core.transport.FakeHostConnection
 import com.pocketshell.core.usage.PocketshellUsageJsonParser
 import com.pocketshell.next.connect.ConnectionsRegistry
 import com.pocketshell.next.connect.FakeHostConnectionFactory
 import com.pocketshell.next.connect.RoomTrustStore
+import com.pocketshell.next.hostcli.HostCliClientFactory
+import com.pocketshell.next.hostcli.asRemoteExec
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
@@ -45,6 +49,24 @@ class TestUsageStack {
         parser = PocketshellUsageJsonParser(),
     )
 
+    /** The production binding, verbatim (see `AppModule.provideHostCliClientFactory`). */
+    val clients = HostCliClientFactory { connection -> HostCliClient(connection.asRemoteExec()) }
+
+    /**
+     * Exec rules applied to every connection the fake factory produces.
+     *
+     * The registry dials LAZILY, so a test cannot hold the connection and
+     * script it up front; each `script*` call appends a rule here and they are
+     * all applied at dial time. A list rather than one lambda because a
+     * session-focused pill test scripts TWO commands (`usage --json` and
+     * `sessions list --json`) and neither may clobber the other.
+     */
+    private val execRules = mutableListOf<(FakeHostConnection) -> Unit>()
+
+    init {
+        factory.script = { connection -> execRules.forEach { rule -> rule(connection) } }
+    }
+
     /** Inserts an `ssh_keys` row + a `hosts` row, returning the host id. */
     fun seedHost(name: String = "fixture"): Long = runBlocking {
         val keyId = db.sshKeyDao().insert(
@@ -66,11 +88,21 @@ class TestUsageStack {
 
     /** Scripts every future dial's `pocketshell usage --json` reply. */
     fun scriptUsage(stdout: String, exitCode: Int = 0, stderr: String = "") {
-        factory.script = { connection: FakeHostConnection ->
-            connection.onExec(
-                "pocketshell usage --json",
-                com.pocketshell.core.transport.ExecResult(exitCode, stdout, stderr, false),
-            )
+        script("pocketshell usage --json", stdout, exitCode, stderr)
+    }
+
+    /**
+     * Scripts every future dial's `pocketshell sessions list --json` reply —
+     * the listing [UsageGlanceViewModel] reads to find the open session's
+     * aplexer-detected agent (issue #2579).
+     */
+    fun scriptSessions(stdout: String, exitCode: Int = 0, stderr: String = "") {
+        script("pocketshell sessions list --json", stdout, exitCode, stderr)
+    }
+
+    private fun script(command: String, stdout: String, exitCode: Int, stderr: String) {
+        execRules += { connection: FakeHostConnection ->
+            connection.onExec(command, ExecResult(exitCode, stdout, stderr, false))
         }
     }
 

--- a/app2/src/test/java/com/pocketshell/next/usage/UsageGlancePillTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/usage/UsageGlancePillTest.kt
@@ -1,0 +1,385 @@
+package com.pocketshell.next.usage
+
+import com.pocketshell.core.usage.UsageProviderRecord
+import com.pocketshell.core.usage.UsageStatus
+import com.pocketshell.core.usage.UsageWindow
+import com.pocketshell.uikit.model.PillKind
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * [usageGlancePillState] — the pure derivation behind the terminal top bar's
+ * pill, with and without a [GlanceFocus] (issue #2579).
+ *
+ * The maintainer's report: a session running Claude Code showed "Grok 7d 83%".
+ * The pill was answering "how close is the nearest limit ANYWHERE", which is
+ * the tree's question, not the session's. On the session screen the question is
+ * "how close is the agent I am talking to", and the answer is that agent's
+ * LONGEST window with no window token — "Claude 38%".
+ *
+ * Every fallback path is pinned alongside it, because the focus must never be
+ * able to REMOVE a pill: an unknown host, a provider with no reading, and a
+ * blank provider name all have to land back on the old behaviour byte for byte.
+ */
+class UsageGlancePillTest {
+
+    // --- the focused pill --------------------------------------------------
+
+    /**
+     * The headline case, with the maintainer's own numbers: Claude's 5h bucket
+     * is more drained (40%) than its 7d one (38%), and the pill still shows the
+     * 7d number — "longest window", not "most constrained window".
+     */
+    @Test
+    fun `a focus shows the focused provider's longest window with no window token`() {
+        val pill = pill(
+            snapshots = mapOf(
+                HOST to records(
+                    claude(fiveHourPercent = 40.0, sevenDayPercent = 38.0),
+                    grok(sevenDayPercent = 83.0),
+                ),
+            ),
+            focus = GlanceFocus(HOST, "claude"),
+        )
+
+        assertNotNull(pill)
+        assertEquals(38, pill!!.percent)
+        assertEquals("Claude", pill.provider)
+        assertNull(pill.window)
+        // The rendered strings, not just the fields: "Claude 38%" is what the
+        // maintainer asked to see, and `attribution` is what the pill paints.
+        assertEquals("Claude", pill.attribution)
+        assertEquals("Claude 38%", pill.label)
+        assertEquals("Usage Claude 38%", pill.contentDescription)
+    }
+
+    /** Without the focus the SAME snapshot is the pre-#2579 pill, unchanged. */
+    @Test
+    fun `the same snapshot without a focus still reports the worst provider anywhere`() {
+        val snapshots = mapOf(
+            HOST to records(
+                claude(fiveHourPercent = 40.0, sevenDayPercent = 38.0),
+                grok(sevenDayPercent = 83.0),
+            ),
+        )
+
+        val pill = pill(snapshots = snapshots, focus = null)
+
+        assertNotNull(pill)
+        assertEquals(83, pill!!.percent)
+        assertEquals("Grok", pill.provider)
+        assertEquals("7d", pill.window)
+        assertEquals("Grok 7d 83%", pill.label)
+    }
+
+    /** A provider whose only long window is monthly reports the monthly one. */
+    @Test
+    fun `a monthly-only provider focuses on monthly, not on its 5h bucket`() {
+        val pill = pill(
+            snapshots = mapOf(
+                HOST to records(
+                    record(
+                        provider = "copilot",
+                        windows = listOf(window("5h", 0.0), window("monthly", 88.0)),
+                    ),
+                ),
+            ),
+            focus = GlanceFocus(HOST, "copilot"),
+        )
+
+        assertEquals(88, pill?.percent)
+        assertEquals("Copilot", pill?.provider)
+        assertNull(pill?.window)
+    }
+
+    /** The host's vocabulary is lowercase; a differently-cased focus still matches. */
+    @Test
+    fun `the provider match is case-insensitive`() {
+        val pill = pill(
+            snapshots = mapOf(HOST to records(claude(40.0, 38.0))),
+            focus = GlanceFocus(HOST, "Claude"),
+        )
+
+        assertEquals(38, pill?.percent)
+    }
+
+    /**
+     * The focus changes WHICH window is displayed, never whether the reading is
+     * honest about its age: a stale focused pill still says so and still
+     * carries the fetch clock.
+     */
+    @Test
+    fun `a focused pill keeps the staleness and the fetch clock`() {
+        val fetchedAt = Instant.parse("2026-09-06T10:15:00Z")
+        val pill = usageGlancePillState(
+            snapshots = mapOf(HOST to records(claude(40.0, 38.0), fetchedAt = fetchedAt)),
+            warnPercent = WARN,
+            focus = GlanceFocus(HOST, "claude"),
+            now = fetchedAt.plus(Duration.ofHours(1)),
+            zoneId = ZoneId.of("UTC"),
+        )
+
+        assertEquals(true, pill?.stale)
+        assertEquals("10:15", pill?.fetchedClock)
+        assertEquals("Usage Claude 38%, read at 10:15", pill?.contentDescription)
+    }
+
+    // --- severity ----------------------------------------------------------
+
+    /**
+     * A hard-blocked provider stays Blocked even when the window the pill
+     * DISPLAYS is comfortable. Claude's 5h bucket is exhausted, so the session
+     * cannot run; a green dot over "Claude 38%" would say the opposite.
+     */
+    @Test
+    fun `a blocked record is a Blocked pill regardless of the displayed percent`() {
+        val pill = pill(
+            snapshots = mapOf(
+                HOST to records(
+                    record(
+                        provider = "claude",
+                        status = UsageStatus.Blocked,
+                        windows = listOf(window("5h", 98.0), window("7d", 38.0)),
+                    ),
+                ),
+            ),
+            focus = GlanceFocus(HOST, "claude"),
+        )
+
+        assertEquals(38, pill?.percent)
+        assertEquals(PillKind.Blocked, pill?.kind)
+    }
+
+    /** A blocked provider that reports NO window at all still surfaces, at 100%. */
+    @Test
+    fun `a blocked record with no windows focuses at 100 percent`() {
+        val pill = pill(
+            snapshots = mapOf(
+                HOST to records(
+                    record(provider = "claude", status = UsageStatus.Blocked, windows = emptyList()),
+                ),
+            ),
+            focus = GlanceFocus(HOST, "claude"),
+        )
+
+        assertEquals(100, pill?.percent)
+        assertEquals(PillKind.Blocked, pill?.kind)
+        assertEquals("Claude 100%", pill?.label)
+    }
+
+    /**
+     * Severity otherwise describes the number NEXT TO IT. Claude's 5h bucket is
+     * at 90% (Approaching on its own) while the displayed 7d window is at 12%;
+     * an amber dot over "Claude 12%" would be just as misleading in reverse.
+     */
+    @Test
+    fun `an un-blocked record takes its severity from the displayed window`() {
+        val calm = pill(
+            snapshots = mapOf(
+                HOST to records(
+                    record(
+                        provider = "claude",
+                        windows = listOf(window("5h", 90.0), window("7d", 12.0)),
+                    ),
+                ),
+            ),
+            focus = GlanceFocus(HOST, "claude"),
+        )
+
+        assertEquals(12, calm?.percent)
+        assertEquals(PillKind.Ok, calm?.kind)
+
+        val warned = pill(
+            snapshots = mapOf(
+                HOST to records(
+                    record(
+                        provider = "claude",
+                        windows = listOf(window("5h", 5.0), window("7d", 87.0)),
+                    ),
+                ),
+            ),
+            focus = GlanceFocus(HOST, "claude"),
+        )
+
+        assertEquals(87, warned?.percent)
+        assertEquals(PillKind.Warn, warned?.kind)
+    }
+
+    // --- fallbacks ---------------------------------------------------------
+
+    /**
+     * The provider the session's agent maps to has no reading on this host —
+     * the user never bought that quota, or `quse` could not probe it. The pill
+     * must not vanish; it falls back to the cross-provider answer.
+     */
+    @Test
+    fun `a focus on a provider with no record on that host falls back`() {
+        val snapshots = mapOf(HOST to records(grok(sevenDayPercent = 83.0)))
+
+        val focused = pill(snapshots = snapshots, focus = GlanceFocus(HOST, "claude"))
+
+        assertEquals(pill(snapshots = snapshots, focus = null), focused)
+        assertEquals("Grok 7d 83%", focused?.label)
+    }
+
+    /**
+     * A record that exists but carries neither a window nor a block has no
+     * number to show. Painting a fake 0% would be worse than the honest
+     * cross-provider answer.
+     */
+    @Test
+    fun `a focus on a record with no windows and no block falls back`() {
+        val snapshots = mapOf(
+            HOST to records(
+                record(provider = "claude", status = UsageStatus.Unsupported, windows = emptyList()),
+                grok(sevenDayPercent = 83.0),
+            ),
+        )
+
+        assertEquals("Grok 7d 83%", pill(snapshots, GlanceFocus(HOST, "claude"))?.label)
+    }
+
+    /** A focus naming a host that produced no snapshot falls back. */
+    @Test
+    fun `a focus on an unknown host falls back`() {
+        val snapshots = mapOf(HOST to records(claude(40.0, 38.0), grok(83.0)))
+
+        assertEquals(
+            pill(snapshots, focus = null),
+            pill(snapshots, GlanceFocus(OTHER_HOST, "claude")),
+        )
+    }
+
+    /** A host that FAILED its usage read carries no records to focus on. */
+    @Test
+    fun `a focus on a host whose read failed falls back`() {
+        val snapshots = mapOf(
+            HOST to UsageSnapshot.Failed(HOST, "box", "not connected", FETCHED_AT),
+            OTHER_HOST to records(grok(83.0), hostId = OTHER_HOST),
+        )
+
+        assertEquals("Grok 7d 83%", pill(snapshots, GlanceFocus(HOST, "claude"))?.label)
+    }
+
+    /** A blank provider name is "the host said nothing", never a match attempt. */
+    @Test
+    fun `a focus with a blank provider falls back`() {
+        val snapshots = mapOf(HOST to records(grok(83.0)))
+
+        assertEquals(pill(snapshots, focus = null), pill(snapshots, GlanceFocus(HOST, "   ")))
+    }
+
+    /** With nothing readable at all, a focus cannot conjure a pill. */
+    @Test
+    fun `a focus over an empty snapshot map still hides the pill`() {
+        assertNull(pill(snapshots = emptyMap(), focus = GlanceFocus(HOST, "claude")))
+    }
+
+    // --- window spans ------------------------------------------------------
+
+    @Test
+    fun `window spans follow the producer's own vocabulary`() {
+        assertEquals(5, windowSpanHours("5h"))
+        assertEquals(24, windowSpanHours("1d"))
+        assertEquals(168, windowSpanHours("7d"))
+        assertEquals(168, windowSpanHours("weekly"))
+        assertEquals(720, windowSpanHours("monthly"))
+        assertEquals(720, windowSpanHours(" MONTHLY "))
+        // Unknown names score 0: they still compete, they just never outrank a
+        // span that is actually known.
+        assertEquals(0, windowSpanHours("short_term"))
+        assertEquals(0, windowSpanHours(""))
+        assertEquals(0, windowSpanHours(null))
+    }
+
+    /** `7d` and `weekly` are the same span; the producer's order breaks the tie. */
+    @Test
+    fun `equal spans keep the first window the host listed`() {
+        val pill = pill(
+            snapshots = mapOf(
+                HOST to records(
+                    record(
+                        provider = "claude",
+                        windows = listOf(window("7d", 38.0), window("weekly", 71.0)),
+                    ),
+                ),
+            ),
+            focus = GlanceFocus(HOST, "claude"),
+        )
+
+        assertEquals(38, pill?.percent)
+    }
+
+    /**
+     * A provider whose ONLY window has a name this build has never seen still
+     * gets a focused pill — scoring 0 means "unranked", not "ignored".
+     */
+    @Test
+    fun `a provider with only an unrecognised window still focuses on it`() {
+        val pill = pill(
+            snapshots = mapOf(
+                HOST to records(
+                    record(provider = "claude", windows = listOf(window("short_term", 44.0))),
+                ),
+            ),
+            focus = GlanceFocus(HOST, "claude"),
+        )
+
+        assertEquals(44, pill?.percent)
+        assertNull(pill?.window)
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private fun pill(
+        snapshots: Map<Long, UsageSnapshot>,
+        focus: GlanceFocus?,
+    ): UsageGlancePillState? = usageGlancePillState(
+        snapshots = snapshots,
+        warnPercent = WARN,
+        focus = focus,
+        now = FETCHED_AT,
+        zoneId = ZoneId.of("UTC"),
+    )
+
+    private fun records(
+        vararg records: UsageProviderRecord,
+        hostId: Long = HOST,
+        fetchedAt: Instant = FETCHED_AT,
+    ) = UsageSnapshot.Records(hostId, "box-$hostId", records.toList(), fetchedAt)
+
+    private fun record(
+        provider: String,
+        windows: List<UsageWindow>,
+        status: UsageStatus = UsageStatus.Ok,
+    ) = UsageProviderRecord(
+        provider = provider,
+        status = status,
+        windows = windows,
+        rawStatus = status.name.lowercase(),
+    )
+
+    /** `used` is already in percent units, exactly as the usage parser emits. */
+    private fun window(name: String, percent: Double) =
+        UsageWindow(name = name, used = percent, limit = 100.0, unit = "percent", resetAt = null)
+
+    private fun claude(fiveHourPercent: Double, sevenDayPercent: Double) = record(
+        provider = "claude",
+        windows = listOf(window("5h", fiveHourPercent), window("7d", sevenDayPercent)),
+    )
+
+    private fun grok(sevenDayPercent: Double) =
+        record(provider = "grok", windows = listOf(window("7d", sevenDayPercent)))
+
+    private companion object {
+        const val HOST = 7L
+        const val OTHER_HOST = 8L
+        const val WARN = UsageProviderRecord.DEFAULT_WARN_PERCENT
+        val FETCHED_AT: Instant = Instant.parse("2026-09-06T10:15:00Z")
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/usage/UsageGlanceViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/usage/UsageGlanceViewModelTest.kt
@@ -19,7 +19,15 @@ import org.junit.runner.RunWith
 /**
  * [UsageGlanceViewModel] — the terminal top bar's pill (task P-5). Pins that
  * it starts absent (no fetch has run), and that a real fetch round turns into
- * the single most-constraining [UsageGlancePillState] the pill paints.
+ * the [UsageGlancePillState] the pill paints.
+ *
+ * Issue #2579 added the session-scoped half: given a host and a session name,
+ * the round ALSO reads `pocketshell sessions list --json` over the connection
+ * the screen already holds and focuses the pill on that session's
+ * aplexer-detected agent. Every listing shape the host can answer with is
+ * driven here through the REAL [com.pocketshell.core.hostapi.HostCliClient]
+ * over a scripted connection — the parse is not stubbed, so a wire-format
+ * mistake fails here rather than on a device.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -35,7 +43,7 @@ class UsageGlanceViewModelTest {
 
     @Test
     fun `before any refresh the pill is absent, not a placeholder`() = vmTest { _ ->
-        val viewModel = UsageGlanceViewModel(stack!!.fetcher)
+        val viewModel = viewModel(stack!!)
 
         assertNull(viewModel.state.value)
     }
@@ -45,7 +53,7 @@ class UsageGlanceViewModelTest {
         val hostId = stack.seedHost("codex-box")
         stack.scriptUsage(CODEX_NEAR_LIMIT_NDJSON)
         stack.connect(hostId)
-        val viewModel = UsageGlanceViewModel(stack.fetcher)
+        val viewModel = viewModel(stack)
 
         viewModel.refresh()
         runCurrent()
@@ -60,13 +68,177 @@ class UsageGlanceViewModelTest {
     @Test
     fun `no connected hosts leaves the pill absent`() = vmTest { stack ->
         stack.seedHost()
-        val viewModel = UsageGlanceViewModel(stack.fetcher)
+        val viewModel = viewModel(stack)
 
         viewModel.refresh()
         runCurrent()
 
         assertNull(viewModel.state.value)
     }
+
+    // --- session-focused pill (issue #2579) -------------------------------
+
+    /**
+     * The maintainer's shape: an aplexer session whose workload is running
+     * Claude Code, on a host whose worst provider is Grok. Before #2579 the
+     * pill read "Grok 7d 83%" on that screen; it must now read "Claude 38%"
+     * — Claude's LONGEST window, no window token.
+     */
+    @Test
+    fun `an aplexer session with a detected agent focuses the pill on that agent`() =
+        vmTest { stack ->
+            val hostId = stack.seedHost("claude-box")
+            stack.scriptUsage(CLAUDE_AND_GROK_NDJSON)
+            stack.scriptSessions(sessionsListing(APLEXER_CLAUDE_ROW))
+            stack.connect(hostId)
+            val viewModel = viewModel(stack)
+
+            viewModel.refresh(hostId = hostId, sessionName = SESSION)
+            runCurrent()
+
+            val pill = viewModel.state.value
+            checkNotNull(pill) { "expected a pill state after a connected host's fetch" }
+            assertEquals("Claude", pill.provider)
+            assertEquals(38, pill.percent)
+            assertNull(pill.window)
+            assertEquals("Claude 38%", pill.label)
+        }
+
+    /**
+     * Same host, same usage numbers, same session name — but the row is tmux.
+     * tmux cannot see inside a session, so there is nothing to focus on and the
+     * pill keeps its cross-provider meaning.
+     */
+    @Test
+    fun `a tmux row yields the old worst-provider pill`() = vmTest { stack ->
+        val hostId = stack.seedHost("claude-box")
+        stack.scriptUsage(CLAUDE_AND_GROK_NDJSON)
+        stack.scriptSessions(sessionsListing(TMUX_ROW))
+        stack.connect(hostId)
+        val viewModel = viewModel(stack)
+
+        viewModel.refresh(hostId = hostId, sessionName = SESSION)
+        runCurrent()
+
+        assertEquals("Grok 7d 83%", viewModel.state.value?.label)
+    }
+
+    /** An aplexer session with no agent detected is likewise unfocused. */
+    @Test
+    fun `an aplexer row with a null agent yields the old worst-provider pill`() =
+        vmTest { stack ->
+            val hostId = stack.seedHost("claude-box")
+            stack.scriptUsage(CLAUDE_AND_GROK_NDJSON)
+            stack.scriptSessions(sessionsListing(APLEXER_NO_AGENT_ROW))
+            stack.connect(hostId)
+            val viewModel = viewModel(stack)
+
+            viewModel.refresh(hostId = hostId, sessionName = SESSION)
+            runCurrent()
+
+            assertEquals("Grok 7d 83%", viewModel.state.value?.label)
+        }
+
+    /**
+     * A host CLI old enough not to emit `agent` at all (the state of every
+     * installed host until #2581 ships). It must be indistinguishable from
+     * "no agent detected" — never a crash, never a missing pill.
+     */
+    @Test
+    fun `a host CLI that never emits the agent key yields the old pill`() = vmTest { stack ->
+        val hostId = stack.seedHost("claude-box")
+        stack.scriptUsage(CLAUDE_AND_GROK_NDJSON)
+        stack.scriptSessions(sessionsListing(APLEXER_OLD_CLI_ROW))
+        stack.connect(hostId)
+        val viewModel = viewModel(stack)
+
+        viewModel.refresh(hostId = hostId, sessionName = SESSION)
+        runCurrent()
+
+        assertEquals("Grok 7d 83%", viewModel.state.value?.label)
+    }
+
+    /**
+     * The listing is a decoration on top of numbers already in hand. A failed
+     * listing therefore costs the FOCUS, not the pill — dropping the whole pill
+     * because a second read failed would be a worse regression than showing the
+     * cross-provider number (this is issue #2532's lesson, re-applied).
+     */
+    @Test
+    fun `a failed sessions listing still leaves the old pill, not an absent one`() =
+        vmTest { stack ->
+            val hostId = stack.seedHost("claude-box")
+            stack.scriptUsage(CLAUDE_AND_GROK_NDJSON)
+            stack.scriptSessions(stdout = "", exitCode = 127, stderr = "sh: pocketshell: not found")
+            stack.connect(hostId)
+            val viewModel = viewModel(stack)
+
+            viewModel.refresh(hostId = hostId, sessionName = SESSION)
+            runCurrent()
+
+            assertEquals("Grok 7d 83%", viewModel.state.value?.label)
+        }
+
+    /** A session name that is not in the listing at all is simply not focusable. */
+    @Test
+    fun `a session the host does not list yields the old pill`() = vmTest { stack ->
+        val hostId = stack.seedHost("claude-box")
+        stack.scriptUsage(CLAUDE_AND_GROK_NDJSON)
+        stack.scriptSessions(sessionsListing(APLEXER_CLAUDE_ROW))
+        stack.connect(hostId)
+        val viewModel = viewModel(stack)
+
+        viewModel.refresh(hostId = hostId, sessionName = "some-other-session")
+        runCurrent()
+
+        assertEquals("Grok 7d 83%", viewModel.state.value?.label)
+    }
+
+    /**
+     * The tree's Usage affordance keeps calling the no-argument overload, and
+     * must keep the cross-provider meaning even when the host WOULD have
+     * reported a focusable agent.
+     */
+    @Test
+    fun `the no-argument refresh never focuses, even when the host could`() = vmTest { stack ->
+        val hostId = stack.seedHost("claude-box")
+        stack.scriptUsage(CLAUDE_AND_GROK_NDJSON)
+        stack.scriptSessions(sessionsListing(APLEXER_CLAUDE_ROW))
+        stack.connect(hostId)
+        val viewModel = viewModel(stack)
+
+        viewModel.refresh()
+        runCurrent()
+
+        assertEquals("Grok 7d 83%", viewModel.state.value?.label)
+    }
+
+    /**
+     * D21: the pill never dials. A host the registry holds no live connection
+     * for is not asked for a listing, so the focus is absent — and, with no
+     * connection, so is every reading, so the pill stays hidden.
+     */
+    @Test
+    fun `a disconnected host is never dialed just to resolve a focus`() = vmTest { stack ->
+        val hostId = stack.seedHost("claude-box")
+        stack.scriptUsage(CLAUDE_AND_GROK_NDJSON)
+        stack.scriptSessions(sessionsListing(APLEXER_CLAUDE_ROW))
+        val viewModel = viewModel(stack)
+
+        viewModel.refresh(hostId = hostId, sessionName = SESSION)
+        runCurrent()
+
+        assertNull(viewModel.state.value)
+        assertEquals(0, stack.factory.dialCount)
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private fun viewModel(stack: TestUsageStack) = UsageGlanceViewModel(
+        fetcher = stack.fetcher,
+        connections = stack.registry,
+        clients = stack.clients,
+    )
 
     private fun vmTest(body: suspend TestScope.(TestUsageStack) -> Unit) = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
@@ -76,6 +248,10 @@ class UsageGlanceViewModelTest {
         body(stack)
     }
 
+    /** A schema-2 `sessions list --json` document holding exactly [row]. */
+    private fun sessionsListing(row: String): String =
+        """{"schema": 2, "managers": ["tmux", "aplexer"], "sessions": [$row], "errors": []}"""
+
     private companion object {
         // percent_remaining 9 -> 91% used, above WARN_PERCENT(85) and below
         // CRITICAL_PERCENT(95) -> Approaching -> the pill's Warn kind.
@@ -83,5 +259,45 @@ class UsageGlanceViewModelTest {
             "{\"provider\":\"codex\",\"status\":\"ok\"," +
                 "\"windows\":{\"7d\":{\"percent_remaining\":9.0,\"reset_at\":null}}," +
                 "\"block_reason\":null,\"error\":null,\"details\":{}}"
+
+        const val SESSION = "git-pocketshell"
+
+        /**
+         * The maintainer's numbers (#2579): Claude 5h at 40% used and 7d at
+         * 38% used, on a box whose Grok 7d is the worst reading anywhere. The
+         * unfocused pill is therefore "Grok 7d 83%" and the focused one is
+         * "Claude 38%" — the two answers can never be confused.
+         */
+        const val CLAUDE_AND_GROK_NDJSON =
+            "{\"provider\":\"claude\",\"status\":\"ok\",\"windows\":{" +
+                "\"5h\":{\"percent_remaining\":60.0,\"reset_at\":null}," +
+                "\"7d\":{\"percent_remaining\":62.0,\"reset_at\":null}}," +
+                "\"block_reason\":null,\"error\":null,\"details\":{}}\n" +
+                "{\"provider\":\"grok\",\"status\":\"ok\",\"windows\":{" +
+                "\"7d\":{\"percent_remaining\":17.0,\"reset_at\":null}}," +
+                "\"block_reason\":null,\"error\":null,\"details\":{}}"
+
+        /**
+         * `engine` says "shell" and `agent` says "claude" — the real shape of
+         * every aplexer session on the maintainer's box, and the reason the
+         * client cannot answer this question from `engine`.
+         */
+        const val APLEXER_CLAUDE_ROW =
+            "{\"name\": \"$SESSION\", \"manager\": \"aplexer\", \"attached\": true, " +
+                "\"engine\": \"shell\", \"agent\": \"claude\"}"
+
+        const val APLEXER_NO_AGENT_ROW =
+            "{\"name\": \"$SESSION\", \"manager\": \"aplexer\", \"attached\": true, " +
+                "\"engine\": \"shell\", \"agent\": null}"
+
+        /** No `agent` key at all: a host CLI predating #2581. */
+        const val APLEXER_OLD_CLI_ROW =
+            "{\"name\": \"$SESSION\", \"manager\": \"aplexer\", \"attached\": true, " +
+                "\"engine\": \"shell\"}"
+
+        /** tmux never reports an agent, so this row carries the key as null. */
+        const val TMUX_ROW =
+            "{\"name\": \"$SESSION\", \"manager\": \"tmux\", \"attached\": true, " +
+                "\"agent\": null}"
     }
 }

--- a/scripts/journey-quarantine.txt
+++ b/scripts/journey-quarantine.txt
@@ -25,3 +25,4 @@
 # fixed or removed) or by RE-TRIAGING it (a fresh `added`/`expires` in both
 # places, and a reason that says why it is still broken) — never let a row sit
 # expired.
+com.pocketshell.next.usage.J12UsagePanelJourney#theSessionPillFocusesTheSessionsDetectedAgentAndDropsTheWindowToken	2586	2026-09-06	2026-09-20	the Docker agents fixture's `sessions list` arm reads aplexer rows from ~/.pocketshell-fixture-aplexer.json instead of enumerating live ones, so the app cannot see the real aplexer session this journey creates; #2586 fixes that. Also waiting on the fixture's aplexer 0.1.3 pin, which emits no `agent` key (#2580 detection, #2581 CLI pass-through + pin bump).

--- a/scripts/test-journey-quarantine-non-blocking.sh
+++ b/scripts/test-journey-quarantine-non-blocking.sh
@@ -67,7 +67,41 @@ run_guard() {  # against the sandbox root + the real list
 # must be a real journey class (so the guard's registry accepts it) that the
 # shipped list does NOT quarantine, so a planted annotation is genuinely
 # untracked.
-FIXTURE_CLASS="com.pocketshell.next.usage.J12UsagePanelJourney"
+#
+# CHOSEN FROM THE TREE, NEVER HARD-CODED. A pinned class name is the same
+# "incidental dependency on what the shipped tree happens to contain" trap the
+# planting helper below documents, just pointing the other way: the day that one
+# class gets quarantined for real, its fixture assumption breaks and this whole
+# self-test hard-fails on a tree the guard is perfectly happy with. That is
+# exactly what happened when J12UsagePanelJourney — the previous hard-coded
+# value — was quarantined on #2586. Pick the first class (sorted, so the choice
+# is deterministic and the failure message reproducible) that carries a
+# plantable `@Test` and that no row in the shipped list names.
+quarantined_classes() {
+  grep -vE '^[[:space:]]*(#|$)' "$QUARANTINE_LIST" | cut -f1 | sed 's/#.*$//' |
+    LC_ALL=C sort -u
+}
+
+pick_fixture_class() {
+  local excluded f rel fqcn
+  excluded="$(quarantined_classes)"
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    # The planter matches this exact line, so a class without it is unusable.
+    grep -qxF '    @Test' "$f" || continue
+    rel="${f#"$REAL_ROOT"/}"
+    rel="${rel#java/}"; rel="${rel#kotlin/}"; rel="${rel%.kt}"
+    fqcn="${rel//\//.}"
+    if [[ -n "$excluded" ]] && grep -qxF "$fqcn" <<<"$excluded"; then
+      continue
+    fi
+    printf '%s\n' "$fqcn"
+    return 0
+  done < <(find "$REAL_ROOT" -type f -name '*.kt' 2>/dev/null | LC_ALL=C sort)
+  return 1
+}
+
+FIXTURE_CLASS="$(pick_fixture_class)" || fail "no unquarantined journey class with a plantable @Test under $REAL_ROOT — cases (c) and (d) cannot be built"
 
 # Plants `@Ignore("silently parked")` on the first @Test method of
 # $FIXTURE_CLASS in the SANDBOX copy and echoes the method name it annotated.

--- a/shared/core-hostapi/src/main/java/com/pocketshell/core/hostapi/SessionRow.kt
+++ b/shared/core-hostapi/src/main/java/com/pocketshell/core/hostapi/SessionRow.kt
@@ -17,6 +17,25 @@ data class SessionRow(
     val tag: String?,
     val engine: String?,
     val profile: String?,
+    /**
+     * Which agent aplexer detected RUNNING inside this session's workload
+     * ("claude", "codex", "opencode", "grok"), lowercase, verbatim off the
+     * wire (issue #2579).
+     *
+     * Distinct from [engine], which is only what the session was STARTED as:
+     * every aplexer session on the maintainer's box is `engine: "shell"`
+     * (`a start … -- /bin/bash -l`) with the agent launched inside it
+     * afterwards, so [engine] answers nothing about what is running now.
+     * aplexer owns the workload process tree, so it is the one place that can
+     * answer; the client never probes for this itself.
+     *
+     * `null` means the host reported no agent — a tmux row (always null), an
+     * aplexer session with no known agent among its workload's descendants,
+     * or, importantly, a host CLI old enough not to emit the key at all. All
+     * three collapse to "no focus" at the call site, so an older host keeps
+     * working unchanged.
+     */
+    val agent: String?,
     val agentState: AgentState?,
     val agentStateSource: AgentStateSource?,
     val attached: Boolean,

--- a/shared/core-hostapi/src/main/java/com/pocketshell/core/hostapi/SessionsJson.kt
+++ b/shared/core-hostapi/src/main/java/com/pocketshell/core/hostapi/SessionsJson.kt
@@ -19,6 +19,10 @@ import kotlinx.serialization.json.intOrNull
  * - An unrecognised `manager` keeps the row with [Backend.UNKNOWN]; an
  *   unrecognised `agent_state` / `agent_state_source` keeps the row with a
  *   `null` state. Forward compatibility never costs a row.
+ * - `agent` is carried through verbatim (issue #2579) — no enum, no
+ *   normalisation beyond trimming — because the vocabulary belongs to
+ *   aplexer's detector on the host. Missing, null or blank all become
+ *   `null`, so a host CLI that predates the key parses exactly as before.
  * - `errors[]` is mapped verbatim onto [SessionsListing.errors] and never
  *   dropped, even when it is the only thing in the document.
  * - Anything genuinely unreadable — non-JSON, a non-object root, a missing
@@ -122,6 +126,12 @@ object SessionsJson {
         val tag: String? = null,
         val engine: String? = null,
         val profile: String? = null,
+        /**
+         * `agent` (issue #2579). Absent OR explicitly null both decode to
+         * null, which is what keeps a host CLI predating the key working —
+         * the client's only reaction to null is "no agent focus".
+         */
+        val agent: String? = null,
         @SerialName("agent_state") val agentState: String? = null,
         @SerialName("agent_state_source") val agentStateSource: String? = null,
         @SerialName("created_epoch") val createdEpoch: Long? = null,
@@ -135,6 +145,10 @@ object SessionsJson {
             tag = tag,
             engine = engine,
             profile = profile,
+            // Verbatim, only trimmed/blank-collapsed: the vocabulary is the
+            // HOST's (aplexer's detector), so an unrecognised value must reach
+            // the caller intact rather than be mapped to an enum here and lost.
+            agent = agent?.trim()?.takeIf { it.isNotEmpty() },
             agentState = AgentState.fromWire(agentState),
             agentStateSource = AgentStateSource.fromWire(agentStateSource),
             attached = attached,

--- a/shared/core-hostapi/src/test/java/com/pocketshell/core/hostapi/SessionsJsonEdgeCaseTest.kt
+++ b/shared/core-hostapi/src/test/java/com/pocketshell/core/hostapi/SessionsJsonEdgeCaseTest.kt
@@ -221,6 +221,7 @@ class SessionsJsonEdgeCaseTest {
                 tag = null,
                 engine = null,
                 profile = null,
+                agent = null,
                 agentState = null,
                 agentStateSource = null,
                 attached = false,
@@ -229,5 +230,52 @@ class SessionsJsonEdgeCaseTest {
             ),
             row,
         )
+    }
+
+    // --- `agent` (issue #2579) --------------------------------------------
+
+    /**
+     * The three shapes a host can send for `agent`, all on the SAME parse so
+     * one lenient default cannot mask another: a row from a host CLI that
+     * never heard of the key, a row that reports it as an explicit null, and
+     * a row naming an agent this client build has never heard of.
+     *
+     * The unknown string is kept VERBATIM rather than mapped to an enum: the
+     * vocabulary belongs to aplexer's detector on the host, and a client that
+     * folded an unrecognised value to null would silently lose a focus the
+     * host had already resolved.
+     */
+    @Test
+    fun `agent is absent, null and unknown-string tolerant`() {
+        val raw = """
+            {"schema": 2, "sessions": [
+              {"name": "old-cli", "manager": "aplexer", "attached": false},
+              {"name": "explicit-null", "manager": "aplexer", "attached": false, "agent": null},
+              {"name": "blank", "manager": "aplexer", "attached": false, "agent": "  "},
+              {"name": "unknown", "manager": "aplexer", "attached": false, "agent": "mystery-9"},
+              {"name": "padded", "manager": "aplexer", "attached": false, "agent": " claude "}
+            ]}
+        """.trimIndent()
+
+        val rows = SessionsJson.parseSessionsList(raw).getOrThrow().sessions
+            .associateBy { it.name }
+
+        assertEquals(5, rows.size)
+        assertNull(rows.getValue("old-cli").agent)
+        assertNull(rows.getValue("explicit-null").agent)
+        // A blank string is "the host said nothing", not an agent named "".
+        assertNull(rows.getValue("blank").agent)
+        assertEquals("mystery-9", rows.getValue("unknown").agent)
+        assertEquals("claude", rows.getValue("padded").agent)
+    }
+
+    /** A non-string `agent` is a real defect, not something to shrug off. */
+    @Test
+    fun `a non-string agent fails the parse instead of silently nulling`() {
+        val raw =
+            """{"schema": 2, "sessions": [{"name": "s", "manager": "aplexer", """ +
+                """"attached": false, "agent": 7}]}"""
+
+        assertTrue(SessionsJson.parseSessionsList(raw).exceptionOrNull() is HostCliError.Malformed)
     }
 }

--- a/shared/core-hostapi/src/test/java/com/pocketshell/core/hostapi/SessionsJsonRealCaptureTest.kt
+++ b/shared/core-hostapi/src/test/java/com/pocketshell/core/hostapi/SessionsJsonRealCaptureTest.kt
@@ -61,6 +61,7 @@ class SessionsJsonRealCaptureTest {
                 tag = null,
                 engine = null,
                 profile = null,
+                agent = null,
                 agentState = null,
                 agentStateSource = null,
                 attached = true,
@@ -84,6 +85,7 @@ class SessionsJsonRealCaptureTest {
                 tag = "zsp",
                 engine = "claude",
                 profile = "zlaude",
+                agent = null,
                 agentState = AgentState.WAITING,
                 agentStateSource = AgentStateSource.HEURISTIC,
                 attached = false,
@@ -113,6 +115,69 @@ class SessionsJsonRealCaptureTest {
         assertEquals(listOf("git-pocketshell-2"), attached.map { it.name })
     }
 
+    /**
+     * The capture predates the `agent` key entirely (issue #2579): it was
+     * taken off a host CLI that never emitted it. That is precisely the
+     * "older host CLI keeps working" case, so it is pinned HERE, on a
+     * genuine old payload, rather than only on a hand-built fixture.
+     */
+    @Test
+    fun `a capture from a host CLI predating the agent key parses with a null agent`() {
+        val listing = listing()
+
+        assertTrue(listing.sessions.isNotEmpty())
+        assertTrue(listing.sessions.all { it.agent == null })
+        // Not a null-everything parse: the aplexer rows still carry engines.
+        assertEquals(
+            listOf("codex", "codex", "claude", "grok"),
+            listing.sessions.filter { it.backend == Backend.APLEXER }.map { it.engine },
+        )
+    }
+
+    // --- the agent-carrying capture ---------------------------------------
+
+    private fun agentListing(): SessionsListing =
+        SessionsJson.parseSessionsList(fixture("sessions-list-agent.json")).getOrThrow()
+
+    /**
+     * The shape the maintainer's box emits once aplexer detects the workload's
+     * agent (#2579/#2580): `engine` says "shell" — the session was started as
+     * `a start … -- /bin/bash -l` — while `agent` says "claude". A client that
+     * read `engine` to answer "which agent" would get the wrong answer here,
+     * which is the whole reason the field exists.
+     */
+    @Test
+    fun `an agent-carrying aplexer row maps agent independently of engine`() {
+        val row = agentListing().sessions.single { it.name == "pocketshell:git-pocketshell" }
+
+        assertEquals(
+            SessionRow(
+                name = "pocketshell:git-pocketshell",
+                backend = Backend.APLEXER,
+                id = "b31c7f21-4b40-4a1e-8d0f-4b2f5c9e77aa",
+                workspace = "/home/alexey/git/pocketshell",
+                tag = "git-pocketshell",
+                engine = "shell",
+                profile = null,
+                agent = "claude",
+                agentState = AgentState.WORKING,
+                agentStateSource = AgentStateSource.HEURISTIC,
+                attached = true,
+                createdEpoch = 1788381061L,
+                activityEpoch = 1788409253L,
+            ),
+            row,
+        )
+    }
+
+    @Test
+    fun `agent stays null for a tmux row and for an aplexer row with no detection`() {
+        val listing = agentListing()
+
+        assertNull(listing.sessions.single { it.name == "git-pocketshell" }.agent)
+        assertNull(listing.sessions.single { it.name == "aplexer-follow:idle" }.agent)
+    }
+
     @Test
     fun `real tmux rows carry no agent metadata at all`() {
         val tmuxRows = listing().sessions.filter { it.backend == Backend.TMUX }
@@ -122,6 +187,7 @@ class SessionsJsonRealCaptureTest {
         assertTrue(tmuxRows.all { it.tag == null })
         assertTrue(tmuxRows.all { it.engine == null })
         assertTrue(tmuxRows.all { it.profile == null })
+        assertTrue(tmuxRows.all { it.agent == null })
         assertTrue(tmuxRows.all { it.agentState == null })
         assertTrue(tmuxRows.all { it.agentStateSource == null })
         // ...but they do carry timestamps, so a null-everything bug can't hide

--- a/shared/core-hostapi/src/test/resources/fixtures/sessions-list-agent.json
+++ b/shared/core-hostapi/src/test/resources/fixtures/sessions-list-agent.json
@@ -1,0 +1,55 @@
+{
+  "schema": 2,
+  "managers": [
+    "tmux",
+    "aplexer"
+  ],
+  "sessions": [
+    {
+      "name": "git-pocketshell",
+      "manager": "tmux",
+      "id": null,
+      "workspace": "/home/alexey/git/pocketshell",
+      "tag": null,
+      "engine": null,
+      "profile": null,
+      "agent": null,
+      "agent_state": null,
+      "agent_state_source": null,
+      "attached": false,
+      "created_epoch": 1788159369,
+      "activity_epoch": 1788381055
+    },
+    {
+      "name": "pocketshell:git-pocketshell",
+      "manager": "aplexer",
+      "id": "b31c7f21-4b40-4a1e-8d0f-4b2f5c9e77aa",
+      "workspace": "/home/alexey/git/pocketshell",
+      "tag": "git-pocketshell",
+      "engine": "shell",
+      "profile": null,
+      "agent": "claude",
+      "agent_state": "working",
+      "agent_state_source": "heuristic",
+      "attached": true,
+      "created_epoch": 1788381061,
+      "activity_epoch": 1788409253
+    },
+    {
+      "name": "aplexer-follow:idle",
+      "manager": "aplexer",
+      "id": "52a2508e-c902-4bd6-9ea8-dd3668381749",
+      "workspace": "/tmp/aplexer-follow",
+      "tag": "idle",
+      "engine": "shell",
+      "profile": null,
+      "agent": null,
+      "agent_state": null,
+      "agent_state_source": null,
+      "attached": false,
+      "created_epoch": 1787765485,
+      "activity_epoch": 1787838957
+    }
+  ],
+  "errors": []
+}


### PR DESCRIPTION
Closes #2582 (child of #2579). Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2582#issuecomment-5560586726

## What

On the session screen the glance pill showed the worst window across all providers ("Grok 7d 83%" on a Claude session, see #2579's screenshot). Now `UsageGlanceViewModel.refresh(hostId, sessionName)` reads `sessions list --json` over the existing connection concurrently with the usage round; when the row is an aplexer session with a detected `agent` and the host has a usage record for that provider, the pill shows that provider's longest window with a reading, no window token ("Claude 38%"). Every other case falls back to the old pill; the tree is untouched; the app never contacts aplexer. `SessionRow.agent` added to core-hostapi (older host CLI still parses).

## Evidence (reviewer's own run)

- core-hostapi 110/110, app2 988/988 unfiltered; `UsageGlancePillTest` 17, `UsageGlanceViewModelTest` 11.
- Three red→green probes: ignoring `focus` → 7 focus failures only; not reading `agent` → hostapi + the VM chain test; `detectFocus` null → the one VM focus test. Fallback cases asserted equal to the no-focus state.
- Journey `J12UsagePanelJourney#theSessionPillFocusesTheSessionsDetectedAgentAndDropsTheWindowToken` is written against the real fixture `a`, asserts "Usage Claude 60%" (a fallback pill there reads "Usage Claude 5h 98%", so it cannot pass vacuously), and is quarantined on #2586 (fixture lists no live aplexer row; #2581 pin bump is the other blocker), expiry 2026-09-20.

## Not closed by this PR

The maintainer's screenshot needs #2581 (CLI emits `agent`, aplexer 0.1.4 pin) on the host as well; #2579 stays open until the journey runs green after #2586.