### PR TITLE
test: let a journey enumerate real aplexer sessions in the agents fixture

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/terminal/J15TerminalScrollJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/terminal/J15TerminalScrollJourney.kt
@@ -657,7 +657,14 @@ class J15TerminalScrollJourney {
      * would see from a real enumeration.
      */
     private fun seedAplexerSession() {
-        AgentsFixture.exec("rm -f $ERRORS_FILE")
+        // $LIVE_MARKER: issue #2586. A journey that opted into the fixture's
+        // LIVE aplexer arm leaves that marker in the shared container (#2474
+        // runs the suite unfiltered, one process, one fixture), and marker +
+        // the seed written below is a deliberate rc-78 mode conflict — the app
+        // would receive no listing at all and this journey would fail as a bare
+        // 60-second Compose timeout. Cleared with the errors file it already
+        // clears, so the deterministic arm defends itself.
+        AgentsFixture.exec("rm -f $ERRORS_FILE $LIVE_MARKER")
         // One live session per run: a leftover from a previous run would be a
         // second `<workspace>:<tag>` and `a start` refuses the duplicate.
         killAplexerSession()
@@ -801,6 +808,9 @@ class J15TerminalScrollJourney {
 
         const val APLEXER_FILE = "\$HOME/.pocketshell-fixture-aplexer.json"
         const val ERRORS_FILE = "\$HOME/.pocketshell-fixture-session-errors.json"
+
+        /** The fixture's LIVE-aplexer opt-in marker (issue #2586); cleared, never set. */
+        const val LIVE_MARKER = "\$HOME/.pocketshell-fixture-aplexer-live"
 
         const val TMUX_SOCKET_DIR = "\"\${TMUX_TMPDIR:-/tmp}/tmux-\$(id -u)\""
         const val TMUX_SOCKET =

--- a/app2/src/androidTest/java/com/pocketshell/next/tree/J02SessionTreeListJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/tree/J02SessionTreeListJourney.kt
@@ -143,6 +143,16 @@ class J02SessionTreeListJourney {
     private fun seedHostSessions(description: Description) {
         val partial = description.methodName.contains("partial", ignoreCase = true)
         val now = System.currentTimeMillis() / 1000
+        // Issue #2586: the live-enumeration marker is per-user state in a
+        // container the WHOLE suite shares (#2474 runs it unfiltered, one
+        // process, one fixture), and nothing expires it — a journey that opted
+        // into live mode leaves it behind for everyone after it. Marker + the
+        // seed this journey writes is a deliberate rc-78 mode conflict, so the
+        // app would receive no listing at all and every assertion below would
+        // fail as a bare 60-second Compose timeout that names nothing. Cleared
+        // unconditionally, BEFORE the partial branch: the deterministic arm
+        // defends itself rather than trusting the previous journey's teardown.
+        AgentsFixture.exec("rm -f $LIVE_MARKER")
         AgentsFixture.writeFile(
             DETAIL_FILE,
             """
@@ -379,6 +389,13 @@ class J02SessionTreeListJourney {
         const val DETAIL_FILE = "\$HOME/.pocketshell-fixture-session-detail.json"
         const val APLEXER_FILE = "\$HOME/.pocketshell-fixture-aplexer.json"
         const val ERRORS_FILE = "\$HOME/.pocketshell-fixture-session-errors.json"
+
+        /**
+         * The opt-in marker for the fixture's LIVE aplexer arm (issue #2586).
+         * This journey drives the deterministic seed arm and must therefore
+         * remove it — see [seedHostSessions].
+         */
+        const val LIVE_MARKER = "\$HOME/.pocketshell-fixture-aplexer-live"
 
         val HOST_IDS: Map<String, Long> = mapOf(
             "connectingToAHostListsItsRealSessionsGroupedByWorkspace" to 9_201L,

--- a/app2/src/androidTest/java/com/pocketshell/next/tree/J04CreateSessionJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/tree/J04CreateSessionJourney.kt
@@ -132,7 +132,13 @@ class J04CreateSessionJourney {
      * instead, silently testing the wrong half).
      */
     private fun seedHostState() {
-        AgentsFixture.exec("rm -f $ERRORS_FILE $APLEXER_FILE $DETAIL_FILE")
+        // $LIVE_MARKER: issue #2586. A journey that opted into the fixture's
+        // LIVE aplexer arm leaves that marker in the shared container, and
+        // marker + a seed file is a deliberate rc-78 mode conflict — the app
+        // gets no listing at all and this journey would fail as a bare
+        // 60-second Compose timeout. Cleared here with the seeds it already
+        // clears, so the deterministic arm defends itself.
+        AgentsFixture.exec("rm -f $ERRORS_FILE $APLEXER_FILE $DETAIL_FILE $LIVE_MARKER")
         AgentsFixture.exec("mkdir -p $FOLDER_NEW $FOLDER_TWICE")
         killSession(SESSION_NEW)
         killSession(SESSION_TWICE)
@@ -375,6 +381,9 @@ class J04CreateSessionJourney {
         const val DETAIL_FILE = "\$HOME/.pocketshell-fixture-session-detail.json"
         const val APLEXER_FILE = "\$HOME/.pocketshell-fixture-aplexer.json"
         const val ERRORS_FILE = "\$HOME/.pocketshell-fixture-session-errors.json"
+
+        /** The fixture's LIVE-aplexer opt-in marker (issue #2586); cleared, never set. */
+        const val LIVE_MARKER = "\$HOME/.pocketshell-fixture-aplexer-live"
 
         /** Per-test host ids, for the same reason J01/J02 use them. */
         val HOST_IDS: Map<String, Long> = mapOf(

--- a/app2/src/androidTest/java/com/pocketshell/next/tree/J14StopSessionJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/tree/J14StopSessionJourney.kt
@@ -99,7 +99,13 @@ class J14StopSessionJourney {
     }
 
     private fun seedHostState(description: Description) {
-        AgentsFixture.exec("rm -f $ERRORS_FILE $APLEXER_FILE $DETAIL_FILE")
+        // $LIVE_MARKER: issue #2586. A journey that opted into the fixture's
+        // LIVE aplexer arm leaves that marker in the shared container, and
+        // marker + a seed file is a deliberate rc-78 mode conflict — the app
+        // gets no listing at all and this journey would fail as a bare
+        // 60-second Compose timeout. Cleared here with the seeds it already
+        // clears, so the deterministic arm defends itself.
+        AgentsFixture.exec("rm -f $ERRORS_FILE $APLEXER_FILE $DETAIL_FILE $LIVE_MARKER")
         val name = THROWAWAY_BY_TEST.getValue(description.methodName)
         cleanupThrowaway(name)
         AgentsFixture.exec("pocketshell sessions create --json -- '$name'")
@@ -240,6 +246,9 @@ class J14StopSessionJourney {
         const val DETAIL_FILE = "\$HOME/.pocketshell-fixture-session-detail.json"
         const val APLEXER_FILE = "\$HOME/.pocketshell-fixture-aplexer.json"
         const val ERRORS_FILE = "\$HOME/.pocketshell-fixture-session-errors.json"
+
+        /** The fixture's LIVE-aplexer opt-in marker (issue #2586); cleared, never set. */
+        const val LIVE_MARKER = "\$HOME/.pocketshell-fixture-aplexer-live"
 
         val HOST_IDS: Map<String, Long> = mapOf(
             "stoppingAThrowawaySessionFromTheTreeRemovesItFromTheHost" to 9_141L,

--- a/scripts/test-agents-fixture-aplexer.sh
+++ b/scripts/test-agents-fixture-aplexer.sh
@@ -15,11 +15,21 @@
 #
 # The static half runs per-push in `guards-ci-harness`; `--docker` runs in
 # `Integration tests (Docker)`.
+#
+# Issue #2586 added the second half of the same failure family: the fixture's
+# `sessions list --json` served aplexer rows ONLY from a seed file, so a
+# session really created with `sessions create --backend aplexer` — real
+# worker, real PTY, provably attachable — was invisible to the app. The seed
+# arm stays (it is the only way to produce J02's exact row and #2426's
+# one-backend-failing shape); live enumeration is an opt-in second arm, and
+# POSITIVE 5 below drives both sides of that bug plus the two ways the arms
+# must refuse to be confused with each other.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOCKERFILE="$ROOT_DIR/tests/docker/Dockerfile.agents"
 SELFCHECK="$ROOT_DIR/tests/docker/agents-aplexer-selfcheck.py"
+ENUMERATOR="$ROOT_DIR/tests/docker/agent-bin/pocketshell-fixture-sessions"
 PYPROJECT="$ROOT_DIR/tools/pocketshell/pyproject.toml"
 
 pass_count=0
@@ -123,6 +133,38 @@ ok "the pin is asserted by behaviour, never \`a --version\`"
 python3 -c "import ast,sys; ast.parse(open(sys.argv[1]).read())" "$SELFCHECK" \
   || fail "$SELFCHECK does not parse"
 ok "self-check parses"
+
+# --- The two enumeration arms (issue #2586) --------------------------------
+# The fixture's `sessions list --json` has a DETERMINISTIC seed arm and an
+# opt-in LIVE arm. Each is load-bearing for something the other cannot do, so
+# both the seed arm's contract note and the live arm's wiring are pinned here.
+[[ -f "$ENUMERATOR" ]] || fail "missing $ENUMERATOR"
+grep -Fq 'DETERMINISTIC arm' "$ENUMERATOR" \
+  || fail "the seed arm's contract note is gone from $ENUMERATOR. That arm is
+  not an unfinished stub: it is the only way to produce J02's exact aplexer row
+  and the #2426 shape of one backend failing while the other answers, neither
+  of which a live session can do. Replacing it with live enumeration deletes
+  that coverage silently."
+ok "the deterministic seed arm is still documented as deliberate"
+
+grep -Fq 'enumerate_live_sessions' "$ENUMERATOR" \
+  || fail "the live arm must call the PRODUCTION enumerator
+  (pocketshell.session_enum.enumerate_live_sessions), not a second
+  implementation in the fixture — a fixture that maps aplexer rows its own way
+  can agree with a broken client."
+ok "the live arm delegates to the production enumerator"
+
+grep -Fq 'FIXTURE-SESSIONS FAIL [mode]' "$ENUMERATOR" \
+  && grep -Fq 'FIXTURE-SESSIONS FAIL [live]' "$ENUMERATOR" \
+  || fail "the live arm must fail LOUDLY for a stale seed ([mode]) and for an
+  unresolvable \`a\` or a kill switch ([live]). Both degrade into a listing
+  that looks healthy, which is the vacuous-green shape this whole guard exists
+  to prevent."
+ok "both live-arm conflict diagnostics are present"
+
+python3 -c "import ast,sys; ast.parse(open(sys.argv[1]).read())" "$ENUMERATOR" \
+  || fail "$ENUMERATOR does not parse"
+ok "the fixture enumerator parses"
 
 printf 'Static invariants passed (%d checks).\n' "$pass_count"
 
@@ -354,6 +396,218 @@ ssh_exec '
 ' || fail "tmux no longer works in the agents image; this slice must not remove tmux"
 ok "tmux capability is intact"
 
+# --- POSITIVE 5: the OPT-IN LIVE enumeration arm (issue #2586) -----------
+#
+# Until now the fixture's `pocketshell sessions list --json` served aplexer
+# rows from a seed file and NOTHING else, so a session a journey really created
+# with `sessions create --backend aplexer` — a real aplexer session, with a
+# real worker and a real PTY, as POSITIVE 2 above proves — was invisible to the
+# app. That seed arm is deliberate and stays: it is the only way to produce
+# J02's exact row and the #2426 shape of one backend failing while the other
+# answers, neither of which a live session can do. So live enumeration is an
+# OPT-IN second arm, and this block drives BOTH sides of the bug plus the two
+# ways the arms must refuse to be confused.
+#
+# Everything here goes through `pocketshell`, the FIXTURE shim the app
+# actually invokes — not `pocketshell-real-send`, which is the real CLI and was
+# never the broken one.
+printf '\nPOSITIVE 5: opt-in live enumeration through the fixture shim...\n'
+LIVE_TAG="guard-live-${SUFFIX}"
+# Literal paths, not $HOME-derived: the container user is always `testuser`,
+# and the seed/marker names are the fixture's published contract, so a journey
+# reading this file sees exactly what it must write.
+
+aplexer_rows_in() {
+  python3 -c 'import json,sys
+d = json.load(open(sys.argv[1]))
+print(len([r for r in d["sessions"] if r["manager"] == "aplexer"]))' "$1"
+}
+
+# Start from the state every journey is in: nothing seeded, no marker.
+ssh_exec "rm -f /home/testuser/.pocketshell-fixture-aplexer.json /home/testuser/.pocketshell-fixture-aplexer-live" \
+  || fail "could not clear the aplexer seed/marker state"
+ssh_exec "pocketshell sessions list --json" > "$tmp_dir/live-before.json" \
+  || fail "the fixture's \`sessions list --json\` failed"
+[[ "$(aplexer_rows_in "$tmp_dir/live-before.json")" == "0" ]] \
+  || fail "the unseeded fixture already reports aplexer rows"
+ok "baseline: unseeded fixture reports zero aplexer rows"
+
+# THE SESSION. Created over the app's own channel, through the fixture shim.
+# No --memory: `a start --memory` fails closed in this unprivileged container
+# (no cgroup delegation), so a limit here would test the fixture's plumbing
+# rather than its enumeration.
+live_create="$(ssh_exec "pocketshell sessions create '$LIVE_TAG' --backend aplexer --cwd /home/testuser --json")" \
+  || fail "\`pocketshell sessions create --backend aplexer\` failed through the fixture shim"
+LIVE_NAME="$(printf '%s' "$live_create" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("name",""))')"
+[[ -n "$LIVE_NAME" ]] || fail "fixture create envelope carried no name: $live_create"
+printf '%s' "$live_create" | grep -Fq '"manager": "aplexer"' \
+  || fail "the fixture shim did not route create to aplexer: $live_create"
+ok "created a REAL aplexer session '$LIVE_NAME' through the fixture shim"
+
+# THE BUG, still true by design: with no opt-in the listing is the
+# deterministic arm, so the live session it just made is not in it. This
+# assertion is not a bug report — it is the guarantee that adding live mode
+# changed nothing for J02 and the #2426 journeys, which seed and never opt in.
+ssh_exec "pocketshell sessions list --json" > "$tmp_dir/live-default.json" \
+  || fail "the fixture's \`sessions list --json\` failed after create"
+[[ "$(aplexer_rows_in "$tmp_dir/live-default.json")" == "0" ]] \
+  || fail "the DEFAULT arm leaked a live session into the listing; J02 and the
+  #2426 journeys depend on the deterministic arm ignoring live state"
+ok "default arm: the live session is invisible (deterministic arm unchanged)"
+
+# THE OPT-IN. One marker file, written over the same SSH channel a journey
+# seeds everything else with.
+ssh_exec "touch /home/testuser/.pocketshell-fixture-aplexer-live" \
+  || fail "could not write the live-mode marker"
+ssh_exec "pocketshell sessions list --json" > "$tmp_dir/live-on.json" \
+  || fail "the fixture's \`sessions list --json\` failed in live mode"
+# The oracle is the REAL CLI's own listing, on a separate connection: the live
+# row must be the row `a` reports, not a row the fixture composed.
+ssh_exec "pocketshell-real-send sessions list --json" > "$tmp_dir/live-real.json" \
+  || fail "the real CLI's \`sessions list --json\` failed"
+python3 - "$tmp_dir/live-on.json" "$tmp_dir/live-real.json" "$LIVE_TAG" "$LIVE_NAME" <<'PY' || fail "live mode did not report the session the real \`a\` reports"
+import json, sys
+fixture = json.load(open(sys.argv[1]))
+real = json.load(open(sys.argv[2]))
+tag, name = sys.argv[3], sys.argv[4]
+rows = [r for r in fixture["sessions"] if r["manager"] == "aplexer" and r["tag"] == tag]
+if not rows:
+    sys.stderr.write("guard: live mode has no aplexer row for %r; managers=%r errors=%r\n"
+                     % (tag, fixture.get("managers"), fixture.get("errors")))
+    raise SystemExit(1)
+row = rows[0]
+truth = [r for r in real["sessions"] if r["manager"] == "aplexer" and r["tag"] == tag]
+if not truth:
+    sys.stderr.write("guard: the REAL CLI does not list %r either\n" % (tag,))
+    raise SystemExit(1)
+truth = truth[0]
+for key in ("name", "id", "workspace", "tag", "phase", "alive"):
+    if row.get(key) != truth.get(key):
+        sys.stderr.write("guard: live row %s=%r but the real CLI says %r\n"
+                         % (key, row.get(key), truth.get(key)))
+        raise SystemExit(1)
+if row["name"] != name:
+    sys.stderr.write("guard: live row name %r != created name %r\n" % (row["name"], name))
+    raise SystemExit(1)
+if "aplexer" not in fixture.get("managers", []):
+    sys.stderr.write("guard: live rows present but aplexer absent from managers\n")
+    raise SystemExit(1)
+if fixture.get("errors"):
+    sys.stderr.write("guard: healthy live enumeration reported errors: %r\n" % (fixture["errors"],))
+    raise SystemExit(1)
+# The canned tmux rows must survive: live mode replaces the aplexer arm only.
+if not [r for r in fixture["sessions"] if r["manager"] == "tmux"]:
+    sys.stderr.write("guard: live mode dropped the canned tmux rows\n")
+    raise SystemExit(1)
+print("guard: live row %s id=%s matches the real CLI byte for byte" % (row["name"], row["id"]))
+PY
+ok "live mode lists the created session with the id + name the real \`a\` reports"
+
+# THE CONFUSION GUARD. A leftover seed plus the marker must not merge into one
+# listing — a journey would assert against whichever source happened to win.
+ssh_exec "printf '%s' '{\"sessions\": [{\"name\": \"stale:row\"}]}' > /home/testuser/.pocketshell-fixture-aplexer.json" \
+  || fail "could not stage the stale-seed state"
+set +e
+conflict_out="$(ssh_exec "pocketshell sessions list --json" 2>"$tmp_dir/live-conflict.err")"
+conflict_rc=$?
+set -e
+printf '  conflict stderr: %s\n' "$(head -c 300 "$tmp_dir/live-conflict.err")"
+[[ $conflict_rc -ne 0 ]] \
+  || fail "live mode with a stale seed file exited 0; the arms merged silently"
+[[ -z "${conflict_out// /}" ]] \
+  || fail "a mode conflict emitted a listing on stdout: $conflict_out"
+grep -Fq 'FIXTURE-SESSIONS FAIL [mode]' "$tmp_dir/live-conflict.err" \
+  || fail "expected a [mode] diagnostic for seed+live, got: $(cat "$tmp_dir/live-conflict.err")"
+ok "stale seed + live marker fails LOUDLY (rc=$conflict_rc, no listing)"
+
+# Back to the deterministic arm: seed alone, no marker, exactly J02's state.
+ssh_exec "rm -f /home/testuser/.pocketshell-fixture-aplexer-live" \
+  || fail "could not remove the live marker"
+ssh_exec "pocketshell sessions list --json" > "$tmp_dir/live-seed-only.json" \
+  || fail "the fixture's \`sessions list --json\` failed with the seed alone"
+python3 - "$tmp_dir/live-seed-only.json" "$LIVE_TAG" <<'PY' || fail "the seed arm did not recover"
+import json, sys
+payload = json.load(open(sys.argv[1]))
+rows = [r for r in payload["sessions"] if r["manager"] == "aplexer"]
+names = [r["name"] for r in rows]
+if names != ["stale:row"]:
+    sys.stderr.write("guard: seed arm reported %r, expected exactly the seeded row\n" % (names,))
+    raise SystemExit(1)
+if any(r.get("tag") == sys.argv[2] for r in rows):
+    sys.stderr.write("guard: the live session leaked into the seed arm\n")
+    raise SystemExit(1)
+print("guard: seed arm reports exactly the seeded row")
+PY
+ok "removing the marker restores the seed arm verbatim (so the red above was the marker)"
+
+# THE CROSS-JOURNEY SEQUENCE, in order (issue #2586, round 2). The marker is
+# per-user state in a container the WHOLE app2 suite shares (#2474 runs it
+# unfiltered, one process, one fixture) and nothing expires it, so a journey
+# that opts into live mode leaves it behind for every journey after it. The
+# next journey to seed the deterministic arm then gets rc 78 and no listing —
+# which reaches its author as bare 60-second Compose timeouts naming nothing.
+# Reproduced here at the fixture level, with the EXACT `rm -f` string
+# J02/J04/J14 now run, so the property is pinned rather than rediscovered.
+printf '  cross-journey sequence: live journey -> seeding journey\n'
+JOURNEY_CLEAR="rm -f /home/testuser/.pocketshell-fixture-session-errors.json \
+/home/testuser/.pocketshell-fixture-aplexer.json \
+/home/testuser/.pocketshell-fixture-session-detail.json \
+/home/testuser/.pocketshell-fixture-aplexer-live"
+SEED_ROW='{"sessions": [{"name": "aplexer-follow:yolo", "id": "seed-id"}]}'
+
+# 1. A live-mode journey ran and left the marker. The next journey seeds
+#    WITHOUT clearing it — the round-1 state, and it must be hostile.
+ssh_exec "rm -f /home/testuser/.pocketshell-fixture-aplexer.json" \
+  || fail "could not clear the seed"
+ssh_exec "touch /home/testuser/.pocketshell-fixture-aplexer-live" \
+  || fail "could not leave the marker behind"
+ssh_exec "printf '%s' '$SEED_ROW' > /home/testuser/.pocketshell-fixture-aplexer.json" \
+  || fail "could not seed as the next journey would"
+set +e
+poisoned_out="$(ssh_exec "pocketshell sessions list --json" 2>/dev/null)"
+poisoned_rc=$?
+set -e
+[[ $poisoned_rc -ne 0 && -z "${poisoned_out// /}" ]] \
+  || fail "a seeding journey following a live one got a listing (rc=$poisoned_rc);
+  the sequence below would then prove nothing"
+ok "uncleared sequence is genuinely hostile (rc=$poisoned_rc, no listing)"
+
+# 2. The same sequence with the journeys' own clearing command in front of the
+#    seed: the deterministic arm answers, exactly as it does with no live
+#    journey in the run at all.
+ssh_exec "$JOURNEY_CLEAR" || fail "the journeys' clearing command failed"
+ssh_exec "printf '%s' '$SEED_ROW' > /home/testuser/.pocketshell-fixture-aplexer.json" \
+  || fail "could not re-seed after clearing"
+ssh_exec "pocketshell sessions list --json" > "$tmp_dir/live-sequence.json" \
+  || fail "the seeding journey still cannot list after clearing the marker"
+python3 - "$tmp_dir/live-sequence.json" <<'PY' || fail "the clearing command did not restore the deterministic arm"
+import json, sys
+payload = json.load(open(sys.argv[1]))
+names = [r["name"] for r in payload["sessions"] if r["manager"] == "aplexer"]
+if names != ["aplexer-follow:yolo"]:
+    sys.stderr.write("guard: after clearing, aplexer rows were %r\n" % (names,))
+    raise SystemExit(1)
+if not [r for r in payload["sessions"] if r["manager"] == "tmux"]:
+    sys.stderr.write("guard: the canned tmux rows are missing\n")
+    raise SystemExit(1)
+print("guard: seeding journey after a live journey sees exactly its seeded row")
+PY
+ok "the journeys' \`rm -f ... aplexer-live\` makes the sequence green again"
+
+# The human table is not part of either arm and must not have moved.
+ssh_exec "pocketshell sessions list" > "$tmp_dir/live-human.txt" \
+  || fail "the fixture's human \`sessions list\` failed"
+diff -u "$ROOT_DIR/tests/docker/agent-fixtures/pocketshell-sessions-list.txt" \
+  "$tmp_dir/live-human.txt" >/dev/null \
+  || fail "the human \`sessions list\` table is no longer byte-for-byte the canned file"
+ok "the human \`sessions list\` table is still byte-for-byte the canned file"
+
+ssh_exec "rm -f /home/testuser/.pocketshell-fixture-aplexer.json /home/testuser/.pocketshell-fixture-aplexer-live" \
+  || fail "could not clear the seed/marker state"
+ssh_exec "pocketshell-real-send sessions kill '$LIVE_NAME' --json" >/dev/null \
+  || fail "could not kill the live guard session"
+ok "cleaned up the live guard session"
+
 # --- NEGATIVE 1: the bundle is half-installed ----------------------------
 # Issue #2553 (landed after this slice started) made `resolve_a` REJECT a
 # bundled `a` whose sibling worker is missing, rather than let `a` fall back to
@@ -412,6 +666,25 @@ case "$silent" in
   *"aplexer_rows=0"*) ok "confirmed: the real CLI stays silent over SSH (exit 0, zero aplexer rows)" ;;
   *) fail "expected the misplaced-\`a\` state to yield zero aplexer rows, got: $silent" ;;
 esac
+
+# 2b. THE SAME SILENCE, THROUGH THE FIXTURE'S LIVE ARM (issue #2586). A
+#     journey that opted into live enumeration asked for real sessions; being
+#     handed a tmux-only listing with exit 0 because `a` is misplaced is the
+#     vacuous green one level up. The fixture must name it instead.
+ssh_exec "touch /home/testuser/.pocketshell-fixture-aplexer-live" \
+  || fail "could not write the live-mode marker"
+set +e
+live_neg_out="$(ssh_exec "pocketshell sessions list --json" 2>"$tmp_dir/live-neg.err")"
+live_neg_rc=$?
+set -e
+printf '  live-arm stderr: %s\n' "$(head -c 300 "$tmp_dir/live-neg.err")"
+[[ $live_neg_rc -ne 0 ]] \
+  || fail "live mode returned a listing with \`a\` on PATH only: $live_neg_out"
+grep -Fq 'FIXTURE-SESSIONS FAIL [live]' "$tmp_dir/live-neg.err" \
+  || fail "expected a [live] diagnostic for a misplaced \`a\`, got: $(cat "$tmp_dir/live-neg.err")"
+ok "live mode turns the misplaced-\`a\` silence into FAIL [live] (rc=$live_neg_rc)"
+ssh_exec "rm -f /home/testuser/.pocketshell-fixture-aplexer-live" \
+  || fail "could not remove the live-mode marker"
 
 # 3. THE GUARD. The self-check must turn that silence into a named failure.
 set +e

--- a/tests/docker/agent-bin/pocketshell-fixture-sessions
+++ b/tests/docker/agent-bin/pocketshell-fixture-sessions
@@ -33,7 +33,7 @@ The pre-schema-2 ``{"managers": [...], "sessions": [{"name", "manager",
 "created", "attach"}]}`` shape is gone — a hard cut (D22), matching the deleted
 schema-1 client. ``list`` is untouched and still byte-for-byte the canned table.
 
-Three per-user seed files let a journey give the fixture a realistic host
+Four per-user seed files let a journey give the fixture a realistic host
 state over the SSH session it already has, with no image rebuild:
 
   * ``POCKETSHELL_FIXTURE_SESSION_DETAIL_FILE``
@@ -48,7 +48,9 @@ state over the SSH session it already has, with no image rebuild:
     [{"name": ..., "workspace": ..., ...}]}``, appended as ``manager:
     "aplexer"`` rows. Absent file => no aplexer rows, which is every journey
     that does not seed one. Issue #2563 moved this read here from the deleted
-    61-line shell ``a`` stub, which did nothing else.
+    61-line shell ``a`` stub, which did nothing else. This is the DEFAULT
+    and DETERMINISTIC arm; ``POCKETSHELL_FIXTURE_APLEXER_LIVE_FILE`` below is
+    the other one.
   * ``POCKETSHELL_FIXTURE_SESSION_ERRORS_FILE``
     (default ``$HOME/.pocketshell-fixture-session-errors.json``) — a list of
     ``{"manager": ..., "message": ...}`` records, appended verbatim to
@@ -56,8 +58,55 @@ state over the SSH session it already has, with no image rebuild:
     contract on a device: a backend that failed to enumerate while the other
     one answered. Absent file => no errors, which is every other journey.
 
-All three default to absent, so a fixture nobody seeded behaves the same as
-before.
+  * ``POCKETSHELL_FIXTURE_APLEXER_LIVE_FILE``
+    (default ``$HOME/.pocketshell-fixture-aplexer-live``) — a MARKER file, any
+    content, whose mere presence switches the aplexer arm from the seed file to
+    LIVE enumeration through the real pinned ``a`` (issue #2586). A session a
+    journey really made with ``pocketshell sessions create --backend aplexer``
+    used to be invisible here, because this arm only ever read the seed; with
+    the marker in place it is enumerated by the PRODUCTION code
+    (``pocketshell.session_enum.enumerate_live_sessions``), so the fixture and
+    the real CLI cannot disagree about a live session's id or display name.
+
+    The two arms never merge and never degrade quietly:
+
+      * live + a leftover seed file => a hard ``[mode]`` failure, no listing at
+        all. Merging them is how a journey ends up asserting against the wrong
+        source and passing for the wrong reason;
+      * live + no resolvable ``a`` (absent, or the #2543 PATH-only landmine),
+        or live + the ``POCKETSHELL_APLEXER=0`` kill switch => a hard ``[live]``
+        failure. The production probe's answer for those states is "this host
+        has no aplexer": zero rows, zero errors, exit 0. That is right for a
+        tmux-only host and never right for a journey that ASKED for live
+        enumeration — it is the vacuous green ci-pitfalls.md catalogues;
+      * live + an ``a`` that IS there and whose probe FAILS => not a mode error
+        at all, but the #2426 partial-listing contract: the listing is emitted
+        with aplexer in ``errors`` and out of ``managers``.
+
+    LIFECYCLE. The marker is per-user state in a container the WHOLE app2
+    journey suite shares (#2474 runs the set unfiltered, one process, one
+    fixture) and nothing expires it, so a journey that opts in leaves it behind
+    for every journey after it — and the next journey to seed the deterministic
+    arm gets the rc-78 conflict above, which reaches its author as bare
+    60-second Compose timeouts naming nothing. Two rules, both enforced by
+    ``tools/pocketshell/tests/test_agents_fixture_aplexer.py``:
+
+      * a journey opts in and out as a PAIR — the teardown is not optional::
+
+            // setup
+            AgentsFixture.exec(
+                "rm -f \\$HOME/.pocketshell-fixture-aplexer.json && " +
+                    "touch \\$HOME/.pocketshell-fixture-aplexer-live",
+            )
+            // @After
+            AgentsFixture.exec("rm -f \\$HOME/.pocketshell-fixture-aplexer-live")
+
+      * and every journey that SEEDS the deterministic arm removes the marker
+        itself (J02/J04/J14 do, in the ``rm -f`` they already run), so a
+        forgotten teardown cannot poison it.
+
+All four default to absent, so a fixture nobody seeded behaves the same as
+before, and ``list`` (the human table) is untouched by all of them.
 
 Usage: ``pocketshell-fixture-sessions {list|json} <canned-table-file>``
 """
@@ -105,6 +154,22 @@ ROW_KEYS = (
     "activity_epoch",
 )
 TIMESTAMP = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
+
+# `EX_CONFIG`. A mode conflict is a FIXTURE misconfiguration, not a host
+# failure, so it exits non-zero with an empty stdout: a journey gets a hard
+# host-CLI error instead of a listing it could mistake for either arm.
+EXIT_FIXTURE_MISCONFIGURED = 78
+
+# The two ways the aplexer arms refuse to be confused, spelled out as literals
+# so a guard can grep for them (same shape as the self-check's
+# `FIXTURE-APLEXER-SELFCHECK FAIL [placement]`). An unknown kind raises
+# KeyError rather than printing a prefix nobody greps for.
+FAIL_PREFIXES = {
+    #: live enumeration requested while a deterministic seed file still exists
+    "mode": "FIXTURE-SESSIONS FAIL [mode]",
+    #: live enumeration requested but it could not be performed for real
+    "live": "FIXTURE-SESSIONS FAIL [live]",
+}
 LEADING_IDX = re.compile(r"^(\s*\d+\s+)")
 
 
@@ -246,6 +311,130 @@ def aplexer_rows() -> list[dict]:
     return rows
 
 
+class FixtureModeError(Exception):
+    """The fixture was asked for two mutually exclusive things (issue #2586).
+
+    Raised instead of degrading, because every degradation available here is
+    indistinguishable from a healthy answer: a merged seed+live listing looks
+    like a listing, and a live listing with no ``a`` looks like a tmux-only
+    host. Both are the vacuous-green shape ``docs/ci-pitfalls.md`` catalogues.
+    """
+
+    def __init__(self, kind: str, message: str) -> None:
+        super().__init__(message)
+        self.kind = kind
+
+
+def live_mode_requested() -> bool:
+    """Whether a journey opted into live aplexer enumeration (issue #2586).
+
+    A marker FILE, not an environment variable: a journey seeds the fixture
+    over the same non-interactive SSH ``exec`` channel the app uses, where it
+    can write ``$HOME`` but cannot set the environment of the app's later
+    commands. Same reason the other three seeds are files.
+    """
+    return os.path.exists(
+        _seed_file(
+            "POCKETSHELL_FIXTURE_APLEXER_LIVE_FILE",
+            ".pocketshell-fixture-aplexer-live",
+        )
+    )
+
+
+def _real_source_dir() -> str | None:
+    """Where the repository's real ``pocketshell`` package lives, if anywhere.
+
+    The live arm does not reimplement enumeration — it calls the PRODUCTION
+    code, so the fixture's live rows are the rows the real CLI would emit
+    (display name, liveness filtering, agent-state derivation, the #2426 error
+    shape) rather than a second implementation that can drift from it.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates = [
+        os.environ.get("POCKETSHELL_FIXTURE_REAL_SRC"),
+        # Inside the `agents` image (Dockerfile.agents COPYs it there).
+        "/opt/pocketshell-real/src",
+        # Straight out of the repo: tests/docker/agent-bin/<this file>.
+        os.path.join(here, "..", "..", "..", "tools", "pocketshell", "src"),
+    ]
+    for candidate in candidates:
+        if candidate and os.path.isdir(os.path.join(candidate, "pocketshell")):
+            return os.path.abspath(candidate)
+    return None
+
+
+def live_aplexer_rows() -> tuple[list[dict], list[dict]]:
+    """``(rows, errors)`` for the LIVE arm — real sessions through the real ``a``.
+
+    Every precondition below fails LOUDLY rather than returning an empty list,
+    for the reason :class:`FixtureModeError` documents. The one thing that does
+    NOT fail loudly is a resolvable ``a`` whose probe blows up: that is the
+    #2426 partial-listing contract, and the production enumerator already
+    reports it as an ``errors`` entry.
+    """
+    seed = _seed_file(
+        "POCKETSHELL_FIXTURE_APLEXER_FILE", ".pocketshell-fixture-aplexer.json"
+    )
+    live_marker = _seed_file(
+        "POCKETSHELL_FIXTURE_APLEXER_LIVE_FILE",
+        ".pocketshell-fixture-aplexer-live",
+    )
+    if os.path.exists(seed):
+        raise FixtureModeError(
+            "mode",
+            "live aplexer enumeration was requested (%s) but the deterministic "
+            "seed file %s still exists. The two arms are mutually exclusive and "
+            "are never merged: delete the seed before opting into live mode, or "
+            "delete the marker to keep using the seed." % (live_marker, seed),
+        )
+
+    source = _real_source_dir()
+    if source is None:
+        raise FixtureModeError(
+            "live",
+            "live aplexer enumeration needs the repository's real `pocketshell` "
+            "package (tried POCKETSHELL_FIXTURE_REAL_SRC, "
+            "/opt/pocketshell-real/src and the in-repo tools/pocketshell/src); "
+            "none of them holds one",
+        )
+    if source not in sys.path:
+        sys.path.insert(0, source)
+    try:
+        from pocketshell import aplexer as real_aplexer
+        from pocketshell.session_enum import enumerate_live_sessions
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise FixtureModeError(
+            "live",
+            "live aplexer enumeration could not import the real `pocketshell` "
+            "package from %s: %s" % (source, exc),
+        )
+
+    if not real_aplexer.enabled("sessions"):
+        raise FixtureModeError(
+            "live",
+            "live aplexer enumeration was requested but a kill switch is set "
+            "(POCKETSHELL_APLEXER / POCKETSHELL_APLEXER_SESSIONS = 0), which "
+            "would make the probe report a tmux-only host: zero rows, zero "
+            "errors, exit 0",
+        )
+    resolution = real_aplexer.resolve_a()
+    if not resolution.path or not os.path.exists(resolution.path):
+        raise FixtureModeError(
+            "live",
+            "live aplexer enumeration was requested but no pinned `a` resolves "
+            "next to %s. `pocketshell.aplexer` never consults PATH (D22 hard "
+            "cut, #2543), so an `a` that is merely on PATH reads as absent and "
+            "the listing would be silently empty. Tried: %s"
+            % (sys.executable, "; ".join(resolution.tried) or "nothing"),
+        )
+
+    rows, errors = enumerate_live_sessions(tmuxctl_stdout=None)
+    return (
+        [row.to_payload(schema=SCHEMA_VERSION) for row in rows],
+        [dict(error) for error in errors],
+    )
+
+
 def tmux_rows(canned: list[tuple[str, str]]) -> tuple[list[tuple[str, str]], bool]:
     rows = list(canned)
     seen = {name for name, _ in rows}
@@ -341,13 +530,19 @@ def render_json(path: str) -> str:
             row["created_epoch"] = created_epoch(created)
         row["attached"] = bool(seeded.get("attached"))
         sessions.append(row)
-    sessions.extend(aplexer_rows())
+    if live_mode_requested():
+        live_rows, live_errors = live_aplexer_rows()
+        sessions.extend(live_rows)
+    else:
+        sessions.extend(aplexer_rows())
+        live_errors = []
+    errors = backend_errors() + live_errors
 
     managers = []
     for row in sessions:
         if row["manager"] not in managers:
             managers.append(row["manager"])
-    for error in backend_errors():
+    for error in errors:
         # A manager that FAILED contributed no rows, so it must not appear in
         # `managers` — that list is "who answered", `errors` is "who did not".
         if error["manager"] in managers:
@@ -361,7 +556,7 @@ def render_json(path: str) -> str:
                 "schema": SCHEMA_VERSION,
                 "managers": managers,
                 "sessions": sessions,
-                "errors": backend_errors(),
+                "errors": errors,
             },
             indent=2,
         )
@@ -376,7 +571,14 @@ def main(argv: list[str]) -> int:
         sys.stdout.write(render_list(path))
         return 0
     if verb == "json" and path:
-        sys.stdout.write(render_json(path))
+        try:
+            payload = render_json(path)
+        except FixtureModeError as exc:
+            # Nothing on stdout: a partial or ambiguous listing is exactly what
+            # a journey would assert against by accident.
+            sys.stderr.write("%s: %s\n" % (FAIL_PREFIXES[exc.kind], exc))
+            return EXIT_FIXTURE_MISCONFIGURED
+        sys.stdout.write(payload)
         return 0
     sys.stderr.write(
         "pocketshell-fixture-sessions supports: {list|json} <canned-table-file>\n"

--- a/tools/pocketshell/tests/test_agents_fixture_aplexer.py
+++ b/tools/pocketshell/tests/test_agents_fixture_aplexer.py
@@ -304,3 +304,411 @@ def test_unreadable_seed_file_degrades_to_no_rows(tmp_path: Path, garbage: str) 
     assert proc.returncode == 0, proc.stderr
     payload = json.loads(proc.stdout)
     assert [row for row in payload["sessions"] if row["manager"] == "aplexer"] == []
+
+
+# ---------------------------------------------------------------------------
+# The opt-in LIVE arm (issue #2586)
+# ---------------------------------------------------------------------------
+#
+# The seed arm above is the DETERMINISTIC one and stays exactly as it is: it is
+# what lets J02 seed an exact aplexer row and the #2426 partial-listing error
+# shape (one backend failing while the other answers), neither of which a live
+# session can produce. What was missing is the other half — a session really
+# created with `sessions create --backend aplexer` was invisible to the
+# fixture's `sessions list --json`, because that arm only ever read the seed
+# file. So this is additive: a journey opts in by touching a marker file, and
+# the two modes must never merge or be confusable.
+#
+# Every test here pins APLEXER_BIN at a stub. Live mode with APLEXER_BIN unset
+# would resolve the REAL pinned `a` next to `sys.executable` (this repo's venv
+# ships one, since aplexer is a hard dependency) and enumerate whoever's real
+# aplexer sessions are on the machine running the suite — non-deterministic,
+# and on the maintainer's box, other people's sessions.
+
+LIVE_ID = "3b5d1c66-0a4f-4c9b-9f3d-7c2a1e5b8d40"
+LIVE_SNAPSHOT = [
+    {
+        "id": LIVE_ID,
+        "workspace": "/home/testuser/git/pocketshell",
+        "tag": "live-tag",
+        "engine": "claude",
+        "phase": "running",
+        "worker_alive": True,
+        "worker_pid": 4321,
+        "created_at_ms": 1788409253000,
+        "last_activity_ms": 1788409353000,
+    }
+]
+
+
+def _stub_a(tmp_path: Path, *, snapshot: object = None, fails: bool = False) -> Path:
+    """A stand-in for the pinned `a`, wired in through APLEXER_BIN.
+
+    APLEXER_BIN is the CLI's own documented test seam (`aplexer.py`: "the seam
+    the test suite's stub `a` uses"), so this exercises the same resolution and
+    probe code the container runs, without a Rust binary or a real session.
+    """
+    script = tmp_path / "stub-a"
+    if fails:
+        body = "printf 'stub a: snapshot exploded\\n' >&2\nexit 1\n"
+    else:
+        body = "cat <<'STUB_JSON'\n%s\nSTUB_JSON\n" % json.dumps(snapshot)
+    script.write_text("#!/bin/sh\n" + body, encoding="utf-8")
+    script.chmod(0o755)
+    return script
+
+
+def _run_live_fixture(
+    tmp_path: Path,
+    *,
+    marker: bool = True,
+    seed: object | None = None,
+    a_bin: Path | str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("POCKETSHELL_APLEXER", None)
+    env["POCKETSHELL_FIXTURE_TMUX_SOCKET_DIR"] = str(tmp_path / "no-sockets")
+    seed_path = tmp_path / "aplexer-seed.json"
+    if seed is not None:
+        seed_path.write_text(json.dumps(seed), encoding="utf-8")
+    env["POCKETSHELL_FIXTURE_APLEXER_FILE"] = str(seed_path)
+    env["POCKETSHELL_FIXTURE_SESSION_DETAIL_FILE"] = str(tmp_path / "absent-detail")
+    env["POCKETSHELL_FIXTURE_SESSION_ERRORS_FILE"] = str(tmp_path / "absent-errors")
+    marker_path = tmp_path / "live-marker"
+    if marker:
+        marker_path.write_text("", encoding="utf-8")
+    env["POCKETSHELL_FIXTURE_APLEXER_LIVE_FILE"] = str(marker_path)
+    if a_bin is None:
+        env.pop("APLEXER_BIN", None)
+    else:
+        env["APLEXER_BIN"] = str(a_bin)
+    env.update(extra_env or {})
+    return subprocess.run(
+        [sys.executable, str(FIXTURE_SESSIONS), "json", str(CANNED_TABLE)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_live_mode_lists_the_session_the_real_a_reports(tmp_path: Path) -> None:
+    """Acceptance criterion 1, at the unit level.
+
+    The row must carry the id and the display name the real `a` reports —
+    `<workspace-basename>:<tag>`, computed by the production
+    `session_enum.aplexer_display_name`, not a hand-written string.
+    """
+    proc = _run_live_fixture(
+        tmp_path, a_bin=_stub_a(tmp_path, snapshot=LIVE_SNAPSHOT)
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    rows = [row for row in payload["sessions"] if row["manager"] == "aplexer"]
+    assert [row["name"] for row in rows] == ["pocketshell:live-tag"]
+    assert rows[0]["id"] == LIVE_ID
+    assert rows[0]["workspace"] == "/home/testuser/git/pocketshell"
+    assert rows[0]["tag"] == "live-tag"
+    assert rows[0]["engine"] == "claude"
+    assert "aplexer" in payload["managers"]
+    assert payload["errors"] == []
+    # The canned tmux rows are untouched: live mode replaces the APLEXER arm
+    # only.
+    assert [row["name"] for row in payload["sessions"] if row["manager"] == "tmux"]
+
+
+def test_live_mode_with_a_stale_seed_file_fails_loudly(tmp_path: Path) -> None:
+    """Two confusable modes is how a journey asserts against the wrong one.
+
+    Merging a leftover seed row into a live listing would let a journey pass
+    while proving nothing, so the fixture refuses to answer at all.
+    """
+    proc = _run_live_fixture(
+        tmp_path,
+        seed={"sessions": [{"name": "stale:row"}]},
+        a_bin=_stub_a(tmp_path, snapshot=LIVE_SNAPSHOT),
+    )
+    assert proc.returncode != 0, (
+        "live mode with a stale seed file exited 0; the two arms silently merged"
+    )
+    assert proc.stdout.strip() == "", (
+        "a mode conflict must produce NO listing; a partial one is exactly the "
+        "thing a journey would assert against by accident"
+    )
+    assert "FIXTURE-SESSIONS FAIL [mode]" in proc.stderr, proc.stderr
+    assert "aplexer-seed.json" in proc.stderr, proc.stderr
+    assert "live-marker" in proc.stderr, proc.stderr
+    assert "stale:row" not in proc.stdout
+
+
+def test_live_mode_without_a_resolvable_a_fails_loudly(tmp_path: Path) -> None:
+    """The landmine from #2543/#2563, one level up.
+
+    An `a` that is absent (or only on PATH) makes the production probe return
+    "this is a tmux-only host": no rows, no errors, exit 0. That silence is
+    legitimate for a host without aplexer and is NEVER legitimate for a journey
+    that explicitly opted into live enumeration.
+    """
+    proc = _run_live_fixture(tmp_path, a_bin=tmp_path / "definitely-not-here")
+    assert proc.returncode != 0, (
+        "live mode resolved no `a` and still exited 0 — the vacuous-green shape"
+    )
+    assert proc.stdout.strip() == ""
+    assert "FIXTURE-SESSIONS FAIL [live]" in proc.stderr, proc.stderr
+    assert "definitely-not-here" in proc.stderr, proc.stderr
+
+
+def test_live_mode_reports_a_probe_failure_as_a_backend_error(
+    tmp_path: Path,
+) -> None:
+    """#2426, on the live arm: a backend that failed must SAY so.
+
+    A failing `a` is not a mode conflict — it is the partial-listing contract,
+    so the fixture still answers, with aplexer in `errors` and out of
+    `managers`.
+    """
+    proc = _run_live_fixture(tmp_path, a_bin=_stub_a(tmp_path, fails=True))
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert [row for row in payload["sessions"] if row["manager"] == "aplexer"] == []
+    assert [error["manager"] for error in payload["errors"]] == ["aplexer"]
+    assert "aplexer" not in payload["managers"]
+    assert [row for row in payload["sessions"] if row["manager"] == "tmux"]
+
+
+def test_live_mode_with_the_kill_switch_fails_loudly(tmp_path: Path) -> None:
+    """`POCKETSHELL_APLEXER=0` silences the probe; live mode must not accept it."""
+    proc = _run_live_fixture(
+        tmp_path,
+        a_bin=_stub_a(tmp_path, snapshot=LIVE_SNAPSHOT),
+        extra_env={"POCKETSHELL_APLEXER": "0"},
+    )
+    assert proc.returncode != 0, proc.stderr
+    assert proc.stdout.strip() == ""
+    assert "FIXTURE-SESSIONS FAIL [live]" in proc.stderr, proc.stderr
+    assert "POCKETSHELL_APLEXER" in proc.stderr, proc.stderr
+
+
+def test_a_live_session_stays_invisible_to_the_deterministic_arm(
+    tmp_path: Path,
+) -> None:
+    """The bug, and the guarantee that fixing it changed nothing by default.
+
+    With no marker the fixture must behave EXACTLY as it does today: the seeded
+    row and only the seeded row, even though a perfectly good `a` with a live
+    session is right there. J02 and the #2426 journeys ride on this.
+    """
+    proc = _run_live_fixture(
+        tmp_path,
+        marker=False,
+        seed={"sessions": [{"name": "aplexer-follow:yolo", "id": "seed-id"}]},
+        a_bin=_stub_a(tmp_path, snapshot=LIVE_SNAPSHOT),
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    rows = [row for row in payload["sessions"] if row["manager"] == "aplexer"]
+    assert [row["name"] for row in rows] == ["aplexer-follow:yolo"]
+    assert rows[0]["id"] == "seed-id"
+    assert payload["errors"] == []
+
+
+def test_live_mode_leaves_the_human_table_byte_for_byte(tmp_path: Path) -> None:
+    """`list` is the canned table and stays it; only `--json` grew an arm."""
+    env = dict(os.environ)
+    env.pop("POCKETSHELL_APLEXER", None)
+    env["POCKETSHELL_FIXTURE_TMUX_SOCKET_DIR"] = str(tmp_path / "no-sockets")
+    marker = tmp_path / "live-marker"
+    marker.write_text("", encoding="utf-8")
+    env["POCKETSHELL_FIXTURE_APLEXER_LIVE_FILE"] = str(marker)
+    env["APLEXER_BIN"] = str(_stub_a(tmp_path, snapshot=LIVE_SNAPSHOT))
+    proc = subprocess.run(
+        [sys.executable, str(FIXTURE_SESSIONS), "list", str(CANNED_TABLE)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == CANNED_TABLE.read_text(encoding="utf-8")
+
+
+def test_the_docker_guard_covers_live_enumeration(tmp_path: Path) -> None:
+    """The live arm needs the SAME container proof the seed arm never needed.
+
+    A unit test with a stub `a` proves the wiring; only the container proves
+    that a session created through the app's own `pocketshell sessions create
+    --backend aplexer` becomes visible to `pocketshell sessions list --json`.
+    The guard must therefore show BOTH sides of the bug: invisible by default,
+    visible after opting in.
+    """
+    guard = GUARD.read_text(encoding="utf-8")
+    for needle in (
+        ".pocketshell-fixture-aplexer-live",
+        "pocketshell sessions create",
+        "pocketshell sessions list --json",
+    ):
+        assert needle in guard, f"the guard does not drive `{needle}`"
+    assert "FIXTURE-SESSIONS FAIL [mode]" in guard, (
+        "the guard must prove the stale-seed conflict fails LOUDLY in the "
+        "container, not just in a unit test"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The marker's LIFECYCLE across journeys (issue #2586, round 2)
+# ---------------------------------------------------------------------------
+#
+# `.pocketshell-fixture-aplexer-live` is per-user state in a container the
+# WHOLE app2 journey suite shares — #2474 runs the set unfiltered, in one
+# process, against one fixture — and nothing expires it. So a journey that
+# opts into live mode leaves the marker behind for every journey after it, and
+# a later journey that seeds `.pocketshell-fixture-aplexer.json` hits the
+# deliberate rc-78 mode conflict: the app receives NO listing, and what the
+# author sees is three 60-second `ComposeTimeoutException`s that name nothing.
+# (Observed, not theorised: 3 of J02's 4 tests, three minutes of lane time.)
+#
+# The fix is that the deterministic arm defends itself instead of trusting the
+# previous journey's teardown. These two tests pin that as a property of the
+# whole class of journeys — every file that seeds, and every file that opts in
+# — rather than of the three that exist today.
+
+APLEXER_SEED_NAME = ".pocketshell-fixture-aplexer.json"
+LIVE_MARKER_NAME = ".pocketshell-fixture-aplexer-live"
+ANDROID_TEST_ROOT = REPO_ROOT / "app2" / "src" / "androidTest"
+
+_CONST_RE = re.compile(r'const val (\w+)\s*=\s*"\\?\$HOME/([^"]+)"')
+_RM_RE = re.compile(r'"rm -f ([^"]*)"')
+_TOUCH_RE = re.compile(r'"touch ([^"]*)"')
+#: A journey MANAGES the deterministic seed if it writes it — either through
+#: ``AgentsFixture.writeFile(CONST, …)`` (possibly wrapped onto the next line)
+#: or a shell redirect inside an ``exec`` string. Keyed on the COMMAND, never on
+#: the filename appearing anywhere in the file: J12UsagePanelJourney names the
+#: seed only in a KDoc paragraph and an assertion message and seeds nothing, and
+#: a guard that fires on documentation teaches people to add pointless cleanup
+#: calls to silence it — worse than the bug it looks for.
+_WRITE_FILE_RE = re.compile(r"writeFile\(\s*([A-Za-z_]\w*)")
+_REDIRECT_CONST_RE = re.compile(r">\s*\$([A-Za-z_]\w*)")
+_REDIRECT_PATH_RE = re.compile(r">\s*(\S*\.pocketshell-fixture-[\w.-]+)")
+
+
+def _fixture_paths_in(command_args: str, consts: dict[str, str]) -> set[str]:
+    """Resolve `$CONST`/literal tokens of one shell command to `$HOME` names."""
+    resolved: set[str] = set()
+    for token in command_args.split():
+        name = consts.get(token.lstrip("$"))
+        resolved.add(name if name else token.rsplit("/", 1)[-1])
+    return resolved
+
+
+def _journey_sources() -> list[tuple[Path, str, dict[str, str]]]:
+    sources = []
+    for path in sorted(ANDROID_TEST_ROOT.rglob("*.kt")):
+        text = path.read_text(encoding="utf-8")
+        sources.append((path, text, dict(_CONST_RE.findall(text))))
+    return sources
+
+
+def _seed_writes_in(text: str, consts: dict[str, str]) -> set[str]:
+    """`$HOME` names this source WRITES, by command — never by mention."""
+    written: set[str] = set()
+    for name in _WRITE_FILE_RE.findall(text):
+        resolved = consts.get(name)
+        if resolved:
+            written.add(resolved)
+    for name in _REDIRECT_CONST_RE.findall(text):
+        resolved = consts.get(name)
+        if resolved:
+            written.add(resolved)
+    for path in _REDIRECT_PATH_RE.findall(text):
+        written.add(path.rsplit("/", 1)[-1])
+    return written
+
+
+def test_every_journey_that_seeds_the_aplexer_file_clears_the_live_marker() -> None:
+    """Deterministic-arm journeys must remove the marker, not hope nobody set it.
+
+    This is the check that would have caught the round-1 defect — and did catch
+    J15TerminalScrollJourney the first time `main` moved under it.
+
+    "Manages the seed" means the source WRITES it (`writeFile`/redirect) or
+    REMOVES it (`rm -f`), read out of the commands themselves with `$CONST`
+    tokens resolved. Both directions belong: a journey that writes the seed
+    hits the rc-78 conflict outright, and a journey that deletes the seed to
+    get a clean deterministic listing would silently get a LIVE one instead.
+    A file that merely NAMES the seed in prose is not in scope, deliberately.
+    """
+    managing = []
+    for path, text, consts in _journey_sources():
+        removed: set[str] = set()
+        for args in _RM_RE.findall(text):
+            removed |= _fixture_paths_in(args, consts)
+        written = _seed_writes_in(text, consts)
+        if APLEXER_SEED_NAME in (removed | written):
+            managing.append((path, removed, written))
+    assert managing, "no androidTest source manages the aplexer seed any more"
+    for path, removed, written in managing:
+        verb = "seeds" if APLEXER_SEED_NAME in written else "clears"
+        assert LIVE_MARKER_NAME in removed, (
+            f"{path.relative_to(REPO_ROOT)} {verb} {APLEXER_SEED_NAME} but never "
+            f"removes {LIVE_MARKER_NAME}. A journey that opted into live mode "
+            "leaves that marker behind in the shared fixture container "
+            "(#2474 runs the suite unfiltered, one process, one fixture), and "
+            "marker + seed is a deliberate rc-78 mode conflict: this journey "
+            "would get no listing at all and fail as bare 60-second Compose "
+            "timeouts. Add it to the `rm -f` this journey already runs."
+        )
+
+
+def test_every_journey_that_opts_into_live_mode_clears_the_seed() -> None:
+    """The other direction: opting in must not inherit a leftover seed.
+
+    Same conflict, same rc 78, arrived at from the other side — a journey that
+    `touch`es the marker while an earlier journey's seed file is still there.
+    """
+    for path, text, consts in _journey_sources():
+        touched: set[str] = set()
+        for args in _TOUCH_RE.findall(text):
+            touched |= _fixture_paths_in(args, consts)
+        if LIVE_MARKER_NAME not in touched:
+            continue
+        removed: set[str] = set()
+        for args in _RM_RE.findall(text):
+            removed |= _fixture_paths_in(args, consts)
+        assert APLEXER_SEED_NAME in removed, (
+            f"{path.relative_to(REPO_ROOT)} opts into live enumeration but "
+            f"never removes {APLEXER_SEED_NAME}. An earlier journey's seed is "
+            "still in the shared container, and marker + seed is a deliberate "
+            "rc-78 mode conflict — clear the seed in the same command that "
+            "writes the marker."
+        )
+
+
+def test_a_prose_only_mention_of_the_seed_does_not_demand_cleanup() -> None:
+    """The seeding predicate keys on the COMMAND, never on the filename in text.
+
+    Round 2 used a bare substring over the whole source, which put
+    `J12UsagePanelJourney` — the journey quarantined under this very issue — in
+    scope for naming the seed in a KDoc paragraph and an assertion message
+    while seeding nothing. Forcing a meaningless `rm -f` into it to satisfy a
+    guard is worse than the bug the guard looks for: it teaches the next author
+    that cleanup calls are how you silence CI. Kept symmetric with the
+    `touch`-keyed sibling check.
+    """
+    consts = {"APLEXER_FILE": APLEXER_SEED_NAME}
+    prose = (
+        "/** reads ~/.pocketshell-fixture-aplexer.json instead of enumerating */\n"
+        'assertNotNull("… ~/.pocketshell-fixture-aplexer.json …", appRow)\n'
+    )
+    assert _seed_writes_in(prose, consts) == set(), (
+        "a KDoc/assertion-message mention must not read as a write"
+    )
+    write_file = (
+        "AgentsFixture.writeFile(\n"
+        "    APLEXER_FILE,\n"
+        '    """{"sessions": []}""",\n'
+        ")\n"
+    )
+    assert APLEXER_SEED_NAME in _seed_writes_in(write_file, consts)
+    redirect = 'AgentsFixture.exec("printf x > $APLEXER_FILE")'
+    assert APLEXER_SEED_NAME in _seed_writes_in(redirect, consts)
+    literal_redirect = 'exec("printf x > /home/testuser/.pocketshell-fixture-aplexer.json")'
+    assert APLEXER_SEED_NAME in _seed_writes_in(literal_redirect, {})


### PR DESCRIPTION
Closes #2586. Reviewer-`APPROVED` after three rounds.

## The gap

The fixture's `sessions list --json` served aplexer rows from a canned seed file and never enumerated live sessions. A session created with `sessions create --backend aplexer` was alive for `a list`/`a capture` but **invisible to the app**, so no journey could exercise one end to end.

## Why this is additive, not a replacement

The seed arm is **deliberate**, not an unfinished stub — it is what lets J02 pin an exact row and reproduce **#2426**'s partial-listing shape: *one backend failing to enumerate while the other answers*. That cannot be produced from a live session. Replacing the seed path would have silently deleted the coverage that exists because a silently-shorter session list was once indistinguishable from a working one.

So: seed arm byte-identical (all seven functions, verified against `main`), opt-in live mode via a marker file, default unchanged.

Live rows come from the **production** `session_enum.enumerate_live_sessions` through the pinned `/usr/bin/a`, so the fixture and the real CLI cannot drift. `main`'s move to aplexer 0.1.4 flowed its new `agent` key through with no fixture change — which is the point of delegating rather than reimplementing.

The two modes are not silently confusable: marker + stale seed, an unresolvable `a` (including the #2543 PATH-only shape), or the kill switch all fail with an rc-78 diagnostic naming the conflict. A resolvable `a` whose probe merely *fails* stays on the #2426 contract instead — that distinction was the thing most likely to be got wrong.

## The bug the review found, and the guard that now prevents it

The marker is per-user state in a container the **whole journey suite shares** (#2474 runs it unfiltered on purpose). Nothing cleared it. The reviewer left it behind exactly as a live-mode journey would and ran J02: **3 of 4 failed**, three 60 s `ComposeTimeoutException`s. Round 1 was green only because nothing set the marker yet.

Every journey that manages the seed now clears it, and a source-analysing test enforces that for **every** androidTest file rather than the ones that exist today.

**That guard's first real encounter was a true positive**: `J15TerminalScrollJourney` landed in `54b6a8461` (my own merge of #2555, after this work started), seeds the file, and never cleared the marker. Caught by the guard, not by review.

The seeding predicate keys on the **write command**, not a substring — a loose version additionally dragged in `J12UsagePanelJourney`, which names the file only in a KDoc line and would have been forced to add meaningless cleanup. Pinned by a test written against synthetic fixtures so it will not fight J12 when it legitimately opts into live mode.

## Evidence (reviewer-produced)

- J15 RED→GREEN on their own fixture: rc-78 diagnostic **with the remedy**, then **7/7** including the #2426 method, marker present at launch and gone after, container id identical throughout.
- Predicate selection reproduced: tight picks J15/J02 (written) + J04/J14 (removed-only); loose additionally picked J12.
- Hostility assertion load-bearing: neutralising the mode conflict yields `rc=0` with `aplexer rows = []` and the guard reddens — pinned twice.
- Guard **273 added / 0 removed**; `comm` 27 → 42 with none reworded. 14 static + 42 docker checks, exit 0.
- Counts 1351/4 against a **measured** 1340/4 baseline.

## Pre-merge (mine)

`main` moved to `8480b9f77` after the review. Built a local merge preview and ran the reviewer's recommended gate — `pytest tests/test_agents_fixture_aplexer.py`, **24 passed** — because this branch's hazard is *not textual*: a new androidTest journey slipped in by `main` reddens the guard with zero file overlap for git to see. That is exactly how J15 surfaced.

## Known, filed separately

`writeFile("literal path", …)` escapes the seeding predicate — an internal inconsistency, since the literal form *is* handled for redirects. One line; the reviewer judged a fourth round the wrong trade and I agree.

**AC5 is not claimed**: the peer session's J12 is still `@Ignore`d and does not touch the marker. Mechanism delivered, unblocking unproven — the handoff pair is theirs to add.