### PR TITLE
fix: cap aplexer-backed sessions with the same limit tmux sessions get

### DIFF
--- a/docs/aplexer-integration.md
+++ b/docs/aplexer-integration.md
@@ -344,6 +344,61 @@ push feed, `usage` / `quse`.
 
 ---
 
+## Session memory caps: `cgroups.toml` is the source of truth, `memcap.py` reads it (#2562)
+
+Every session PocketShell creates is memory-capped, on both backends. Until
+#2562 only the tmux arm was: `tmuxctl create-detached` resolved the per-project
+cap itself and wrapped the session shell in a capped cgroup-v2 systemd `--user`
+scope, while `a start` was invoked with no memory parameter at all — every
+aplexer-backed session on the dev box recorded `"limits": {}`. That protection
+exists because a runaway session can OOM-kill the whole box, which is the
+maintainer's only dev machine and is usually reached from a phone.
+
+**The decision #2562 asks to record — where cap resolution lives once tmux is
+gone:** in PocketShell, as `tools/pocketshell/src/pocketshell/memcap.py`, reading
+the same per-project files tmuxctl reads. Not `from tmuxctl.robust import
+resolve_mem`, because #2561 deletes that dependency and the aplexer arm has to
+outlive it; importing it would make the cap disappear again exactly when tmux is
+removed, which is the failure #2562 exists to close. The contract is the FILE,
+not tmuxctl's code: `cgroups.toml` keeps its location and format (an explicit
+non-goal of #2562 to change either), and `memcap.py` becomes its only reader
+when the tmux arm goes. `tests/test_sessions_mem_cap.py` pins the two readers'
+agreement against the real tmuxctl while both exist, and asserts the resolved
+BYTE value against the committed file so the number is never copied into code.
+
+Resolution order for a session created in workspace `W`:
+
+1. an explicit `--mem`;
+2. `W/cgroups.toml` → `mem`;
+3. `W/pyproject.toml` → `[tool.tmuxctl] mem`;
+4. the same two files at `W`'s git root;
+5. `memcap.DEFAULT_MEM` (12G — the same fallback tmuxctl uses).
+
+Deliberately NOT carried over: tmuxctl's `ROBUST_TMUX_MEM` env layer and its
+`~/.config/tmuxctl/cgroups.toml` user-config layer. Both are tmuxctl-namespaced
+knobs that die with it, and an inherited environment variable should not be able
+to change a session's containment.
+
+Two fail-loud rules keep "uncapped" from ever happening by accident:
+
+- an unresolvable cap (malformed `cgroups.toml`, an unparseable size, a value
+  below the sanity floor) refuses the create — it does not fall back;
+- `mem = "none"` in a project file is an error. The single escape hatch is
+  `--mem none` typed at the call site, and it is aplexer-only.
+
+`--mem none` exists because aplexer's limits **fail closed**: with no delegated
+cgroup-v2 user scope, `a start --memory` errors rather than running uncapped.
+That is correct on a real host and impossible to satisfy in an unprivileged
+container, so the Docker `agents` fixture
+(`tests/docker/agents-aplexer-selfcheck.py`,
+`scripts/test-agents-fixture-aplexer.sh`) passes `--mem none` explicitly. The
+fixture therefore cannot prove capping; the real-transport proof lives in
+`tests/test_sessions_mem_cap.py`, which creates a session through the production
+CLI against an isolated aplexer instance and reads `memory.max` back out of the
+kernel.
+
+---
+
 ## Product defaults (unless the maintainer says otherwise)
 
 1. **Picker ids.** Phase A keeps PocketShell display names (`Claude (Z.AI)`).

--- a/scripts/test-agents-fixture-aplexer.sh
+++ b/scripts/test-agents-fixture-aplexer.sh
@@ -244,7 +244,10 @@ ok "self-check passes in the built image, over SSH"
 printf '\nPOSITIVE 2: real CLI create -> list -> PTY attach -> capture -> kill...\n'
 CLI_TAG="guard-cli-${SUFFIX}"
 CLI_MARKER="GUARD_CLI_MARKER_${SUFFIX}"
-create_json="$(ssh_exec "pocketshell-real-send sessions create '$CLI_TAG' --backend aplexer --cwd /home/testuser --json")" \
+# `--mem none` (issue #2562): session creates are memory-capped, aplexer's
+# limits fail closed, and this container has no user systemd to delegate a
+# cgroup-v2 scope. The opt-out is explicit here rather than silent in the CLI.
+create_json="$(ssh_exec "pocketshell-real-send sessions create '$CLI_TAG' --backend aplexer --cwd /home/testuser --mem none --json")" \
   || fail "\`sessions create --backend aplexer\` failed over SSH"
 CLI_NAME="$(printf '%s' "$create_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("name",""))')"
 [[ -n "$CLI_NAME" ]] || fail "create envelope carried no name: $create_json"

--- a/tests/docker/agents-aplexer-selfcheck.py
+++ b/tests/docker/agents-aplexer-selfcheck.py
@@ -202,7 +202,22 @@ def check_lifecycle(binary: str) -> None:
     workspace = _home()
 
     created = run_cli(
-        ["sessions", "create", tag, "--backend", "aplexer", "--cwd", workspace, "--json"],
+        # `--mem none` (issue #2562): every session PocketShell creates is
+        # memory-capped, and aplexer's limits FAIL CLOSED — with no delegated
+        # cgroup-v2 user scope, `a start --memory` errors instead of quietly
+        # running uncapped. This container has no user systemd
+        # ("Failed to connect to user scope bus ... $XDG_RUNTIME_DIR not
+        # defined"), so the fixture opts out EXPLICITLY, at the call site,
+        # rather than the CLI silently dropping the cap for everyone. Capping
+        # itself cannot be proven here; `tools/pocketshell/tests/
+        # test_sessions_mem_cap.py` proves it against a real delegated scope.
+        [
+            "sessions", "create", tag,
+            "--backend", "aplexer",
+            "--cwd", workspace,
+            "--mem", "none",
+            "--json",
+        ],
         timeout=CREATE_TIMEOUT_S,
     )
     if created.returncode != 0:

