### PR TITLE
cli: pass aplexer's detected agent through sessions list, pin aplexer 0.1.4

### DIFF
--- a/docs/aplexer-integration.md
+++ b/docs/aplexer-integration.md
@@ -36,7 +36,7 @@ aplexer is **not installed separately**. `tools/pocketshell/pyproject.toml`
 carries a pinned, Linux-marked hard dependency:
 
 ```toml
-"aplexer==0.1.3; sys_platform == 'linux'"
+"aplexer==0.1.4; sys_platform == 'linux'"
 ```
 
 so the documented host install — `uv tool install pocketshell` — also delivers
@@ -138,9 +138,14 @@ BEHAVIOUR the CLI depends on:
   `sessions._aplexer_snapshot` driving the real binary, and by a concurrent
   `a start` (see "0.1.3" below).
 
+- a real session whose workload shell spawns a process named `claude`
+  reports `agent: "claude"` on `a --json list` **and** `a --json snapshot`,
+  and reports `null` again once that process exits (see "0.1.4" below).
+
 Those assertions were verified to fail against published 0.1.1 and pass
-against 0.1.2 (the `executable` / shell-env pair), and to fail against 0.1.2
-and pass against 0.1.3 (the registry-scan trio). **Re-run that file whenever
+against 0.1.2 (the `executable` / shell-env pair), to fail against 0.1.2
+and pass against 0.1.3 (the registry-scan trio), and to fail against 0.1.3 and
+pass against 0.1.4 (the `agent` field). **Re-run that file whenever
 the pin moves** — it is what a bump has to re-verify, in place of a version
 check that cannot see the difference.
 
@@ -181,6 +186,52 @@ error, `_aplexer_snapshot` is not `None`, a live session stays listed, and a
 second `a start` still succeeds. Verified red on published 0.1.2, green on
 0.1.3.
 