--- a/tools/pocketshell/src/pocketshell/memcap.py
+++ b/tools/pocketshell/src/pocketshell/memcap.py
@@ -1,0 +1,259 @@
+"""Per-session memory cap resolution for `pocketshell sessions create` (#2562).
+
+Every session PocketShell starts must be memory-capped. The reason is written
+into `sessions.py` and predates this module: a runaway session that can eat
+the whole box triggers "the OOM-kill cascade that wiped the agent team", and
+the box is the maintainer's only dev machine, usually reached from a phone
+where recovering from that cascade is worst.
+
+Where the number lives
+----------------------
+
+In the repo's ``cgroups.toml``, and nowhere else. This module is a READER of
+that file, never a second copy of the value:
+
+.. code-block:: toml
+
+    # <repo>/cgroups.toml
+    mem = "30G"
+
+Resolution order for a session whose workspace is ``W`` (first match wins):
+
+1. an explicit ``--mem`` on the command line (``--mem none`` = uncapped, see
+   below);
+2. ``W/cgroups.toml``'s top-level ``mem``;
+3. ``W/pyproject.toml``'s ``[tool.tmuxctl] mem`` (Python projects state it
+   there instead of a dedicated file);
+4. the same two files at ``W``'s git root;
+5. :data:`DEFAULT_MEM` — the documented fallback, never "no cap".
+
+That is deliberately the same shape ``tmuxctl.robust.read_project_value`` /
+``resolve_mem`` use for the tmux arm, so a workspace resolves to the SAME
+ceiling whichever backend a session lands on. ``tests/test_sessions_mem_cap``
+pins that agreement against the real tmuxctl.
+
+Why a pocketshell-owned reader instead of ``from tmuxctl.robust import
+resolve_mem`` (the decision #2562 asks to record)
+-------------------------------------------------------------------------
+
+tmuxctl is being removed (#2561). Importing its resolver would make the
+aplexer arm — the arm that OUTLIVES tmux — depend on the dependency that
+removal deletes, so the cap would silently vanish again at deletion time,
+which is exactly the failure this issue exists to close. The per-project
+CONFIG FILE, not tmuxctl's code, is the contract: `cgroups.toml` stays where
+it is and keeps its format (an explicit non-goal of #2562), and this module
+becomes its sole reader once the tmux arm goes. tmuxctl's env layer
+(``ROBUST_TMUX_MEM``) and its ``~/.config/tmuxctl/cgroups.toml`` user-config
+layer are deliberately NOT reproduced: both are tmuxctl-namespaced knobs that
+die with it, and a session cap is not something an inherited environment
+variable should be able to change.
+
+Failing loud
+------------
+
+A cap that cannot be resolved is an ERROR, not a shrug: a malformed
+``cgroups.toml`` or an unparseable size raises :class:`MemCapError` and the
+create is refused before anything is started. Silently running uncapped is the
+bug (#2562), and silently substituting the fallback for a file the project
+clearly meant to be authoritative would hide it just as well.
+
+The single, explicit escape hatch is ``--mem none`` at the CALL SITE. It
+exists because a cap is unenforceable on a host with no delegated cgroup-v2
+user scope (an unprivileged container, e.g. the Docker `agents` fixture),
+where aplexer itself fails closed with "systemd did not delegate the memory
+controller". A committed config file can NOT request it: ``mem = "none"`` in
+``cgroups.toml`` is an error, so an uncapped session always has a human-typed
+flag behind it.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Optional
+
+#: Filename holding a project's cap for non-Python projects (PocketShell's own).
+PROJECT_CONFIG_NAME = "cgroups.toml"
+
+#: Python projects state the same value under ``[tool.tmuxctl] mem``.
+PYPROJECT_NAME = "pyproject.toml"
+
+#: The documented fallback for a workspace whose project declares no cap.
+#: Same value tmuxctl falls back to (``robust.DEFAULT_MEM``), so the two arms
+#: agree on a capless workspace. A cap that is merely a default is still a cap.
+DEFAULT_MEM = "12G"
+
+#: The one spelling that means "run this session uncapped". Accepted ONLY from
+#: an explicit ``--mem``, never from a project file.
+UNCAPPED = "none"
+
+#: Anything smaller than this is a typo, not a policy (``mem = "30"`` meaning
+#: 30 GiB would otherwise resolve to 30 BYTES). Refused loudly: aplexer would
+#: fail closed on it anyway, with a much less obvious message.
+MIN_MEM_BYTES = 64 * 1024**2
+
+_SIZE_UNITS = {
+    "B": 1,
+    "K": 1024,
+    "KB": 1024,
+    "KIB": 1024,
+    "M": 1024**2,
+    "MB": 1024**2,
+    "MIB": 1024**2,
+    "G": 1024**3,
+    "GB": 1024**3,
+    "GIB": 1024**3,
+    "T": 1024**4,
+    "TB": 1024**4,
+    "TIB": 1024**4,
+}
+
+_SIZE_RE = re.compile(r"\s*([0-9]+(?:\.[0-9]+)?)\s*([a-zA-Z]*)\s*\Z")
+
+#: `git rev-parse` on a workspace is a local, sub-millisecond call; a hung git
+#: must not hang a create started from the phone.
+_GIT_TIMEOUT_S = 5.0
+
+
+class MemCapError(RuntimeError):
+    """The session's memory cap could not be resolved — refuse the create."""
+
+
+def parse_size(value: str, *, source: str) -> int:
+    """Parse a human size (``30G``, ``512M``, ``1.5G``, ``1048576``) to bytes.
+
+    Accepts exactly what ``tmuxctl.robust.parse_size`` accepts, so the same
+    project file resolves identically on both arms — and is a strict superset
+    of what aplexer's ``parse_byte_size`` takes (it has no fractional form).
+    That is why callers hand aplexer the resulting BYTE COUNT rather than the
+    raw string: a value tmuxctl honours can then never be rejected, or worse
+    reinterpreted, one layer down.
+
+    ``source`` names where the value came from, for the error message.
+    """
+    text = str(value).strip()
+    if not text:
+        raise MemCapError(f"{source}: empty memory cap")
+    match = _SIZE_RE.fullmatch(text)
+    if match is None:
+        raise MemCapError(f"{source}: {value!r} is not a memory size (e.g. 30G)")
+    unit = (match.group(2) or "B").upper()
+    if unit not in _SIZE_UNITS:
+        raise MemCapError(f"{source}: unknown memory-size unit in {value!r}")
+    size = int(float(match.group(1)) * _SIZE_UNITS[unit])
+    if size < MIN_MEM_BYTES:
+        raise MemCapError(
+            f"{source}: memory cap {value!r} resolves to {size} bytes, below the "
+            f"{MIN_MEM_BYTES}-byte floor — did you mean {text}G?"
+        )
+    return size
+
+
+def is_uncapped(flag: Optional[str]) -> bool:
+    """Whether an explicit ``--mem`` value asks for NO cap at all."""
+    return bool(flag) and flag.strip().lower() == UNCAPPED
+
+
+def _read_project_config(path: Path) -> Optional[str]:
+    """``mem`` from a dedicated ``cgroups.toml``.
+
+    A file that exists but cannot be parsed raises: ``cgroups.toml`` has
+    exactly one job, so an unreadable one means the project's cap is unknown,
+    and guessing is how the cap gets lost silently.
+    """
+    if not path.is_file():
+        return None
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        raise MemCapError(f"{path}: cannot be read as TOML: {exc}") from exc
+    value = document.get("mem")
+    return None if value is None else str(value)
+
+
+def _read_pyproject(path: Path) -> Optional[str]:
+    """``[tool.tmuxctl] mem`` from a ``pyproject.toml``.
+
+    Unlike ``cgroups.toml`` this file is NOT primarily a cap declaration, so a
+    malformed one is skipped rather than fatal (tmuxctl does the same): the
+    resolution simply continues, and the fallback still caps the session.
+    """
+    if not path.is_file():
+        return None
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return None
+    tool = document.get("tool")
+    section = tool.get("tmuxctl") if isinstance(tool, dict) else None
+    value = section.get("mem") if isinstance(section, dict) else None
+    return None if value is None else str(value)
+
+
+def _git_root(start: Path) -> Optional[Path]:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    top = completed.stdout.strip()
+    return Path(top) if top else None
+
+
+def read_project_mem(workspace: Path) -> Optional[tuple[str, Path]]:
+    """The project cap for ``workspace`` as ``(raw value, file it came from)``.
+
+    Checks the workspace directory first, then its git root — the same order
+    (and the same two file shapes) tmuxctl uses, so a session started deep in
+    a repo still gets the repo's committed cap.
+    """
+    try:
+        base = workspace.resolve()
+    except OSError:  # pragma: no cover - resolve() is strict=False here
+        base = workspace
+    directories = [base]
+    root = _git_root(base)
+    if root is not None and root != base:
+        directories.append(root)
+    for directory in directories:
+        for reader, name in (
+            (_read_project_config, PROJECT_CONFIG_NAME),
+            (_read_pyproject, PYPROJECT_NAME),
+        ):
+            path = directory / name
+            value = reader(path)
+            if value is not None:
+                return value, path
+    return None
+
+
+def resolve_session_mem_bytes(*, flag: Optional[str], workspace: str) -> Optional[int]:
+    """The cap, in bytes, for a session created in ``workspace``.
+
+    ``None`` means "explicitly uncapped" and can ONLY come from ``--mem none``.
+    Every other outcome is a positive byte count or a :class:`MemCapError`;
+    there is no path that returns "no cap" by accident.
+    """
+    if flag is not None and flag.strip():
+        if is_uncapped(flag):
+            return None
+        return parse_size(flag, source="--mem")
+    found = read_project_mem(Path(workspace))
+    if found is None:
+        return parse_size(DEFAULT_MEM, source="the built-in default cap")
+    raw, path = found
+    if is_uncapped(raw):
+        raise MemCapError(
+            f"{path}: mem = {raw!r} is not allowed in a project file — an "
+            "uncapped session must be asked for explicitly with `--mem none`"
+        )
+    return parse_size(raw, source=str(path))

--- a/tools/pocketshell/src/pocketshell/sessions.py
+++ b/tools/pocketshell/src/pocketshell/sessions.py
@@ -52,6 +52,7 @@ import click
 
 from . import aplexer as _aplexer
 from . import config as _config
+from . import memcap as _memcap
 from . import resume as _resume
 from . import session_enum as _session_enum
 
@@ -486,7 +487,10 @@ def sessions_resume(
 # (tmuxctl >= 0.3.0), which wraps the session shell in a memory-capped
 # cgroup-v2 systemd `--user` scope under `robust.slice`, so sessions
 # PocketShell starts can never trigger the OOM-kill cascade that wiped the
-# agent team. `create-detached` is already idempotent (a no-op when the
+# agent team. The aplexer arm gets the SAME guarantee from the same
+# `cgroups.toml` policy via `a start --memory` (issue #2562, `memcap.py`);
+# until then it passed no memory parameter at all and every aplexer-backed
+# session ran uncapped. `create-detached` is already idempotent (a no-op when the
 # session exists) — that contract is tmuxctl's, not re-implemented here.
 #
 # Since the aplexer adoption (simplification plan §B.3) the same command is
@@ -645,6 +649,17 @@ def _create_on_tmux(
     unparseable (observed on the dev box, not hypothetical). Its output is
     relayed to stderr instead, so nothing is lost.
     """
+    if _memcap.is_uncapped(mem):
+        # `--mem none` is the aplexer arm's explicit "this host cannot enforce
+        # a cap" escape hatch (issue #2562). tmuxctl has no such spelling —
+        # forwarding it would make tmuxctl reject the size, and DROPPING it
+        # would quietly create a session capped at the project default while
+        # the caller believes they asked for no cap. Refuse instead.
+        raise _CreateError(
+            "pocketshell: `--mem none` is only supported on the aplexer "
+            "backend; the tmux arm is always capped by tmuxctl.",
+            exit_code=2,
+        )
     tmuxctl_path = _resolve_tmuxctl_binary()
     if tmuxctl_path is None:
         raise _CreateError(_tmuxctl_missing_message(), exit_code=127)
@@ -752,6 +767,7 @@ def aplexer_start_argv(
     tag: str,
     engine: Optional[str],
     profile: Optional[str],
+    memory_bytes: Optional[int],
 ) -> list[str]:
     """Build ``a --json start --workspace <ws> --tag <tag> [--engine …]``.
 
@@ -759,12 +775,24 @@ def aplexer_start_argv(
     subcommand exactly like :func:`pocketshell.aplexer.run_json` does — one
     spelling across the codebase. ``--engine`` is omitted for a plain shell
     session so aplexer applies its own configured default.
+
+    ``memory_bytes`` is the resolved per-session cap (issue #2562), handed to
+    aplexer as ``--memory <bytes>`` so it wraps the workload in a cgroup-v2
+    scope with that ``MemoryMax`` — the containment the tmux arm has had since
+    #726 and this arm had none of. A byte COUNT rather than the raw ``30G``
+    string because aplexer's own size parser is narrower than the one that
+    read the project file (no fractional sizes), and a cap must never be
+    silently reinterpreted between the file and the kernel. ``None`` means the
+    caller asked for an uncapped session with ``--mem none``; that is the only
+    way this argv comes out without ``--memory``.
     """
     argv = [aplexer_path, "--json", "start", "--workspace", workspace, "--tag", tag]
     if engine:
         argv.extend(["--engine", engine])
     if profile:
         argv.extend(["--profile", profile])
+    if memory_bytes is not None:
+        argv.extend(["--memory", str(memory_bytes)])
     return argv
 
 
@@ -903,10 +931,34 @@ def _reap_aplexer_blockers(
     )
 
 
+def _cap_unenforceable_hint(memory_bytes: Optional[int], detail: str) -> str:
+    """Explain an `a start` that failed BECAUSE the host cannot enforce a cap.
+
+    aplexer's limits fail closed (``lib.rs::Cgroup::create``): with no
+    delegated cgroup-v2 user scope — an unprivileged container, a host with no
+    user systemd — ``--memory`` turns the start into an error rather than a
+    silently uncapped session. That is the right default (issue #2562), but
+    the raw message ("systemd did not delegate the memory controller") does
+    not tell the operator what to do, so name the one deliberate escape hatch.
+    """
+    if memory_bytes is None:
+        return ""
+    lowered = detail.lower()
+    if "fail closed" not in lowered and "delegate" not in lowered:
+        return ""
+    return (
+        f" This host could not enforce the {memory_bytes}-byte session memory "
+        "cap (no delegated cgroup-v2 user scope). Fix the host's systemd "
+        "--user setup, or create the session explicitly uncapped with "
+        "`--mem none`."
+    )
+
+
 def _create_on_aplexer(
     *,
     name: str,
     cwd: Optional[str],
+    mem: Optional[str],
     engine: Optional[str],
     profile: Optional[str],
 ) -> dict[str, Any]:
@@ -919,6 +971,13 @@ def _create_on_aplexer(
     ``name`` is the row's listing name (``<workspace-basename>:<tag>``, from
     ``session_enum.aplexer_display_name``) so it round-trips with what
     `sessions list --json` shows.
+
+    The session's memory cap (issue #2562) is resolved from the workspace's
+    project policy — the very ``cgroups.toml`` the tmux arm's cap comes from —
+    BEFORE anything is started, reaped or probed: an unresolvable cap must
+    refuse the create outright, not fail halfway through it, and certainly not
+    produce an uncapped session (which is what this arm did for every session
+    it ever created).
     """
     resolution = _aplexer.resolve_a()
     aplexer_path = resolution.path
@@ -941,6 +1000,13 @@ def _create_on_aplexer(
             exit_code=127,
         )
     workspace = cwd or os.getcwd()
+    try:
+        memory_bytes = _memcap.resolve_session_mem_bytes(flag=mem, workspace=workspace)
+    except _memcap.MemCapError as exc:
+        raise _CreateError(
+            f"pocketshell: cannot create {name!r} in {workspace!r}: {exc}",
+            exit_code=2,
+        ) from exc
 
     snapshot = _aplexer_snapshot()
     existing = _aplexer_existing_record(snapshot, workspace=workspace, tag=name)
@@ -988,6 +1054,7 @@ def _create_on_aplexer(
         tag=name,
         engine=engine,
         profile=profile,
+        memory_bytes=memory_bytes,
     )
     code, stdout, stderr = _run_aplexer(argv)
     if code != 0:
@@ -1009,7 +1076,8 @@ def _create_on_aplexer(
                 exit_code=code,
             )
         raise _CreateError(
-            f"pocketshell: `a start --tag {name}` exited {code}: {detail}",
+            f"pocketshell: `a start --tag {name}` exited {code}: {detail}"
+            + _cap_unenforceable_hint(memory_bytes, detail),
             exit_code=code,
         )
     try:
@@ -1069,9 +1137,12 @@ def _emit_create_failure(
     "--mem",
     default=None,
     help=(
-        "Memory cap for the session's tmuxctl scope, e.g. 24G. "
-        "DEFAULT: unset — tmuxctl resolves the per-project cap from the repo's "
-        "cgroups.toml (PocketShell's is 30G). Only pass this to override that policy."
+        "Memory cap for the new session, e.g. 24G. DEFAULT: unset — the "
+        "per-project cap is resolved from the workspace's cgroups.toml "
+        "(PocketShell's is 30G), falling back to 12G for a project that "
+        "declares none. Only pass this to override that policy. `--mem none` "
+        "creates an UNCAPPED session and is only accepted on the aplexer "
+        "backend, for hosts that cannot delegate a cgroup-v2 user scope."
     ),
 )
 @click.option(
@@ -1130,11 +1201,16 @@ def sessions_create(
     `[backends].agent` and a plain session `[backends].shell` from
     `~/.config/pocketshell/config.toml` (both default to tmux).
 
-    On tmux the session is created inside tmuxctl's cgroup-v2 systemd `--user`
-    scope (capped under `robust.slice`); with `--engine` the agent launch line
-    is then sent into it server-side. `--mem` is intentionally UNSET by
-    default so tmuxctl resolves the per-project cap from the repo's
-    `cgroups.toml` (PocketShell's is 30G).
+    Both backends cap the session's memory (issue #2562). On tmux the session
+    is created inside tmuxctl's cgroup-v2 systemd `--user` scope (capped under
+    `robust.slice`), with tmuxctl resolving the per-project cap; on aplexer the
+    same `cgroups.toml` cap is resolved here (`pocketshell.memcap`) and passed
+    as `a start --memory`, which wraps the workload in its own capped scope.
+    `--mem` is intentionally UNSET by default so the repo's committed policy
+    (PocketShell's `cgroups.toml` says 30G) is what applies; a cap that cannot
+    be resolved refuses the create rather than starting an uncapped session.
+    With `--engine` the agent launch line is then sent into the tmux session
+    server-side.
 
     The create is idempotent: an existing session is a success that reports
     `"created": false` and starts no second agent in it.
@@ -1144,7 +1220,7 @@ def sessions_create(
         resolved = _route_backend(engine, backend, config)
         if resolved == _config.BACKEND_APLEXER:
             result = _create_on_aplexer(
-                name=name, cwd=cwd, engine=engine, profile=profile
+                name=name, cwd=cwd, mem=mem, engine=engine, profile=profile
             )
         elif resolved == _config.BACKEND_TMUX:
             result = _create_on_tmux(

--- a/tools/pocketshell/tests/test_sessions_create_routing.py
+++ b/tools/pocketshell/tests/test_sessions_create_routing.py
@@ -32,9 +32,16 @@ import pytest
 from click.testing import CliRunner
 
 from pocketshell import config as psconfig
+from pocketshell import memcap as psmemcap
 from pocketshell import session_enum
 from pocketshell import sessions
 from pocketshell.sessions import _route_backend, sessions_group
+
+#: The cap a workspace with no project policy of its own resolves to
+#: (issue #2562). Derived from the production constant, not retyped.
+FALLBACK_CAP_BYTES = psmemcap.parse_size(
+    psmemcap.DEFAULT_MEM, source="the built-in default cap"
+)
 
 
 # ----- fixtures -------------------------------------------------------
@@ -723,6 +730,11 @@ def test_aplexer_arm_start_argv(monkeypatch: pytest.MonkeyPatch) -> None:
             "--tag", "work",
             "--engine", "claude",
             "--profile", "work",
+            # Issue #2562: every aplexer create carries the resolved memory
+            # cap. This workspace does not exist, so no project `cgroups.toml`
+            # applies and the documented fallback does — never "no cap".
+            # `tests/test_sessions_mem_cap.py` owns the resolution itself.
+            "--memory", str(FALLBACK_CAP_BYTES),
         ]
     ]
 
@@ -740,7 +752,12 @@ def test_aplexer_arm_omits_engine_for_a_shell_session(
 
     assert result.exit_code == 0, result.output
     assert start.calls == [
-        ["/fake/a", "--json", "start", "--workspace", "/home/me/proj", "--tag", "work"]
+        [
+            "/fake/a", "--json", "start",
+            "--workspace", "/home/me/proj",
+            "--tag", "work",
+            "--memory", str(FALLBACK_CAP_BYTES),
+        ]
     ]
 
 
@@ -1219,7 +1236,10 @@ def test_cli_engine_routes_via_backends_agent_config(
     assert result.exit_code == 0, result.output
     assert envelope(result)["manager"] == "aplexer"
     assert len(start.calls) == 1
-    assert tmuxctl.calls == []
+    # Nothing was routed to tmuxctl. (`subprocess.run` is patched process-wide
+    # here, so the cap resolver's `git rev-parse --show-toplevel` workspace
+    # probe lands in this stub too — filter on the binary, not on emptiness.)
+    assert [call for call in tmuxctl.calls if call[0] == "/fake/tmuxctl"] == []
 
 
 def test_cli_shell_session_ignores_backends_agent_config(

--- a/tools/pocketshell/tests/test_sessions_mem_cap.py
+++ b/tools/pocketshell/tests/test_sessions_mem_cap.py
@@ -1,0 +1,520 @@
+"""Every session PocketShell creates carries a memory cap (issue #2562).
+
+The tmux arm has been capped since #726: `tmuxctl create-detached` wraps the
+session shell in a cgroup-v2 systemd `--user` scope and resolves the ceiling
+from the repo's committed `cgroups.toml` (PocketShell's is 30G). The aplexer
+arm passed **no** memory parameter at all, so every aplexer-backed session ran
+uncapped — visible on the dev box as `"limits": {}` on every live record. This
+file pins the fix on both arms:
+
+* the resolved value (bytes), not merely the presence of a flag;
+* `--mem` overriding it identically on both backends;
+* a cap that cannot be resolved failing LOUDLY instead of starting an uncapped
+  session (silence is the bug this issue is about);
+* and, against a real isolated aplexer, the KERNEL as the oracle — the created
+  session's own cgroup must carry the expected `memory.max`.
+
+The stubbed arms reuse the seams `test_sessions_create_routing` already owns,
+so nothing here touches a real `a`, tmuxctl or tmux server. The one real
+transport test drives the production CLI (`python -m pocketshell`) against a
+throwaway aplexer instance (`APLEXER_CONFIG` / `APLEXER_STATE_DIR` /
+`APLEXER_RUNTIME_DIR`), never the maintainer's live sessions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from pocketshell import memcap
+from pocketshell.sessions import sessions_group
+
+# The REAL tmuxctl (a hard dependency of this CLI today, `pyproject.toml`) is
+# imported so the "same source of truth" claim is checked against the arm it
+# has to agree with, not asserted. Delete those comparisons together with the
+# tmux arm in #2561; the byte-value assertions against the committed
+# `cgroups.toml` are the ones that must survive it.
+from tmuxctl import robust as tmuxctl_robust
+from tests.test_sessions_create_routing import (  # shared process seams
+    AplexerStub,
+    TmuxStub,
+    TmuxctlStub,
+    envelope,
+    use_aplexer_backend,
+    use_tmux_backend,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROJECT_CGROUPS_TOML = REPO_ROOT / "cgroups.toml"
+
+#: The cap `cgroups.toml` currently commits, in bytes. Derived independently of
+#: the code under test (see `_independent_bytes`) so a bug in our parser cannot
+#: make the expectation agree with itself, and asserted as a LITERAL below so
+#: "the cap silently became something else" is a red test, not a quiet pass.
+REPO_CAP_BYTES = 30 * 1024**3  # 30G
+
+#: The documented fallback for a workspace whose project has no cap of its own
+#: — deliberately the same value tmuxctl falls back to (`robust.DEFAULT_MEM`),
+#: so both arms agree. Never "no cap".
+FALLBACK_CAP_BYTES = 12 * 1024**3  # 12G
+
+
+def _independent_bytes(raw: str) -> int:
+    """Parse `30G` -> bytes WITHOUT the production parser (anti-tautology)."""
+    units = {"K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+    text = raw.strip()
+    assert text[-1].upper() in units, f"unhandled unit in {raw!r}"
+    return int(text[:-1]) * units[text[-1].upper()]
+
+
+def repo_cap_bytes() -> int:
+    """The repo's committed per-project cap, read from `cgroups.toml`."""
+    raw = tomllib.loads(PROJECT_CGROUPS_TOML.read_text(encoding="utf-8"))["mem"]
+    value = _independent_bytes(str(raw))
+    assert value == REPO_CAP_BYTES, (
+        f"cgroups.toml now commits {raw!r} ({value} bytes), not 30G. If that "
+        "change is deliberate, update REPO_CAP_BYTES here in the same commit."
+    )
+    return value
+
+
+def write_cgroups_toml(directory: Path, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "cgroups.toml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def start_argv(start: AplexerStub) -> list[str]:
+    assert len(start.calls) == 1, f"expected exactly one `a start`, got {start.calls}"
+    return start.calls[0]
+
+
+def memory_arg(start: AplexerStub) -> str:
+    argv = start_argv(start)
+    assert "--memory" in argv, f"`a start` ran with no --memory: {argv}"
+    return argv[argv.index("--memory") + 1]
+
+
+def create(*args: str):
+    return CliRunner().invoke(sessions_group, ["create", *args])
+
+
+# ----- the resolved value, on the aplexer arm -------------------------------
+
+
+def test_aplexer_arm_passes_the_repo_project_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session in THIS repo is capped at cgroups.toml's 30G, in bytes."""
+    start = AplexerStub(record={"id": "abc", "workspace": str(REPO_ROOT), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(REPO_ROOT), "--backend", "aplexer", "--json")
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(repo_cap_bytes())
+
+
+def test_aplexer_arm_reads_the_workspace_cgroups_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "1G"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(1024**3)
+
+
+def test_aplexer_arm_reads_the_git_root_cgroups_toml_for_a_subdirectory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A session started in a subdir inherits the repo's cap, like tmuxctl."""
+    root = tmp_path / "repo"
+    (root / "sub" / "deep").mkdir(parents=True)
+    write_cgroups_toml(root, 'mem = "2G"\n')
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    start = AplexerStub(record={"id": "abc", "workspace": str(root), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create(
+        "work", "--cwd", str(root / "sub" / "deep"), "--backend", "aplexer", "--json"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(2 * 1024**3)
+
+
+def test_workspace_without_a_project_cap_gets_the_documented_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No cgroups.toml anywhere is still CAPPED, never uncapped."""
+    workspace = tmp_path / "loose"
+    workspace.mkdir()
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "w"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("w", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(FALLBACK_CAP_BYTES)
+
+
+# ----- `--mem` honoured identically on both arms ----------------------------
+
+
+def test_explicit_mem_overrides_the_project_cap_on_the_aplexer_arm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "1G"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create(
+        "work", "--cwd", str(workspace), "--mem", "4G", "--backend", "aplexer", "--json"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(4 * 1024**3)
+
+
+def test_explicit_mem_is_forwarded_on_the_tmux_arm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The tmux arm keeps handing `--mem` to tmuxctl, unchanged."""
+    tmuxctl = TmuxctlStub()
+    use_tmux_backend(monkeypatch, tmuxctl=tmuxctl, tmux=TmuxStub())
+
+    result = create(
+        "work", "--cwd", str(tmp_path), "--mem", "4G", "--backend", "tmux", "--json"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ["--mem", "4G"] == tmuxctl.calls[0][-2:]
+
+
+# ----- an unresolvable cap fails LOUDLY -------------------------------------
+
+
+def test_unparseable_project_cap_starts_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "banana"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code != 0
+    assert start.calls == [], "an unresolvable cap must not create a session"
+    assert "banana" in envelope(result)["error"]
+
+
+def test_malformed_project_cgroups_toml_starts_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, "mem = \n")
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code != 0
+    assert start.calls == []
+    assert "cgroups.toml" in envelope(result)["error"]
+
+
+def test_unparseable_mem_flag_starts_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    workspace.mkdir()
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create(
+        "w", "--cwd", str(workspace), "--mem", "lots", "--backend", "aplexer", "--json"
+    )
+
+    assert result.exit_code != 0
+    assert start.calls == []
+
+
+def test_a_project_file_cannot_ask_for_an_uncapped_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`none` is an explicit-flag-only escape hatch, never a committed policy."""
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "none"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code != 0
+    assert start.calls == []
+
+
+def test_explicit_mem_none_is_the_only_uncapped_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Hosts that cannot enforce a cap (containers) opt out AT THE CALL SITE."""
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "1G"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create(
+        "work", "--cwd", str(workspace), "--mem", "none", "--backend", "aplexer", "--json"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "--memory" not in start_argv(start)
+
+
+def test_mem_none_is_rejected_on_the_tmux_arm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    tmuxctl = TmuxctlStub()
+    use_tmux_backend(monkeypatch, tmuxctl=tmuxctl, tmux=TmuxStub())
+
+    result = create(
+        "work", "--cwd", str(tmp_path), "--mem", "none", "--backend", "tmux", "--json"
+    )
+
+    assert result.exit_code != 0
+    assert tmuxctl.calls == []
+
+
+# ----- real transport: the kernel is the oracle -----------------------------
+
+
+REAL_CAP = "512M"
+REAL_CAP_BYTES = 512 * 1024**2
+
+
+def _real_runtime_dir() -> str:
+    """The user's REAL XDG_RUNTIME_DIR — `systemd-run --user` needs its bus."""
+    return f"/run/user/{os.getuid()}"
+
+
+def _skip_unless_user_scopes_work() -> None:
+    """Skip only when this host cannot delegate a memory-capped user scope.
+
+    Narrow on purpose: the failure this file exists to catch (no `--memory`
+    passed at all) does NOT hide behind this skip — it shows up as an empty
+    `limits` on a session that was created just fine.
+    """
+    runtime = _real_runtime_dir()
+    if not os.path.isdir(runtime):
+        pytest.skip(f"no user runtime dir at {runtime}; systemd --user is unavailable")
+    if shutil.which("systemd-run") is None:
+        pytest.skip("systemd-run is not installed")
+    probe = subprocess.run(
+        [
+            "systemd-run", "--user", "--scope", "--collect", "-p", "Delegate=yes",
+            "-p", "MemoryMax=64M", "--", "/bin/true",
+        ],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "XDG_RUNTIME_DIR": runtime, "HOME": str(Path.home())},
+        timeout=60,
+    )
+    if probe.returncode != 0:
+        pytest.skip(
+            "this host cannot create a memory-capped user scope "
+            f"(systemd-run exited {probe.returncode}: {probe.stderr.strip()})"
+        )
+
+
+def _short_runtime_root() -> str:
+    """A throwaway APLEXER_RUNTIME_DIR short enough for AF_UNIX sun_path."""
+    suffix = len("/sessions/") + 36 + len("/control.sock")
+    for base in (tempfile.gettempdir(), "/dev/shm"):
+        if not os.path.isdir(base):
+            continue
+        root = tempfile.mkdtemp(prefix="ps2562-", dir=base)
+        if len(root) + suffix < 108:
+            return root
+        os.rmdir(root)
+    raise AssertionError("no temp base short enough for an AF_UNIX control socket")
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="aplexer ships Linux wheels only")
+def test_real_aplexer_session_cgroup_carries_the_resolved_cap(tmp_path: Path) -> None:
+    """End to end: cgroups.toml -> `sessions create` -> the kernel's memory.max.
+
+    Drives the production CLI against an ISOLATED aplexer instance (its own
+    config/state/runtime), so the maintainer's live sessions are never read,
+    capped or killed. The session is torn down and its scope's disappearance
+    is asserted.
+    """
+    _skip_unless_user_scopes_work()
+
+    workspace = tmp_path / "ws"
+    write_cgroups_toml(workspace, f'mem = "{REAL_CAP}"\n')
+    state_dir = tmp_path / "aplexer-state"
+    home = tmp_path / "home"
+    for directory in (state_dir, home):
+        directory.mkdir()
+    config = tmp_path / "aplexer.toml"
+    config.write_text("version = 1\n", encoding="utf-8")
+    runtime_root = _short_runtime_root()
+    tag = "ps2562-cap"
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": str(home),
+        "TERM": "dumb",
+        "XDG_RUNTIME_DIR": _real_runtime_dir(),
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        "APLEXER_CONFIG": str(config),
+        "APLEXER_STATE_DIR": str(state_dir),
+        "APLEXER_RUNTIME_DIR": runtime_root,
+        "POCKETSHELL_APLEXER": "1",
+    }
+
+    def run_cli(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "-m", "pocketshell", *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(tmp_path),
+            timeout=120,
+        )
+
+    created = run_cli(
+        "sessions", "create", tag, "--cwd", str(workspace), "--backend", "aplexer", "--json"
+    )
+    record: dict = {}
+    try:
+        assert created.returncode == 0, (
+            f"`sessions create --backend aplexer` exited {created.returncode}: "
+            f"{created.stderr or created.stdout}"
+        )
+        records = sorted((state_dir / "sessions").glob("*/session.json"))
+        assert len(records) == 1, f"expected one session record, got {records}"
+        record = json.loads(records[0].read_text(encoding="utf-8"))
+
+        assert record["limits"] == {"memory_bytes": REAL_CAP_BYTES}, (
+            "the created aplexer session records NO memory cap: "
+            f"limits={record['limits']!r}"
+        )
+        cgroup = record.get("containment_cgroup")
+        assert cgroup, "the session has no containment cgroup, so nothing caps it"
+        memory_max = Path(cgroup, "memory.max").read_text(encoding="utf-8").strip()
+        assert memory_max == str(REAL_CAP_BYTES), (
+            f"kernel says memory.max={memory_max} for {cgroup}, "
+            f"expected {REAL_CAP_BYTES}"
+        )
+    finally:
+        # Tear the session down whatever the assertions did, then PROVE the
+        # teardown: a test that leaks a scope onto the maintainer's box is a
+        # bug of its own.
+        killed = None
+        if record.get("id"):
+            killed = run_cli("sessions", "kill", str(record["id"]), "--json")
+        shutil.rmtree(runtime_root, ignore_errors=True)
+    assert killed is not None and killed.returncode == 0, (
+        f"cleanup kill failed: {killed.stderr if killed else 'no record to kill'}"
+    )
+    leftover = record.get("containment_cgroup")
+    assert leftover and not Path(leftover).exists(), (
+        f"the test's own cgroup {leftover} outlived the session"
+    )
+
+
+# ----- the resolver itself, and its agreement with the tmux arm -------------
+#
+# "Don't hardcode a second copy of the limit" (#2562) is only true if both arms
+# read the same file the same way, so these compare against the real tmuxctl.
+
+SIZE_TABLE = ("30G", "512M", "1.5G", "12G", "2GiB", "1T", "8gb")
+
+
+@pytest.mark.parametrize("raw", SIZE_TABLE)
+def test_size_parsing_agrees_with_tmuxctl(raw: str) -> None:
+    assert memcap.parse_size(raw, source="test") == tmuxctl_robust.parse_size(raw)
+
+
+def test_the_fallback_cap_is_the_same_one_tmuxctl_falls_back_to() -> None:
+    """A capless workspace must resolve identically on both backends."""
+    assert memcap.DEFAULT_MEM == tmuxctl_robust.DEFAULT_MEM
+    assert FALLBACK_CAP_BYTES == tmuxctl_robust.parse_size(tmuxctl_robust.DEFAULT_MEM)
+
+
+def test_project_lookup_agrees_with_tmuxctl_on_this_repo() -> None:
+    found = memcap.read_project_mem(REPO_ROOT)
+    assert found is not None
+    raw, path = found
+    assert raw == tmuxctl_robust.read_project_mem(cwd=REPO_ROOT)
+    assert path == PROJECT_CGROUPS_TOML
+
+
+def test_resolving_this_repo_yields_the_committed_cap() -> None:
+    resolved = memcap.resolve_session_mem_bytes(flag=None, workspace=str(REPO_ROOT))
+    assert resolved == repo_cap_bytes() == 32212254720  # 30G
+
+
+def test_pyproject_tool_tmuxctl_is_a_cap_source(tmp_path: Path) -> None:
+    """Python projects declare the cap in pyproject.toml; tmuxctl reads it too."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.tmuxctl]\nmem = "3G"\n', encoding="utf-8"
+    )
+    assert memcap.resolve_session_mem_bytes(flag=None, workspace=str(tmp_path)) == (
+        3 * 1024**3
+    )
+    assert tmuxctl_robust.read_project_mem(cwd=tmp_path) == "3G"
+
+
+def test_a_dedicated_cgroups_toml_wins_over_pyproject(tmp_path: Path) -> None:
+    write_cgroups_toml(tmp_path, 'mem = "5G"\n')
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.tmuxctl]\nmem = "3G"\n', encoding="utf-8"
+    )
+    assert memcap.resolve_session_mem_bytes(flag=None, workspace=str(tmp_path)) == (
+        5 * 1024**3
+    )
+
+
+def test_a_malformed_pyproject_still_leaves_the_session_capped(tmp_path: Path) -> None:
+    """pyproject.toml is not primarily a cap file, so a broken one is skipped.
+
+    The session is still capped by the fallback — the outcome that must never
+    happen is "no cap", not "the fallback cap".
+    """
+    (tmp_path / "pyproject.toml").write_text("[tool.tmuxctl\n", encoding="utf-8")
+    assert memcap.resolve_session_mem_bytes(flag=None, workspace=str(tmp_path)) == (
+        FALLBACK_CAP_BYTES
+    )
+
+
+def test_a_bare_number_below_the_floor_is_a_typo_not_a_policy() -> None:
+    """`mem = "30"` (meaning 30G) must not silently become 30 BYTES."""
+    with pytest.raises(memcap.MemCapError) as excinfo:
+        memcap.parse_size("30", source="cgroups.toml")
+    assert "floor" in str(excinfo.value)
+
+
+def test_only_an_explicit_flag_can_ask_for_no_cap(tmp_path: Path) -> None:
+    assert memcap.resolve_session_mem_bytes(flag="none", workspace=str(tmp_path)) is None
+    assert memcap.resolve_session_mem_bytes(flag="NONE", workspace=str(tmp_path)) is None
+    write_cgroups_toml(tmp_path, 'mem = "none"\n')
+    with pytest.raises(memcap.MemCapError):
+        memcap.resolve_session_mem_bytes(flag=None, workspace=str(tmp_path))


### PR DESCRIPTION
Closes #2562.

## The gap

The tmux arm of `sessions create` wraps each session in a memory-capped cgroup-v2 systemd `--user` scope, resolving the per-project cap from `cgroups.toml` (PocketShell's is **30G**). The aplexer arm passed **no memory parameter at all** — live records showed `"limits": {}`.

`sessions.py`'s own comment states the stakes: *"so sessions PocketShell starts can never trigger the OOM-kill cascade that wiped the agent team."* Today the exposure is partial (default backend is tmux). After #2561 every session is aplexer-backed and **nothing** would be capped — on the maintainer's only dev box, reached from a phone.

## Two design questions, both answered against source rather than assertion

**Is the 12G fallback a silent downgrade from 30G?** No. `tmuxctl/robust.py:32` is `DEFAULT_MEM = "12G"` — the same literal, not a second number. And the *effective workspace* is identical on both arms (`cwd = start_dir or os.getcwd()` vs `workspace = cwd or os.getcwd()`), so the fallback is reached **exactly when the tmux arm would also have used 12G**. Measured: repo → `32212254720` (30G), capless dir → `12884901888` (12G).

Two deliberate divergences, both **stricter**: tmuxctl swallows resolution errors into 12G (`except Exception: return DEFAULT_MEM`) where `memcap` **raises** — the fail-loud the issue demanded; and the floor is tighter, never laxer.

**Can `--mem none` be reached accidentally?** No. The reviewer probed 13 flag shapes and 5 project-file shapes: the only routes to uncapped are the three explicit `none` spellings. Unset, empty and whitespace all fall through to project resolution, and the tmux arm rejects it with **exit 2**, creating nothing.

Its use in the Docker fixture is **necessary**, confirmed in a throwaway container: the delegation probe reproduces `Failed to connect to user scope bus`, and `a start --memory` **exits 1 with "limits fail closed"** where the same start without it exits 0. Passing the cap unconditionally would have broken every fixture create.

## The kernel is the oracle

A record showing `limits` is not evidence. Reviewer's own value: `cgroups.toml mem = "768M"` → record `805306368` → kernel `memory.max: 805306368`, `swap.max: 0`; after kill the cgroup is gone and the scope count returns to baseline.

## Evidence

- RED 11 failed with `assert {} == {'memory_bytes': 536870912}`; GREEN 28 passed.
- Suite **1360 passed / 4 skipped** post-rebase (1331/4 with only the new file excluded → **+28 exact**, skip count unchanged).
- `test_real_aplexer_session_cgroup_carries_the_resolved_cap` **PASSED, did not skip** — checked explicitly, since a silently-skipped real-transport test would be the obvious way this looks done without being done.
- Could not construct a path producing an uncapped session; cap resolution runs before snapshot/reap/start.
- Existing fixture guard's static half byte-identical on branch and base.
- Hygiene, test-validity, CI-lock, `git diff --check` clean.

## Not run, and why

The reviewer did **not** run the fixture guard's `--docker` half: it does two `docker build`s and `/data` is at 98% / 12 GiB. They said so explicitly rather than lowering a disk guard, and covered its substance with direct container probes. Flagging it here rather than leaving it implicit.

## Follow-ups found, filed separately

A no-`--cwd` → `$HOME` → 12G parity gap (the app should pass `--cwd`); systemd scope-unit accumulation; and that a typo in the committed `cgroups.toml` would hard-fail aplexer creates while tmux keeps working — worth knowing before #2561 removes the tmux arm.