+### 0.1.4 — the session tree can say WHICH agent is running
+
+Issue #2581 (slice 2 of #2579). Through 0.1.3 the only agent-ish field on a
+snapshot row was `engine`, and `engine` cannot answer the question. Every
+session PocketShell creates is `engine: "shell"` with the agent started by
+hand inside it, so `engine` is `null` on exactly the rows a user would call
+"my claude session" — a tree of claude/codex/opencode sessions was
+indistinguishable from a tree of bare shells.
+
+0.1.4 (aplexer `ca56fa5`, spec.md §18, `src/agent_kind.rs`) adds a derived
+`agent` field: `claude`, `codex`, `opencode`, `grok`, or `null`. Three
+properties matter to this CLI:
+
+- **Derived at query time, never persisted.** aplexer walks the workload's
+  descendant process tree (`workload_pid` plus `/proc/<pid>/task/*/children`,
+  the same walk containment uses) on every `a list --json` / `a snapshot` /
+  `a status --json`, and classifies each process's `comm`/`cmdline` by
+  whole-word command token — the same rule as
+  `cgroup_agents.py`/`AgentDetector.namesAgent`, so `node /…/bin/codex` names
+  codex while `codex-helper` in an unrelated path does not. Because nothing is
+  written to disk, the value cannot go stale; it goes back to `null` the
+  moment the agent exits.
+- **The key is always present**, so a consumer reads it unconditionally.
+- **A terminal-phase record is never probed** — its `workload_pid` names a
+  dead process and a recycled pid must not resurrect an agent.
+
+Host side, `session_enum._aplexer_rows` reads it onto `LiveSession.agent` and
+schema 2 emits it on every row (`null` for tmux rows, which have no workload
+pid to walk). An older `a` simply omits the key, which reads as `null`, never
+a `KeyError` — the pin is a floor, not a promise about the binary a given host
+happens to be running.
+
+Pinned behaviour, in `test_aplexer_contract.py`: a real session started on the
+`shell` engine (the production shape) reports `agent: null` while idle,
+`"claude"` while a live process named `claude` runs in its descendant tree,
+and `null` again once that process is killed — asserted on the raw `a` output
+**and** on the schema-2 payload `session_enum._probe_aplexer` produces from
+it. Verified red on published 0.1.3 (no `agent` key at all), green on 0.1.4.
+
+The Docker `agents` fixture needs no separate bump: `tests/docker/
+Dockerfile.agents` derives the aplexer release it downloads from this same
+`aplexer==X.Y.Z` pin, which `tests/test_agents_fixture_aplexer.py` enforces.
+The consequence is an ordering constraint, not an edit — the pin may only move
+after the matching GitHub release assets (`a-linux-{amd64,arm64}`,
+`aplexer-linux-{amd64,arm64}`) are published, or every image rebuild 404s.
+
 ### Lock cutoff
 
 `[tool.uv] exclude-newer` in `tools/pocketshell/pyproject.toml` (mirrored in
@@ -188,9 +239,10 @@ second `a start` still succeeds. Verified red on published 0.1.2, green on
 package uploaded *after* it is simply invisible to `uv lock` — which looks
 like a broken index rather than a stale cutoff. So it moves in lock-step with
 every new pin: past quse 0.0.15 (#2293), then past aplexer 0.1.2's
-2026-09-05T22:38:08Z upload (#2543), now past aplexer 0.1.3's
+2026-09-05T22:38:08Z upload (#2543), then past aplexer 0.1.3's
 2026-09-06T00:32:09Z upload (its `aplexer-client` runtime dependency landed at
-00:32:04Z). Bump both places together, or `uv lock --check` fails.
+00:32:04Z), now past aplexer 0.1.4's 2026-09-06T16:14:52Z upload
+(`aplexer-client` at 16:14:48Z) for #2581. Bump both places together, or `uv lock --check` fails.
 
 Two host-level traps when re-locking: this box carries a rolling global
 `exclude-newer = "7 days"` in `~/.config/uv/uv.toml`, so a local `uv lock` /

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,11 +210,23 @@ user-controlled argument goes through `shellSingleQuote` and option lists are
 terminated with `--`.
 
 `sessions list --json` schema 2 rows carry `{name, manager, id, workspace, tag,
-engine, profile, agent_state, agent_state_source, attached, created_epoch,
-activity_epoch, phase, alive}` plus a first-class `errors[]` array. A backend
+engine, profile, agent, agent_state, agent_state_source, attached,
+created_epoch, activity_epoch, phase, alive}` plus a first-class `errors[]`
+array. A backend
 that fails to enumerate **must** appear in `errors` rather than silently
 shortening the list; the tree renders that as a "some sessions may be missing"
 banner.
+
+`agent` names WHICH coding agent is running inside the session — `claude`,
+`codex`, `opencode`, `grok`, or `null` (#2581). It is not a restatement of
+`engine`: every session PocketShell creates is `engine: "shell"` with the agent
+started by hand inside it, so `engine` is `null` for exactly the rows a user
+would call "my claude session". aplexer 0.1.4 derives it per query by walking
+the workload's descendant process tree and classifying each `comm`/`cmdline`
+by whole-word command token; nothing is persisted, so it cannot go stale. tmux
+rows are always `null` (no workload pid to walk, and the host must not guess
+one from the session name), and an aplexer older than 0.1.4 omits the key
+entirely, which the host reads as `null` rather than an error.
 
 `phase`/`alive` are the liveness pair (#2554). aplexer keeps a session record
 after the session dies — a killed one stays at `phase: exited` forever, and a

--- a/docs/rewrite-diagnosis-and-design.md
+++ b/docs/rewrite-diagnosis-and-design.md
@@ -302,7 +302,8 @@ Python that already probes both managers):
 
 - `pocketshell sessions list --json` → rows
   `{name, manager: "tmux"|"aplexer", id, workspace, tag, engine, profile,
-  agent_state, agent_state_source, attached, created_epoch, activity_epoch}`
+  agent, agent_state, agent_state_source, attached, created_epoch,
+  activity_epoch}` (`agent` added later, issue #2581)
   plus a first-class `errors` array (a backend that fails to enumerate MUST
   surface there, never silently shrink the list — the #2426 fix as contract).
   This command **already exists and already unions both managers**

--- a/docs/rewrite-implementation-plan.md
+++ b/docs/rewrite-implementation-plan.md
@@ -372,6 +372,7 @@ Extends the EXISTING payload (`session_enum.py:245 json_payload`,
       "tag": null,
       "engine": "claude",
       "profile": "zai",
+      "agent": null,
       "agent_state": null,
       "agent_state_source": null,
       "attached": true,
@@ -386,6 +387,7 @@ Extends the EXISTING payload (`session_enum.py:245 json_payload`,
       "tag": "review",
       "engine": "codex",
       "profile": null,
+      "agent": "codex",
       "agent_state": "waiting",
       "agent_state_source": "reported",
       "attached": false,
@@ -405,6 +407,12 @@ Field rules:
 - `workspace`: absolute path string or `null` (tmux rows: `session_path` from the
   enrichment sweep; aplexer rows: record field).
 - `engine`: engine id string or `null` (= plain shell).
+- `agent`: `"claude" | "codex" | "opencode" | "grok" | null` — WHICH agent is
+  running inside the session, as aplexer 0.1.4 detects it from the workload's
+  descendant process tree (added after this plan, issue #2581). Not derivable
+  from `engine`: a PocketShell-created session is `engine: "shell"` with the
+  agent launched by hand inside it. `null` for `manager:"tmux"` rows and for
+  an aplexer older than 0.1.4, which omits the key.
 - `agent_state`: `"idle" | "waiting" | "working" | null`;
   `agent_state_source`: `"reported" | "heuristic" | null`. For `manager:"tmux"`
   both are `null` until APX-ADOPT (§B.5). For aplexer rows, map from the

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -98,6 +98,28 @@ dependencies = [
     # so the pinned wheel is the ONLY aplexer this CLI can run. Bumping the
     # pin is a deliberate, reviewed change.
     #
+    # 0.1.4 is required for the session tree to say WHICH agent is running.
+    # Through 0.1.3 a snapshot row's only agent-ish field was `engine`, and
+    # `engine` cannot answer that question: every session PocketShell creates
+    # is `engine: "shell"` with the agent launched by hand inside it, so a
+    # tree full of claude/codex/opencode sessions is indistinguishable from a
+    # tree full of bare shells. 0.1.4 derives an `agent` field at QUERY time
+    # by walking the workload's descendant process tree (`workload_pid` plus
+    # `/proc/<pid>/task/*/children`, the same walk containment already uses)
+    # and classifying each `comm`/`cmdline` by whole-word command token —
+    # aplexer ca56fa5, spec.md section 18. It is present on every
+    # `a list --json` / `a snapshot` row (`null` when nothing recognisable is
+    # running) and never persisted, so it cannot go stale.
+    #
+    # `session_enum._aplexer_rows` reads that key straight onto
+    # `LiveSession.agent` and schema 2 emits it on every row. Against 0.1.3
+    # the key is simply absent and every row reports `agent: null` — the
+    # listing still works, it just cannot name an agent, which is the whole
+    # point of the bump. tests/test_aplexer_contract.py pins the behaviour
+    # against the bundled binary: a real session running a process named
+    # `claude` reports `agent == "claude"`, and `null` again once it exits.
+    # Verified red on published 0.1.3 (no `agent` key at all), green on 0.1.4.
+    #
     # 0.1.3 is required for a USER-VISIBLE session-tree defect, not for
     # version hygiene (aplexer#2 / aplexer#3). Through 0.1.2, aplexer's
     # `list_records` treated a session directory containing no `session.json`
@@ -162,12 +184,12 @@ dependencies = [
     # fails loud (there is no PATH fallback — D22) while tmux, the default
     # backend, keeps working.
     #
-    # Install-surface note (unchanged in 0.1.3): as of 0.1.2 the wheels moved
+    # Install-surface note (unchanged in 0.1.4): as of 0.1.2 the wheels moved
     # from manylinux_2_17 to manylinux_2_28, raising the minimum glibc from
     # 2.17 to 2.28. Linux hosts older than that (CentOS 7, Ubuntu 18.04) can
     # no longer install pocketshell at all now that aplexer is a hard
     # dependency. Flagged, not solved here — see docs/aplexer-integration.md.
-    "aplexer==0.1.3; sys_platform == 'linux'",
+    "aplexer==0.1.4; sys_platform == 'linux'",
 ]
 
 [project.scripts]
@@ -230,8 +252,10 @@ required-version = "==0.10.11"
 # rather than a stale cutoff, so this value moves in lock-step with every new
 # pin — and the `uv.lock` options cutoff must be moved to match. Now past
 # aplexer 0.1.3's 2026-09-06T00:32:09Z PyPI upload (its `aplexer-client`
-# runtime dep landed at 00:32:04Z) for the session-tree regression fix above.
-exclude-newer = "2026-09-06T01:00:00Z"
+# runtime dep landed at 00:32:04Z) for the session-tree regression fix above,
+# and now past aplexer 0.1.4's 2026-09-06T16:14:52Z PyPI upload (its
+# `aplexer-client` runtime dep landed at 16:14:48Z) for the `agent` field.
+exclude-newer = "2026-09-06T17:00:00Z"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tools/pocketshell/src/pocketshell/session_enum.py
+++ b/tools/pocketshell/src/pocketshell/session_enum.py
@@ -123,6 +123,15 @@ class LiveSession:
     profile: Optional[str] = None
     aplexer_id: Optional[str] = None
     attach: Optional[str] = None
+    #: Which coding agent aplexer can SEE running inside the session right
+    #: now (``claude``/``codex``/``opencode``/``grok``), or ``None``. Not the
+    #: same question as ``engine``: every session PocketShell creates is
+    #: ``engine: "shell"`` with the agent started by hand inside it, so
+    #: ``engine`` is ``None`` for exactly the rows a user would call "my
+    #: claude session". aplexer 0.1.4 derives this per query from the
+    #: workload's descendant process tree and never persists it, so it
+    #: cannot go stale; a tmux row has no such authority and stays ``None``.
+    agent: Optional[str] = None
     agent_state: Optional[str] = None
     agent_state_source: Optional[str] = None
     attached: bool = False
@@ -153,6 +162,7 @@ class LiveSession:
                 "tag": self.tag,
                 "engine": self.engine,
                 "profile": self.profile,
+                "agent": self.agent,
                 "agent_state": self.agent_state,
                 "agent_state_source": self.agent_state_source,
                 "attached": bool(self.attached),
@@ -332,6 +342,31 @@ def _aplexer_engine(raw: Mapping[str, Any]) -> Optional[str]:
     if not engine or engine == "shell":
         return None
     return engine
+
+
+def _aplexer_agent(raw: Mapping[str, Any]) -> Optional[str]:
+    """The agent aplexer detected in this session, or ``None``.
+
+    ``agent`` is a QUERY-time field (aplexer 0.1.4, ``src/agent_kind.rs`` /
+    spec.md section 18): aplexer walks the workload's descendant process tree
+    and names the coding agent it finds, or reports ``null`` when there is
+    none — including a shell session whose agent has just exited. It is never
+    written to disk, so it cannot go stale.
+
+    A missing key means an aplexer older than 0.1.4 answered the probe, which
+    is a "cannot tell", not "no agent" — both land on ``None`` here, but it
+    must never be a ``KeyError``: the pin is a floor, not a guarantee about
+    the binary a given host happens to run.
+
+    Only a non-empty string is a name. Anything else is read as ``None``
+    rather than coerced with ``str()``, which would turn a malformed
+    ``["claude"]`` into the literal agent name ``"['claude']"`` and put it on
+    the wire.
+    """
+    agent = raw.get("agent")
+    if not isinstance(agent, str):
+        return None
+    return agent.strip() or None
 
 
 def _aplexer_attached(raw: Mapping[str, Any]) -> bool:
@@ -557,6 +592,7 @@ def _aplexer_rows(payload: Any, now_ms: Optional[int]) -> list[LiveSession]:
                 profile=str(profile) if profile else None,
                 aplexer_id=ident or None,
                 attach=attach,
+                agent=_aplexer_agent(raw),
                 agent_state=state,
                 agent_state_source=state_source,
                 attached=_aplexer_attached(raw),

--- a/tools/pocketshell/tests/fixtures/aplexer/snapshot-agent.json
+++ b/tools/pocketshell/tests/fixtures/aplexer/snapshot-agent.json
@@ -1,0 +1,83 @@
+[
+  {
+    "agent": "claude",
+    "command": [
+      "/bin/sh",
+      "/tmp/ps2581/bin/session-runner-claude.sh"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788711819237,
+    "cwd": "/tmp/ps2581/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/ps2581/state/sessions/f8514235-4a65-4139-b8fa-c8c917cb5d4b/history.bin",
+    "id": "f8514235-4a65-4139-b8fa-c8c917cb5d4b",
+    "limits": {},
+    "phase": "running",
+    "schema_version": 1,
+    "socket_path": "/tmp/ps2581/rt/sessions/f8514235-4a65-4139-b8fa-c8c917cb5d4b/control.sock",
+    "state": "running",
+    "tag": "claude",
+    "updated_at_ms": 1788711819327,
+    "worker_alive": true,
+    "worker_pid": 4025324,
+    "workload_pid": 4025332,
+    "workspace": "/tmp/ps2581/ws"
+  },
+  {
+    "agent": "codex",
+    "command": [
+      "/bin/sh",
+      "/tmp/ps2581/bin/session-runner-codex.sh"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788711829161,
+    "cwd": "/tmp/ps2581/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/ps2581/state/sessions/0ef96cac-7169-4e8d-90bc-3ff95d5be3fe/history.bin",
+    "id": "0ef96cac-7169-4e8d-90bc-3ff95d5be3fe",
+    "limits": {},
+    "phase": "running",
+    "schema_version": 1,
+    "socket_path": "/tmp/ps2581/rt/sessions/0ef96cac-7169-4e8d-90bc-3ff95d5be3fe/control.sock",
+    "state": "running",
+    "tag": "codex",
+    "updated_at_ms": 1788711829320,
+    "worker_alive": true,
+    "worker_pid": 4027631,
+    "workload_pid": 4027658,
+    "workspace": "/tmp/ps2581/ws"
+  },
+  {
+    "agent": null,
+    "command": [
+      "/bin/sleep",
+      "3600"
+    ],
+    "containment_empty": false,
+    "created_at_ms": 1788711829398,
+    "cwd": "/tmp/ps2581/ws",
+    "engine": "shell",
+    "env": {},
+    "env_unset": [],
+    "history_bytes": 4194304,
+    "history_path": "/tmp/ps2581/state/sessions/e4da25b0-22f2-4612-aa07-e3eb7be69d8e/history.bin",
+    "id": "e4da25b0-22f2-4612-aa07-e3eb7be69d8e",
+    "limits": {},
+    "phase": "running",
+    "schema_version": 1,
+    "socket_path": "/tmp/ps2581/rt/sessions/e4da25b0-22f2-4612-aa07-e3eb7be69d8e/control.sock",
+    "state": "running",
+    "tag": "plain",
+    "updated_at_ms": 1788711829542,
+    "worker_alive": true,
+    "worker_pid": 4027719,
+    "workload_pid": 4027735,
+    "workspace": "/tmp/ps2581/ws"
+  }
+]

--- a/tools/pocketshell/tests/test_aplexer_contract.py
+++ b/tools/pocketshell/tests/test_aplexer_contract.py
@@ -36,8 +36,8 @@ personal ``~/.config/aplexer/config.toml`` or the live sessions in
 and disturb real work while doing it. Every assertion here was verified to
 fail on the previous published wheel and pass on the pinned one (0.1.1 -> 0.1.2
 for the ``executable`` / shell-env pair, 0.1.2 -> 0.1.3 for the registry-scan
-trio); a future pin that regresses fails loudly instead of shipping a silent
-downgrade.
+trio, 0.1.3 -> 0.1.4 for the ``agent`` field); a future pin that regresses
+fails loudly instead of shipping a silent downgrade.
 
 They run in the ``Python utility tests`` job (``tests.yml``), on Linux, with
 no Docker service or fixture port — the same gate the rest of this suite uses.
@@ -543,6 +543,172 @@ def test_session_being_created_does_not_erase_live_aplexer_sessions(
     finally:
         kill(live_tag)
         kill(second_tag)
+
+
+# ---------------------------------------------------------------------------
+# 0.1.4 — the snapshot names WHICH agent is running inside the session
+# ---------------------------------------------------------------------------
+#
+# `engine` cannot answer that. Every session PocketShell creates is
+# `engine: "shell"` with the agent started by hand inside it, so on 0.1.3 a
+# tree of claude/codex/opencode sessions was indistinguishable from a tree of
+# bare shells. 0.1.4 derives an `agent` field at QUERY time from the
+# workload's descendant process tree (aplexer ca56fa5, spec.md section 18)
+# and puts it on every `a list --json` / `a snapshot` row.
+#
+# Version-trap rule (AGENTS.md): pin the BEHAVIOUR, never the string. So this
+# drives the bundled binary through a real session whose workload shell spawns
+# a real process named `claude`, and follows it all the way out to the
+# schema-2 payload the phone reads.
+
+
+def _poll(read, predicate, *, timeout: float = 30.0, interval: float = 0.2):
+    """Poll ``read()`` until ``predicate`` holds; return the last value seen.
+
+    Detection is a live ``/proc`` walk, so the answer changes a few hundred ms
+    after the process tree does. Polling with a deadline is the honest way to
+    observe that; a fixed sleep would be either flaky or slow.
+    """
+    deadline = time.monotonic() + timeout
+    value = read()
+    while not predicate(value) and time.monotonic() < deadline:
+        time.sleep(interval)
+        value = read()
+    return value
+
+
+def test_bundled_aplexer_names_the_agent_running_inside_a_session(
+    aplexer_fixture, monkeypatch
+) -> None:
+    """A real session: no agent -> `claude` -> no agent again, on the real `a`.
+
+    The workload is a plain shell (the production shape); the "agent" is a
+    symlink to ``sleep`` whose FILENAME is the agent's command token, exactly
+    how detection is supposed to recognise a hand-launched agent. Nothing in
+    the shell's own argv names an agent, so the null bookends are real
+    evidence and not an accident of the temp path.
+
+    Published 0.1.3 has no `agent` key at all — the first assertion below
+    fails on it — while 0.1.4 tracks the process tree in both directions.
+    Both ends of the wire are checked: the raw `a --json list`/`snapshot`
+    rows, and the schema-2 payload `pocketshell sessions list --json` emits
+    after `session_enum._probe_aplexer` has driven the same binary.
+    """
+    agent_bin = aplexer_fixture.workspace.parent / "ps2581-bin"
+    agent_bin.mkdir()
+    # `sleep` under an agent's name: `comm` and argv[0] both become the token
+    # detection looks for, with no coding agent installed anywhere.
+    (agent_bin / "claude").symlink_to("/bin/sleep")
+    go_marker = aplexer_fixture.workspace.parent / "ps2581-go"
+    pid_file = aplexer_fixture.workspace.parent / "ps2581-agent-pid"
+    runner = aplexer_fixture.workspace.parent / "ps2581-session-runner.sh"
+    # The paths live in the SCRIPT, never in the shell's argv, so the parent
+    # process cannot itself be mistaken for the agent.
+    runner.write_text(
+        "#!/bin/sh\n"
+        f'while [ ! -e "{go_marker}" ]; do sleep 0.05; done\n'
+        f'"{agent_bin}/claude" 3600 &\n'
+        f'echo $! > "{pid_file}"\n'
+        "wait\n"
+        "exec sleep 300\n",
+        encoding="utf-8",
+    )
+    runner.chmod(0o755)
+    # Deliberately the literal `shell` engine, overridden to run the fixture
+    # runner: that is the shape EVERY PocketShell session has, and the shape
+    # in which `engine` is null on the wire and therefore cannot name the
+    # agent. Anything else would prove the field works on a session type the
+    # product never creates.
+    aplexer_fixture.write_config(
+        "version = 1\n"
+        "[engines.shell]\n"
+        f'command = ["/bin/sh", "{runner}"]\n'
+    )
+    for key, value in aplexer_fixture.env.items():
+        monkeypatch.setenv(key, value)
+    tag = f"ps2581-{uuid.uuid4().hex[:8]}"
+
+    def listed(subcommand: str = "list") -> dict[str, Any]:
+        rows = [
+            row for row in aplexer_fixture.json([subcommand]) if row["tag"] == tag
+        ]
+        assert len(rows) == 1, f"expected exactly one `{tag}` row, got {rows}"
+        return rows[0]
+
+    def probed_payload() -> dict[str, Any]:
+        payload, error = _session_enum._probe_aplexer(aplexer_fixture.env)
+        assert error is None, error
+        rows = _session_enum.sessions_from_aplexer_snapshot(payload)
+        row = next(r for r in rows if r.tag == tag)
+        return row.to_payload(schema=2)
+
+    started = aplexer_fixture.run(
+        [
+            "--json", "start",
+            "--workspace", str(aplexer_fixture.workspace),
+            "--tag", tag,
+            "--engine", "shell",
+        ]
+    )
+    try:
+        assert started.returncode == 0, (
+            f"could not start the fixture session: {started.stderr.strip()}"
+        )
+        assert json.loads(started.stdout)["command"] == ["/bin/sh", str(runner)], (
+            "the fixture must own the workload; the config override did not "
+            f"take: {started.stdout}"
+        )
+
+        # 1. The key exists at all. This is what 0.1.3 cannot do.
+        row = listed()
+        assert "agent" in row, (
+            "the bundled aplexer emits no `agent` field; this is aplexer "
+            "ca56fa5, missing from published 0.1.3, and without it the "
+            "session tree cannot say which agent a session is running "
+            f"(engine is {row.get('engine')!r} for every PocketShell "
+            f"session). Row keys: {sorted(row)}"
+        )
+        # 2. ...and it is honest before anything agent-shaped is running.
+        assert row["agent"] is None, (
+            "an idle shell session reported an agent; the workload's own argv "
+            f"({row.get('command')}) must not name one. Row: {row}"
+        )
+        assert probed_payload()["agent"] is None
+
+        # 3. Launch the agent inside the session; detection follows the tree.
+        go_marker.touch()
+        row = _poll(listed, lambda r: r.get("agent") is not None)
+        assert row["agent"] == "claude", (
+            "the bundled aplexer did not detect a live `claude` process in "
+            f"the session's own descendant tree. Row: {row}"
+        )
+        # `a snapshot` is the probe pocketshell tries FIRST; the two commands
+        # must not disagree.
+        assert listed("snapshot")["agent"] == "claude"
+        # ...and it survives the whole host path out to the wire.
+        payload = probed_payload()
+        assert payload["agent"] == "claude", payload
+        assert payload["engine"] is None, (
+            "precondition for the whole feature: this row's engine says "
+            f"nothing about the agent. Payload: {payload}"
+        )
+
+        # 4. The agent exits; the session stays. Nothing may be sticky —
+        #    detection is per-query and must never be persisted.
+        os.kill(int(pid_file.read_text().strip()), 15)
+        row = _poll(listed, lambda r: r.get("agent") is None)
+        assert row["agent"] is None, (
+            "the agent exited but the row still names it, so the value is "
+            f"cached or persisted rather than derived per query. Row: {row}"
+        )
+        assert row["phase"] == "running", (
+            f"the session itself must still be alive: {row}"
+        )
+        assert probed_payload()["agent"] is None
+    finally:
+        aplexer_fixture.run(
+            ["kill", "--workspace", str(aplexer_fixture.workspace), "--tag", tag]
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/pocketshell/tests/test_aplexer_resolution.py
+++ b/tools/pocketshell/tests/test_aplexer_resolution.py
@@ -398,6 +398,10 @@ def test_aplexer_is_pinned_exactly() -> None:
       scan on a session directory that has no `session.json` yet, which is the
       state every `a start` creates for 26-43 ms, so a session being created
       blanked the phone's aplexer session rows (aplexer#2 / aplexer#3).
+    * 0.1.4, never 0.1.3 — 0.1.3 emits no `agent` field, so the session tree
+      cannot say WHICH agent a session is running. `engine` cannot stand in
+      for it: every session PocketShell creates is `engine: "shell"` with the
+      agent launched by hand inside it (issue #2581).
 
     This assertion only guards the STRING. ``test_aplexer_contract.py`` pins
     the behaviours themselves against the bundled binary, which is the part
@@ -405,7 +409,7 @@ def test_aplexer_is_pinned_exactly() -> None:
     """
     requirement = _aplexer_requirement()
     pin = requirement.split(";")[0].strip()
-    assert pin == "aplexer==0.1.3", pin
+    assert pin == "aplexer==0.1.4", pin
 
 
 def test_aplexer_dependency_marker_is_linux_only() -> None:

--- a/tools/pocketshell/tests/test_session_enum_schema2.py
+++ b/tools/pocketshell/tests/test_session_enum_schema2.py
@@ -35,6 +35,15 @@ The aplexer fixtures under ``tests/fixtures/aplexer/`` are REAL captures of
   (``SessionRecord::worker_alive`` returns false for a ``None`` pid). Every
   ``a start`` passes through this shape for tens of milliseconds. Calling it
   dead hides a session that is being created — the #2547 symptom.
+- ``snapshot-agent.json`` — captured against the PINNED aplexer 0.1.4
+  (issue #2581), the first release that derives an ``agent`` field. Three
+  sessions in one isolated instance, all ``engine: "shell"`` (the production
+  shape — PocketShell never sets an engine, the agent is launched by hand
+  inside the session): one whose workload shell has a live child named
+  ``claude``, one with a child named ``codex``, and one plain ``sleep``.
+  aplexer reports ``agent: "claude"``, ``"codex"`` and ``null`` respectively,
+  which is the whole point of the field: ``engine`` is ``"shell"`` on all
+  three and therefore cannot tell them apart.
 - ``snapshot-crashed-start.json`` — the OTHER side of that boundary,
   captured by SIGKILLing a real ``a start``'s process group inside the
   pre-PID window: byte-identical in shape (``starting`` / no ``worker_pid``
@@ -42,9 +51,13 @@ The aplexer fixtures under ``tests/fixtures/aplexer/`` are REAL captures of
   ``a list`` renders it ``✗ broken``. The two fixtures differ only in age,
   which is why age is the discriminator.
 
-Both were captured with the maintainer's ``a 0.1.3``; the key set was
-compared against the copy PINNED in this package's venv and is identical,
-and neither carries a ``state`` field (that is unreleased — see #2556).
+All but ``snapshot-agent.json`` were captured with the maintainer's
+``a 0.1.3``; the key set was compared against the copy PINNED in this
+package's venv and is identical, and none of them carries an ``agent`` or a
+``state`` field, because 0.1.3 emits neither. That makes them the
+older-aplexer fixtures for free: every assertion below that an ``agent``-less
+row reads as ``agent: null`` (never a ``KeyError``) runs against real 0.1.3
+output rather than a hand-deleted key.
 """
 
 from __future__ import annotations
@@ -72,6 +85,9 @@ SCHEMA2_ROW_KEYS = {
     "tag",
     "engine",
     "profile",
+    # Issue #2581: WHICH agent aplexer sees running inside the session. Not a
+    # restatement of `engine` — see the agent tests below.
+    "agent",
     "agent_state",
     "agent_state_source",
     "attached",
@@ -96,6 +112,13 @@ ZOMBIE_ID = "c06513a5-ee94-4081-b4b1-6d4d39d22ac5"
 MID_CREATE_ID = "078e2bf5-8e37-44e6-b1cf-8f72e261495e"
 # id from snapshot-crashed-start.json (real capture of a killed `a start`)
 CRASHED_START_ID = "6b1ddabb-1b5c-4a76-b46b-1f7e70d78a9a"
+# ids from snapshot-agent.json (real aplexer 0.1.4 capture, issue #2581)
+AGENT_CLAUDE_ID = "f8514235-4a65-4139-b8fa-c8c917cb5d4b"
+AGENT_CODEX_ID = "0ef96cac-7169-4e8d-90bc-3ff95d5be3fe"
+AGENT_NONE_ID = "e4da25b0-22f2-4612-aa07-e3eb7be69d8e"
+# `now` for snapshot-agent.json: a few seconds after the capture, so all
+# three records are comfortably live.
+AGENT_NOW_MS = 1_788_711_835_000
 # Captured values, read back from the fixture rather than restated here.
 
 
@@ -371,6 +394,160 @@ def test_exited_session_has_no_agent_state() -> None:
     assert row.agent_state_source is None
     assert row.phase == "exited"
     assert row.alive is False
+
+
+# ---------------------------------------------------------------------------
+# `agent` — WHICH agent is running in the session (issue #2581, aplexer 0.1.4)
+# ---------------------------------------------------------------------------
+#
+# `engine` cannot answer this. Every session PocketShell creates is
+# `engine: "shell"` with the agent started by hand inside it, so `engine` is
+# `null` for exactly the rows a user would call "my claude session". aplexer
+# 0.1.4 derives `agent` per query from the workload's descendant process tree
+# and emits it on every `a list --json` / `a snapshot` row; the host passes it
+# straight through on schema 2.
+
+
+def test_aplexer_row_names_the_agent_running_inside_it() -> None:
+    """The real 0.1.4 capture: claude, codex, and none — all `engine: shell`."""
+    snapshot = _load("snapshot-agent.json")
+    assert {row["engine"] for row in snapshot} == {"shell"}, (
+        "fixture precondition: all three rows are the production shape, so "
+        "`engine` cannot be what tells them apart"
+    )
+
+    sessions = session_enum.sessions_from_aplexer_snapshot(
+        snapshot, now_ms=AGENT_NOW_MS
+    )
+
+    by_id = {row.aplexer_id: row for row in sessions}
+    assert by_id[AGENT_CLAUDE_ID].agent == "claude"
+    assert by_id[AGENT_CODEX_ID].agent == "codex"
+    assert by_id[AGENT_NONE_ID].agent is None
+    # ...and the field it is NOT a restatement of.
+    assert {row.engine for row in sessions} == {None}
+
+
+def test_schema_2_emits_the_agent_on_every_row() -> None:
+    """"Every key, always" covers `agent`: named, null, and tmux alike."""
+    sessions, errors = session_enum.enumerate_live_sessions(
+        tmuxctl_stdout=_tmuxctl_table(),
+        aplexer_payload=_load("snapshot-agent.json"),
+        now_ms=AGENT_NOW_MS,
+    )
+    payload = session_enum.json_payload(sessions, errors)
+
+    for row in payload["sessions"]:
+        assert set(row) == SCHEMA2_ROW_KEYS
+        assert "agent" in row
+
+    agents = {row["id"]: row["agent"] for row in payload["sessions"]}
+    assert agents[AGENT_CLAUDE_ID] == "claude"
+    assert agents[AGENT_CODEX_ID] == "codex"
+    assert agents[AGENT_NONE_ID] is None
+
+
+def test_tmux_rows_never_carry_an_agent() -> None:
+    """A tmux row has no process-tree authority behind it: explicit null.
+
+    tmuxctl exposes no workload pid to walk, and the host must not guess one
+    from the session name, so the key is present and null rather than absent
+    or invented (the same rule `agent_state` follows until APX-ADOPT).
+    """
+    sessions, errors = session_enum.enumerate_live_sessions(
+        tmuxctl_stdout=_tmuxctl_table(),
+        include_aplexer=False,
+    )
+    payload = session_enum.json_payload(sessions, errors)
+
+    assert payload["sessions"], "fixture must produce tmux rows"
+    for row in payload["sessions"]:
+        assert row["manager"] == "tmux"
+        assert "agent" in row
+        assert row["agent"] is None
+
+
+def test_an_aplexer_without_the_agent_key_reads_as_null_not_a_keyerror() -> None:
+    """An older `a` (0.1.3, the previous pin) simply omits the key.
+
+    The pin is a floor, not a promise about the binary a given host runs — a
+    stale bundled wheel, or the fixture image mid-rebuild, answers the probe
+    with no `agent` field at all. That is "cannot tell", which serialises as
+    null; it must never be an exception that blanks the whole session list.
+    `snapshot-reported-state.json` is a REAL 0.1.3 capture, so this is the
+    genuine older-aplexer wire shape rather than a hand-deleted key.
+    """
+    snapshot = _load("snapshot-reported-state.json")
+    assert all("agent" not in row for row in snapshot), (
+        "fixture precondition: these captures predate the `agent` field"
+    )
+
+    sessions = session_enum.sessions_from_aplexer_snapshot(
+        snapshot, now_ms=1_788_409_006_000
+    )
+
+    assert sessions, "fixture must produce aplexer rows"
+    for row in sessions:
+        assert row.agent is None
+        payload = row.to_payload(schema=2)
+        assert set(payload) == SCHEMA2_ROW_KEYS
+        assert payload["agent"] is None
+
+
+def test_an_empty_or_non_string_agent_reads_as_null() -> None:
+    """Defensive read: only a non-empty string is an agent name.
+
+    ``["claude"]`` matters more than it looks: a ``str()`` coercion would put
+    the literal name ``"['claude']"`` on the wire instead of admitting it
+    could not tell.
+    """
+    live = _row(_load("snapshot-agent.json"), AGENT_CLAUDE_ID)
+    for value in ("", "   ", None, 0, [], {}, ["claude"], 7, True):
+        grown = [dict(live, agent=value)]
+        row = session_enum.sessions_from_aplexer_snapshot(
+            grown, now_ms=AGENT_NOW_MS
+        )[0]
+        assert row.agent is None, f"agent={value!r} should read as null"
+
+
+def test_a_dead_row_still_serialises_its_agent_key() -> None:
+    """The dead projection is schema 2 too — no key may go missing there.
+
+    aplexer never probes the process tree of a terminal-phase record (its
+    `workload_pid` names a process that is gone and a recycled pid must not
+    resurrect an agent), so a dead row's `agent` is null in practice; what is
+    pinned here is that the KEY is emitted regardless.
+    """
+    dead = session_enum.dead_sessions_from_aplexer_snapshot(
+        _load("snapshot-liveness-mix.json"), now_ms=1_788_682_060_000
+    )
+
+    assert dead, "fixture must contain dead records"
+    for row in dead:
+        payload = row.to_payload(schema=2)
+        assert set(payload) == SCHEMA2_ROW_KEYS
+        assert payload["agent"] is None
+
+
+def test_cli_list_json_carries_the_agent_end_to_end(install_fake_a) -> None:
+    """Through the real CLI: `sessions list --json` reaches stdout with `agent`.
+
+    The fake `a` replays the 0.1.4 capture verbatim, so this exercises the
+    production probe -> `_aplexer_rows` -> schema-2 payload path the phone
+    reads, not just the row builder.
+    """
+    install_fake_a(snapshot=_load("snapshot-agent.json"))
+
+    result = _invoke_list_json(tmuxctl_stdout=_tmuxctl_table())
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["errors"] == []
+    agents = {row["name"]: row["agent"] for row in payload["sessions"]}
+    assert agents["ws:claude"] == "claude"
+    assert agents["ws:codex"] == "codex"
+    assert agents["ws:plain"] is None
+    assert agents["git-pocketshell"] is None
 
 
 def test_aplexer_rows_are_not_attached_without_a_snapshot_field() -> None:

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-09-06T01:00:00Z"
+exclude-newer = "2026-09-06T17:00:00Z"
 
 [[package]]
 name = "annotated-doc"
@@ -16,23 +16,23 @@ wheels = [
 
 [[package]]
 name = "aplexer"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aplexer-client" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/af/f543f10a7a60b17b92c7d2c07a70297eaa5ca28fd15723b72adecb68ab79/aplexer-0.1.3-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fcbeb382cae10a845642354abdf5b9f92a904b1c5c89884f5eb401dcab0ced50", size = 2628621, upload-time = "2026-09-06T00:32:08.244Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/a9/0e94c7111b3065a1988a3c8c22a6694a3cb9d1ebeb9319418badcabcd907/aplexer-0.1.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:98296baeb01a4970f9526f841a93a774efbcb2cc0eb72f709c9df0639be88f26", size = 2729042, upload-time = "2026-09-06T00:32:09.795Z" },
+    { url = "https://files.pythonhosted.org/packages/82/66/62a25e0299c7e378f25960afe54fea0432d4c56b694f071a84c5d2a0eeb9/aplexer-0.1.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d7bbb60ac5c9bdb7db1d882374cbec3e91ea3f0d6f23e2d1272c0eb945b517c7", size = 2717004, upload-time = "2026-09-06T16:14:51.769Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e7/4bb8451c729457bf739aa86722c43db48c407ca82f4922bc67b24c6fffbe/aplexer-0.1.4-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:052705edcf832f35a336e0c20fe133ad2532fd27028f7dd332b40402c58da07d", size = 2822247, upload-time = "2026-09-06T16:14:52.986Z" },
 ]
 
 [[package]]
 name = "aplexer-client"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/08/14dd9dff0689b53962f6098d8b301180765530e361745078419f1a7352cc/aplexer_client-0.1.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d7d1bb379e1a1ec4877c376d5404db686c3f376d05ed382544d9fe0c3e7d0e52", size = 1172818, upload-time = "2026-09-06T00:32:03.086Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a4/34a98e50347da9e954a20c78ee0b6a01640bd287dba294444e4730517a2d/aplexer_client-0.1.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:58821be985be0cb179fb7647da1e899499372fa728cff8a75e67ff360d4c0022", size = 1202892, upload-time = "2026-09-06T00:32:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/74/68/8f5263a3df4061ae4b9d9b0119a9baaca6bb0a832bb5ecf09d5ab3aa1440/aplexer_client-0.1.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48b3b171f07a8126e61624d191ecb320fb24e5cf73d70cd3ec73d34426a814d3", size = 1192947, upload-time = "2026-09-06T16:14:46.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b8/060e123125438e294f7b44d20e70f56acb1c0e0b13251203caffd3eab7c8/aplexer_client-0.1.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7fe606b60b5b0b2276952df202e770fc588123e675b62468538e02de0f263c67", size = 1227601, upload-time = "2026-09-06T16:14:48.211Z" },
 ]
 
 [[package]]
@@ -363,7 +363,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aplexer", marker = "sys_platform == 'linux'", specifier = "==0.1.3" },
+    { name = "aplexer", marker = "sys_platform == 'linux'", specifier = "==0.1.4" },
     { name = "click", specifier = ">=8.2.0" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },


### PR DESCRIPTION
Closes #2581 (child of #2579). Reviewer APPROVED: https://github.com/alexeygrigorev/pocketshell/issues/2581#issuecomment-5560662216

## What

- `sessions list --json` (schema 2) rows gain `agent` — aplexer 0.1.4's workload-process-tree detection (claude/codex/opencode/grok), null for tmux rows or an older aplexer. Liveness predicate byte-identical to main.
- Pin `aplexer==0.1.4`, `exclude-newer` advanced past the 2026-09-06T16:14:52Z uploads, `uv.lock` regenerated (`aplexer-client` 0.1.4 too). The Docker `agents` fixture derives its binary download from this pin — no Dockerfile edit; the `agents` lane on `main` after merge is the on-host proof that the v0.1.4 assets download and run.

## Evidence (reviewer's own run)

- Full Python suite 1340 passed / 4 skipped; targeted 122; `uv lock --check`, `uv sync --frozen --group dev`, lock/ci guards green; bundled `a`/`aplexer` report 0.1.4.
- Red→green both halves: contract test fails on published 0.1.3 (missing `agent`), passes on 0.1.4; `session_enum.py` reverted → 13 failures incl. all seven new tests.
- Fixture `snapshot-agent.json` reproduced from a real isolated 0.1.4 capture.

Merge order: this after #2587 is fine either way (no file overlap); both are needed on the host + phone for the #2579 screenshot to change.