### PR TITLE
fix: cap aplexer-backed sessions with the same limit tmux sessions get

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -897,9 +897,16 @@ jobs:
         working-directory: tools/pocketshell
         run: uv sync --frozen --group dev
 
+      # `-rs` prints the REASON for every skipped test in the summary. Issue
+      # #2562: the kernel-level session-cap proof can only run on a host that
+      # delegates a cgroup-v2 user scope, which this runner does not, so it
+      # skips here by design — and a bare "SKIPPED" line is indistinguishable
+      # from a test that quietly stopped running. With `-rs` the log names the
+      # missing capability. `scripts/check-cgroup-cap-proof.sh` is what turns
+      # that skip back into a hard failure on a host that CAN run it.
       - name: Run pytest
         working-directory: tools/pocketshell
-        run: uv run --frozen pytest -v
+        run: uv run --frozen pytest -v -rs
 
       # Issue #2430 / audit F22: this proof used to be an uncalled top-level
       # script. It removes the missing-window production guard in a copied tree,

--- a/docs/aplexer-integration.md
+++ b/docs/aplexer-integration.md
@@ -449,6 +449,20 @@ fixture therefore cannot prove capping; the real-transport proof lives in
 CLI against an isolated aplexer instance and reads `memory.max` back out of the
 kernel.
 
+GitHub's hosted runners fail the same way for a different reason (PR #2590): the
+scope is created, but the runner's process tree lives outside
+`user@<uid>.service`, so cgroup-v2's common-ancestor rule denies moving the
+workload into it — `a start --memory` exits with `spawn workload: Permission
+denied`. The kernel proof therefore probes that exact capability first and skips
+naming it when it is absent, CI keeps an environment-independent proof that the
+resolved cap reaches `a start`'s argv, and `scripts/check-cgroup-cap-proof.sh`
+re-imposes the kernel proof on a host that can delegate — asserting the reported
+test counts rather than pytest's exit code, which is 0 for a skip. That script
+is a step in `scripts/pre-release-confidence-gate.sh`, so a release cut from
+this box re-proves the cap against the kernel every time; a bumped aplexer pin
+that stopped honouring `--memory` would be caught there rather than by whoever
+remembered to run a script (see `docs/testing.md`, "Session memory-cap proof").
+
 ---
 
 ## Product defaults (unless the maintainer says otherwise)

--- a/docs/aplexer-integration.md
+++ b/docs/aplexer-integration.md
@@ -396,6 +396,61 @@ push feed, `usage` / `quse`.
 
 ---
 
+## Session memory caps: `cgroups.toml` is the source of truth, `memcap.py` reads it (#2562)
+
+Every session PocketShell creates is memory-capped, on both backends. Until
+#2562 only the tmux arm was: `tmuxctl create-detached` resolved the per-project
+cap itself and wrapped the session shell in a capped cgroup-v2 systemd `--user`
+scope, while `a start` was invoked with no memory parameter at all — every
+aplexer-backed session on the dev box recorded `"limits": {}`. That protection
+exists because a runaway session can OOM-kill the whole box, which is the
+maintainer's only dev machine and is usually reached from a phone.
+
+**The decision #2562 asks to record — where cap resolution lives once tmux is
+gone:** in PocketShell, as `tools/pocketshell/src/pocketshell/memcap.py`, reading
+the same per-project files tmuxctl reads. Not `from tmuxctl.robust import
+resolve_mem`, because #2561 deletes that dependency and the aplexer arm has to
+outlive it; importing it would make the cap disappear again exactly when tmux is
+removed, which is the failure #2562 exists to close. The contract is the FILE,
+not tmuxctl's code: `cgroups.toml` keeps its location and format (an explicit
+non-goal of #2562 to change either), and `memcap.py` becomes its only reader
+when the tmux arm goes. `tests/test_sessions_mem_cap.py` pins the two readers'
+agreement against the real tmuxctl while both exist, and asserts the resolved
+BYTE value against the committed file so the number is never copied into code.
+
+Resolution order for a session created in workspace `W`:
+
+1. an explicit `--mem`;
+2. `W/cgroups.toml` → `mem`;
+3. `W/pyproject.toml` → `[tool.tmuxctl] mem`;
+4. the same two files at `W`'s git root;
+5. `memcap.DEFAULT_MEM` (12G — the same fallback tmuxctl uses).
+
+Deliberately NOT carried over: tmuxctl's `ROBUST_TMUX_MEM` env layer and its
+`~/.config/tmuxctl/cgroups.toml` user-config layer. Both are tmuxctl-namespaced
+knobs that die with it, and an inherited environment variable should not be able
+to change a session's containment.
+
+Two fail-loud rules keep "uncapped" from ever happening by accident:
+
+- an unresolvable cap (malformed `cgroups.toml`, an unparseable size, a value
+  below the sanity floor) refuses the create — it does not fall back;
+- `mem = "none"` in a project file is an error. The single escape hatch is
+  `--mem none` typed at the call site, and it is aplexer-only.
+
+`--mem none` exists because aplexer's limits **fail closed**: with no delegated
+cgroup-v2 user scope, `a start --memory` errors rather than running uncapped.
+That is correct on a real host and impossible to satisfy in an unprivileged
+container, so the Docker `agents` fixture
+(`tests/docker/agents-aplexer-selfcheck.py`,
+`scripts/test-agents-fixture-aplexer.sh`) passes `--mem none` explicitly. The
+fixture therefore cannot prove capping; the real-transport proof lives in
+`tests/test_sessions_mem_cap.py`, which creates a session through the production
+CLI against an isolated aplexer instance and reads `memory.max` back out of the
+kernel.
+
+---
+
 ## Product defaults (unless the maintainer says otherwise)
 
 1. **Picker ids.** Phase A keeps PocketShell display names (`Claude (Z.AI)`).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -409,6 +409,59 @@ command for cwd `/workspace/pocketshell` finds it via `find ... -mmin -5`.
 | Instrumented UI / smoke | `app/src/androidTest/` on emulator | Compose screen tests, navigation, local emulator-to-Docker agent smoke |
 | Manual smoke | Emulator + Docker | Issue-based implementer/reviewer flow, with reviewer emulator evidence before approval |
 
+## Session memory-cap proof — the one check CI structurally cannot run (issue #2562)
+
+`pocketshell sessions create` caps every session it starts. The aplexer arm's
+cap is only real if the kernel applied it, so
+`tools/pocketshell/tests/test_sessions_mem_cap.py::test_real_aplexer_session_cgroup_carries_the_resolved_cap`
+creates a session through the production CLI against an isolated aplexer
+instance and reads `memory.max` back out of `/sys/fs/cgroup`.
+
+That needs a delegated cgroup-v2 systemd `--user` scope, and **no automated lane
+we own has one**: `Python utility tests` and `release-emulator-validation.yml`
+both run on `ubuntu-latest`, where `a start --memory` fails with `spawn
+workload: Permission denied` (the runner's process tree lives outside
+`user@<uid>.service`, so cgroup-v2's common-ancestor rule denies the move), and
+the Docker `agents` container has no user systemd at all. So the test skips
+there — naming the missing capability, never bare — and CI still proves the
+environment-independent half: `test_production_cli_hands_the_resolved_cap_to_a_start`
+runs the real `python -m pocketshell sessions create` against a recording stub
+`a` and asserts `--memory <resolved bytes>`.
+
+The skip is converted back into an obligation on a host that CAN delegate:
+
+```bash
+scripts/check-cgroup-cap-proof.sh                 # required: a skip is a FAILURE
+scripts/check-cgroup-cap-proof.sh --self-test     # proves that mode still has teeth
+scripts/check-cgroup-cap-proof.sh --if-supported  # what the release gate runs
+```
+
+Run it after touching session containment, `pocketshell/memcap.py`,
+`sessions.py`'s create arms, the delegation probe, or the pinned aplexer
+version. There is deliberately no env knob that can force the proof to skip —
+the only knob is `POCKETSHELL_CGROUP_CAP_PROOF=required`, which makes skipping
+strictly harder.
+
+**The script asserts the reported counts, never pytest's exit code.** `pytest`
+exits 0 on a skip, so the first version of this script printed
+`PASS: the created session's cgroup carried the resolved memory.max.` for a
+proof that never ran — required mode only converts skips raised inside the
+test's own helper, and a decorator-level skip (`@pytest.mark.skipif(… or True)`,
+or simply a non-Linux host) never reaches it. Every mode now requires the exact
+number of passing tests and zero skipped/failed/errored ones.
+
+**Wired into `scripts/pre-release-confidence-gate.sh`** as the
+`session-memory-cap-proof` step, so it runs on every release cut instead of
+when someone remembers — the property it protects ("aplexer honours `--memory`
+and the kernel applies it") regresses when *aplexer* changes, not when this
+repo does. It uses `--if-supported` there because the same gate script is what
+`release-emulator-validation.yml` runs on `ubuntu-latest`, which can neither
+delegate a user scope nor even provide `uv`; that mode still fails on a real
+defect and on any skip that is not a named missing capability, and otherwise
+prints `NOT PROVEN HERE — missing capability: …` into the step log and the
+gate's summary table. On the maintainer's box, where release cuts happen, it is
+the full kernel-level proof.
+
 ## Host-CLI / area coverage guard suite, with area-scoped selection (issue #2063)
 
 The maintainer's directive: *"split our test set into different areas and run

--- a/scripts/check-cgroup-cap-proof.sh
+++ b/scripts/check-cgroup-cap-proof.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kernel-level proof that PocketShell's session memory cap is really applied
+# (issue #2562), asserted on the RESULT of the run — never on its exit code.
+#
+# WHY THIS SCRIPT EXISTS
+#
+# `tests/test_sessions_mem_cap.py::test_real_aplexer_session_cgroup_carries_the_
+# resolved_cap` is the only assertion in the repo that reads `memory.max` back
+# out of the kernel for a session `pocketshell sessions create` just made. It
+# needs a delegated cgroup-v2 systemd `--user` scope, and NO automated lane we
+# own has one:
+#
+#   * `Python utility tests (pocketshell)` runs on `ubuntu-latest`, where
+#     `a start --memory` fails with `spawn workload: Permission denied` because
+#     the runner's process tree lives outside `user@<uid>.service` (PR #2590);
+#   * `Integration tests (Docker)` runs the `agents` container, which has no
+#     user systemd at all — that is why the fixture passes `--mem none`;
+#   * `release-emulator-validation.yml`, which drives the release confidence
+#     gate, is ALSO `runs-on: ubuntu-latest`.
+#
+# So the proof must skip in CI, and a skip nothing converts back into an
+# obligation is how a proof quietly becomes a no-op.
+#
+# WHY IT PARSES THE RESULT INSTEAD OF TRUSTING $?
+#
+# The first version of this script ran pytest and printed PASS on exit 0.
+# `pytest` exits 0 on a SKIP, so a skipped proof printed
+# "PASS: the created session's cgroup carried the resolved memory.max." — the
+# exact vacuous green this whole mechanism exists to prevent (round-2 review).
+# `POCKETSHELL_CGROUP_CAP_PROOF=required` only converts skips raised inside the
+# test's own `_unavailable()`; a DECORATOR-level skip (`@pytest.mark.skipif(...
+# or True)`, or simply running on a non-Linux host) never reaches it. So every
+# mode below asserts the reported COUNTS: the expected number of tests passed,
+# and nothing was skipped, failed, errored or left uncollected.
+#
+# MODES
+#
+#   (default)        Required mode. The proof MUST run and pass here. Any skip,
+#                    for any reason, is a failure. Run this on a host with a
+#                    systemd --user session after touching session containment,
+#                    `pocketshell/memcap.py`, `sessions.py`'s create arms, the
+#                    delegation probe, or the pinned aplexer version.
+#
+#   --if-supported   For the pre-release confidence gate, which also runs on
+#                    hosted runners. A skip is tolerated ONLY when its reason
+#                    names a missing host capability (the marker
+#                    `missing capability:`, emitted by the test's one skip
+#                    helper) — and it is then disclosed loudly as NOT PROVEN,
+#                    never as a pass. Any other skip, and every failure, fails.
+#
+#   --self-test      Proves the mechanism still has teeth: that an environment
+#                    skip names its capability, that required mode converts it
+#                    into a failure, and that no blanket `@pytest.mark.skip`
+#                    can be parked on the proof. Asserts counts too.
+#
+# The proof is named by NODE ID, so renaming or deleting it makes pytest exit
+# non-zero with `collected 0 items` instead of selecting nothing quietly.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG_DIR="$ROOT_DIR/tools/pocketshell"
+
+NODE_ID="tests/test_sessions_mem_cap.py::test_real_aplexer_session_cgroup_carries_the_resolved_cap"
+SELF_TEST_FILTER="missing_capability_skip or required_mode_turns or can_only_be_skipped_through"
+SELF_TEST_EXPECTED=3
+
+MODE="required"
+case "${1:-}" in
+  "") ;;
+  --if-supported) MODE="if-supported" ;;
+  --self-test) MODE="self-test" ;;
+  *)
+    echo "usage: scripts/check-cgroup-cap-proof.sh [--if-supported | --self-test]" >&2
+    exit 2
+    ;;
+esac
+if [[ "$#" -gt 1 ]]; then
+  echo "usage: scripts/check-cgroup-cap-proof.sh [--if-supported | --self-test]" >&2
+  exit 2
+fi
+
+OUT_FILE="$(mktemp -t cgroup-cap-proof-XXXXXX.log)"
+cleanup() { rm -f "$OUT_FILE"; }
+trap cleanup EXIT
+
+# `<count> <outcome>` counts as pytest reports them ("1 passed", "1 skipped",
+# …). Absent outcome -> 0, so every assertion below is explicit.
+count_of() {
+  local outcome="$1" value
+  value="$(grep -oE "[0-9]+ $outcome" "$OUT_FILE" | tail -1 | cut -d' ' -f1 || true)"
+  printf '%s' "${value:-0}"
+}
+
+skip_reason() {
+  grep -E '^SKIPPED' "$OUT_FILE" | tail -1 || true
+}
+
+fail() {
+  printf '\nFAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# Assert on the RESULT, not on pytest's exit code: `pytest` exits 0 on a skip.
+assert_counts() {
+  local expected_passed="$1" status="$2"
+  local passed skipped failed errors
+  passed="$(count_of passed)"
+  skipped="$(count_of skipped)"
+  failed="$(count_of failed)"
+  errors="$(count_of error)"
+  [[ "$failed" == "0" ]] || fail "$failed test(s) failed"
+  [[ "$errors" == "0" ]] || fail "$errors collection/setup error(s)"
+  [[ "$skipped" == "0" ]] || fail "$skipped test(s) SKIPPED — a skipped proof is not a pass: $(skip_reason)"
+  [[ "$passed" == "$expected_passed" ]] ||
+    fail "expected exactly $expected_passed passing test(s), pytest reported $passed"
+  [[ "$status" == "0" ]] || fail "pytest exited $status"
+}
+
+run_pytest() {
+  set +e
+  (cd "$PKG_DIR" && "$@") > "$OUT_FILE" 2>&1
+  local status=$?
+  set -e
+  cat "$OUT_FILE"
+  return "$status"
+}
+
+if [[ "$MODE" == "self-test" ]]; then
+  echo "== cgroup memory-cap proof: self-test of the skip mechanism =="
+  set +e
+  run_pytest uv run --frozen pytest -v -rs tests/test_sessions_mem_cap.py -k "$SELF_TEST_FILTER"
+  status=$?
+  set -e
+  assert_counts "$SELF_TEST_EXPECTED" "$status"
+  echo "PASS: the skip mechanism still names its capability, still converts to a failure under required mode, and is still guarded against a blanket skip."
+  exit 0
+fi
+
+if [[ "$MODE" == "if-supported" ]]; then
+  # Used by scripts/pre-release-confidence-gate.sh, which also runs on hosted
+  # runners that cannot delegate a cgroup-v2 user scope. `uv` may be absent
+  # there too; that is a host capability like any other, and it is DISCLOSED,
+  # never silently passed.
+  echo "== cgroup memory-cap proof (disclose-if-unsupported) =="
+  echo "   node: $NODE_ID"
+  if ! command -v uv >/dev/null 2>&1; then
+    echo "NOT PROVEN HERE — missing capability: uv is not installed, so the"
+    echo "  pocketshell test suite cannot run on this host. The session memory"
+    echo "  cap was NOT verified against the kernel by this run."
+    exit 0
+  fi
+  set +e
+  run_pytest uv run --frozen pytest -q -rs "$NODE_ID"
+  status=$?
+  set -e
+  skipped="$(count_of skipped)"
+  if [[ "$skipped" != "0" ]]; then
+    reason="$(skip_reason)"
+    # Only a MISSING HOST CAPABILITY may be tolerated. A platform guard, a
+    # blanket `@pytest.mark.skip`, or an always-true `skipif` produces a skip
+    # WITHOUT this marker, and must not pass here — that is the decorator-level
+    # hole the round-2 review found.
+    case "$reason" in
+      *"missing capability:"*) ;;
+      *) fail "the proof was skipped for a reason that is not a missing host capability: ${reason:-<no reason reported>}" ;;
+    esac
+    echo
+    echo "NOT PROVEN HERE — $reason"
+    echo "  The session memory cap was NOT verified against the kernel by this"
+    echo "  run. Run scripts/check-cgroup-cap-proof.sh on a host with a systemd"
+    echo "  --user session to prove it."
+    exit 0
+  fi
+  assert_counts 1 "$status"
+  echo "PASS: the created session's cgroup carried the resolved memory.max."
+  exit 0
+fi
+
+echo "== cgroup memory-cap proof (required mode) =="
+echo "   node: $NODE_ID"
+# Exported explicitly (not as a `VAR=x func` prefix, whose scope for a shell
+# FUNCTION is not portable) so the value really reaches pytest's environment.
+export POCKETSHELL_CGROUP_CAP_PROOF=required
+set +e
+run_pytest uv run --frozen pytest -v -rs "$NODE_ID"
+status=$?
+set -e
+assert_counts 1 "$status"
+echo "PASS: the created session's cgroup carried the resolved memory.max."

--- a/scripts/pre-release-confidence-gate.sh
+++ b/scripts/pre-release-confidence-gate.sh
@@ -2008,6 +2008,24 @@ fi
 # instead of producing a green 'OK (0 tests)' deep inside the run.
 assert_app2_instrumented_suite_exists
 
+# Issue #2562: the ONLY check that proves a session PocketShell creates is
+# really memory-capped by the kernel (`memory.max` read back out of the created
+# session's cgroup). It runs here — cheap, before any emulator work — because
+# the property it protects regresses when APLEXER changes, i.e. exactly when
+# nobody is editing this repo and thinking about running a script by hand.
+#
+# `--if-supported`, not required mode, for one concrete reason: this same gate
+# script is what `release-emulator-validation.yml` runs, and that job is
+# `runs-on: ubuntu-latest`, where no cgroup-v2 user scope can be delegated (and
+# `uv` is not installed at all). A hard step would fail every hosted release
+# validation for an environment reason. `--if-supported` still fails on a real
+# defect, on any skip that is not a named MISSING HOST CAPABILITY, and on a
+# skipped-but-reported-as-passed run; where the capability is genuinely absent
+# it prints NOT PROVEN HERE into this step's log and the summary table, so the
+# gap is disclosed rather than silently absent. On the maintainer's box — where
+# release cuts actually happen — it is a full kernel-level proof.
+run_step "session-memory-cap-proof" "$ROOT_DIR/scripts/check-cgroup-cap-proof.sh" --if-supported
+
 run_step "android-sdk-paths" "$ADB" version
 run_step "available-avds" "$EMULATOR" -list-avds
 if ! "$EMULATOR" -list-avds | grep -Fxq "$AVD_NAME"; then

--- a/scripts/test-agents-fixture-aplexer.sh
+++ b/scripts/test-agents-fixture-aplexer.sh
@@ -244,7 +244,10 @@ ok "self-check passes in the built image, over SSH"
 printf '\nPOSITIVE 2: real CLI create -> list -> PTY attach -> capture -> kill...\n'
 CLI_TAG="guard-cli-${SUFFIX}"
 CLI_MARKER="GUARD_CLI_MARKER_${SUFFIX}"
-create_json="$(ssh_exec "pocketshell-real-send sessions create '$CLI_TAG' --backend aplexer --cwd /home/testuser --json")" \
+# `--mem none` (issue #2562): session creates are memory-capped, aplexer's
+# limits fail closed, and this container has no user systemd to delegate a
+# cgroup-v2 scope. The opt-out is explicit here rather than silent in the CLI.
+create_json="$(ssh_exec "pocketshell-real-send sessions create '$CLI_TAG' --backend aplexer --cwd /home/testuser --mem none --json")" \
   || fail "\`sessions create --backend aplexer\` failed over SSH"
 CLI_NAME="$(printf '%s' "$create_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("name",""))')"
 [[ -n "$CLI_NAME" ]] || fail "create envelope carried no name: $create_json"

--- a/tests/docker/agents-aplexer-selfcheck.py
+++ b/tests/docker/agents-aplexer-selfcheck.py
@@ -202,7 +202,22 @@ def check_lifecycle(binary: str) -> None:
     workspace = _home()
 
     created = run_cli(
-        ["sessions", "create", tag, "--backend", "aplexer", "--cwd", workspace, "--json"],
+        # `--mem none` (issue #2562): every session PocketShell creates is
+        # memory-capped, and aplexer's limits FAIL CLOSED — with no delegated
+        # cgroup-v2 user scope, `a start --memory` errors instead of quietly
+        # running uncapped. This container has no user systemd
+        # ("Failed to connect to user scope bus ... $XDG_RUNTIME_DIR not
+        # defined"), so the fixture opts out EXPLICITLY, at the call site,
+        # rather than the CLI silently dropping the cap for everyone. Capping
+        # itself cannot be proven here; `tools/pocketshell/tests/
+        # test_sessions_mem_cap.py` proves it against a real delegated scope.
+        [
+            "sessions", "create", tag,
+            "--backend", "aplexer",
+            "--cwd", workspace,
+            "--mem", "none",
+            "--json",
+        ],
         timeout=CREATE_TIMEOUT_S,
     )
     if created.returncode != 0:

--- a/tools/pocketshell/src/pocketshell/memcap.py
+++ b/tools/pocketshell/src/pocketshell/memcap.py
@@ -1,0 +1,259 @@
+"""Per-session memory cap resolution for `pocketshell sessions create` (#2562).
+
+Every session PocketShell starts must be memory-capped. The reason is written
+into `sessions.py` and predates this module: a runaway session that can eat
+the whole box triggers "the OOM-kill cascade that wiped the agent team", and
+the box is the maintainer's only dev machine, usually reached from a phone
+where recovering from that cascade is worst.
+
+Where the number lives
+----------------------
+
+In the repo's ``cgroups.toml``, and nowhere else. This module is a READER of
+that file, never a second copy of the value:
+
+.. code-block:: toml
+
+    # <repo>/cgroups.toml
+    mem = "30G"
+
+Resolution order for a session whose workspace is ``W`` (first match wins):
+
+1. an explicit ``--mem`` on the command line (``--mem none`` = uncapped, see
+   below);
+2. ``W/cgroups.toml``'s top-level ``mem``;
+3. ``W/pyproject.toml``'s ``[tool.tmuxctl] mem`` (Python projects state it
+   there instead of a dedicated file);
+4. the same two files at ``W``'s git root;
+5. :data:`DEFAULT_MEM` — the documented fallback, never "no cap".
+
+That is deliberately the same shape ``tmuxctl.robust.read_project_value`` /
+``resolve_mem`` use for the tmux arm, so a workspace resolves to the SAME
+ceiling whichever backend a session lands on. ``tests/test_sessions_mem_cap``
+pins that agreement against the real tmuxctl.
+
+Why a pocketshell-owned reader instead of ``from tmuxctl.robust import
+resolve_mem`` (the decision #2562 asks to record)
+-------------------------------------------------------------------------
+
+tmuxctl is being removed (#2561). Importing its resolver would make the
+aplexer arm — the arm that OUTLIVES tmux — depend on the dependency that
+removal deletes, so the cap would silently vanish again at deletion time,
+which is exactly the failure this issue exists to close. The per-project
+CONFIG FILE, not tmuxctl's code, is the contract: `cgroups.toml` stays where
+it is and keeps its format (an explicit non-goal of #2562), and this module
+becomes its sole reader once the tmux arm goes. tmuxctl's env layer
+(``ROBUST_TMUX_MEM``) and its ``~/.config/tmuxctl/cgroups.toml`` user-config
+layer are deliberately NOT reproduced: both are tmuxctl-namespaced knobs that
+die with it, and a session cap is not something an inherited environment
+variable should be able to change.
+
+Failing loud
+------------
+
+A cap that cannot be resolved is an ERROR, not a shrug: a malformed
+``cgroups.toml`` or an unparseable size raises :class:`MemCapError` and the
+create is refused before anything is started. Silently running uncapped is the
+bug (#2562), and silently substituting the fallback for a file the project
+clearly meant to be authoritative would hide it just as well.
+
+The single, explicit escape hatch is ``--mem none`` at the CALL SITE. It
+exists because a cap is unenforceable on a host with no delegated cgroup-v2
+user scope (an unprivileged container, e.g. the Docker `agents` fixture),
+where aplexer itself fails closed with "systemd did not delegate the memory
+controller". A committed config file can NOT request it: ``mem = "none"`` in
+``cgroups.toml`` is an error, so an uncapped session always has a human-typed
+flag behind it.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Optional
+
+#: Filename holding a project's cap for non-Python projects (PocketShell's own).
+PROJECT_CONFIG_NAME = "cgroups.toml"
+
+#: Python projects state the same value under ``[tool.tmuxctl] mem``.
+PYPROJECT_NAME = "pyproject.toml"
+
+#: The documented fallback for a workspace whose project declares no cap.
+#: Same value tmuxctl falls back to (``robust.DEFAULT_MEM``), so the two arms
+#: agree on a capless workspace. A cap that is merely a default is still a cap.
+DEFAULT_MEM = "12G"
+
+#: The one spelling that means "run this session uncapped". Accepted ONLY from
+#: an explicit ``--mem``, never from a project file.
+UNCAPPED = "none"
+
+#: Anything smaller than this is a typo, not a policy (``mem = "30"`` meaning
+#: 30 GiB would otherwise resolve to 30 BYTES). Refused loudly: aplexer would
+#: fail closed on it anyway, with a much less obvious message.
+MIN_MEM_BYTES = 64 * 1024**2
+
+_SIZE_UNITS = {
+    "B": 1,
+    "K": 1024,
+    "KB": 1024,
+    "KIB": 1024,
+    "M": 1024**2,
+    "MB": 1024**2,
+    "MIB": 1024**2,
+    "G": 1024**3,
+    "GB": 1024**3,
+    "GIB": 1024**3,
+    "T": 1024**4,
+    "TB": 1024**4,
+    "TIB": 1024**4,
+}
+
+_SIZE_RE = re.compile(r"\s*([0-9]+(?:\.[0-9]+)?)\s*([a-zA-Z]*)\s*\Z")
+
+#: `git rev-parse` on a workspace is a local, sub-millisecond call; a hung git
+#: must not hang a create started from the phone.
+_GIT_TIMEOUT_S = 5.0
+
+
+class MemCapError(RuntimeError):
+    """The session's memory cap could not be resolved — refuse the create."""
+
+
+def parse_size(value: str, *, source: str) -> int:
+    """Parse a human size (``30G``, ``512M``, ``1.5G``, ``1048576``) to bytes.
+
+    Accepts exactly what ``tmuxctl.robust.parse_size`` accepts, so the same
+    project file resolves identically on both arms — and is a strict superset
+    of what aplexer's ``parse_byte_size`` takes (it has no fractional form).
+    That is why callers hand aplexer the resulting BYTE COUNT rather than the
+    raw string: a value tmuxctl honours can then never be rejected, or worse
+    reinterpreted, one layer down.
+
+    ``source`` names where the value came from, for the error message.
+    """
+    text = str(value).strip()
+    if not text:
+        raise MemCapError(f"{source}: empty memory cap")
+    match = _SIZE_RE.fullmatch(text)
+    if match is None:
+        raise MemCapError(f"{source}: {value!r} is not a memory size (e.g. 30G)")
+    unit = (match.group(2) or "B").upper()
+    if unit not in _SIZE_UNITS:
+        raise MemCapError(f"{source}: unknown memory-size unit in {value!r}")
+    size = int(float(match.group(1)) * _SIZE_UNITS[unit])
+    if size < MIN_MEM_BYTES:
+        raise MemCapError(
+            f"{source}: memory cap {value!r} resolves to {size} bytes, below the "
+            f"{MIN_MEM_BYTES}-byte floor — did you mean {text}G?"
+        )
+    return size
+
+
+def is_uncapped(flag: Optional[str]) -> bool:
+    """Whether an explicit ``--mem`` value asks for NO cap at all."""
+    return bool(flag) and flag.strip().lower() == UNCAPPED
+
+
+def _read_project_config(path: Path) -> Optional[str]:
+    """``mem`` from a dedicated ``cgroups.toml``.
+
+    A file that exists but cannot be parsed raises: ``cgroups.toml`` has
+    exactly one job, so an unreadable one means the project's cap is unknown,
+    and guessing is how the cap gets lost silently.
+    """
+    if not path.is_file():
+        return None
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+        raise MemCapError(f"{path}: cannot be read as TOML: {exc}") from exc
+    value = document.get("mem")
+    return None if value is None else str(value)
+
+
+def _read_pyproject(path: Path) -> Optional[str]:
+    """``[tool.tmuxctl] mem`` from a ``pyproject.toml``.
+
+    Unlike ``cgroups.toml`` this file is NOT primarily a cap declaration, so a
+    malformed one is skipped rather than fatal (tmuxctl does the same): the
+    resolution simply continues, and the fallback still caps the session.
+    """
+    if not path.is_file():
+        return None
+    try:
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return None
+    tool = document.get("tool")
+    section = tool.get("tmuxctl") if isinstance(tool, dict) else None
+    value = section.get("mem") if isinstance(section, dict) else None
+    return None if value is None else str(value)
+
+
+def _git_root(start: Path) -> Optional[Path]:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    top = completed.stdout.strip()
+    return Path(top) if top else None
+
+
+def read_project_mem(workspace: Path) -> Optional[tuple[str, Path]]:
+    """The project cap for ``workspace`` as ``(raw value, file it came from)``.
+
+    Checks the workspace directory first, then its git root — the same order
+    (and the same two file shapes) tmuxctl uses, so a session started deep in
+    a repo still gets the repo's committed cap.
+    """
+    try:
+        base = workspace.resolve()
+    except OSError:  # pragma: no cover - resolve() is strict=False here
+        base = workspace
+    directories = [base]
+    root = _git_root(base)
+    if root is not None and root != base:
+        directories.append(root)
+    for directory in directories:
+        for reader, name in (
+            (_read_project_config, PROJECT_CONFIG_NAME),
+            (_read_pyproject, PYPROJECT_NAME),
+        ):
+            path = directory / name
+            value = reader(path)
+            if value is not None:
+                return value, path
+    return None
+
+
+def resolve_session_mem_bytes(*, flag: Optional[str], workspace: str) -> Optional[int]:
+    """The cap, in bytes, for a session created in ``workspace``.
+
+    ``None`` means "explicitly uncapped" and can ONLY come from ``--mem none``.
+    Every other outcome is a positive byte count or a :class:`MemCapError`;
+    there is no path that returns "no cap" by accident.
+    """
+    if flag is not None and flag.strip():
+        if is_uncapped(flag):
+            return None
+        return parse_size(flag, source="--mem")
+    found = read_project_mem(Path(workspace))
+    if found is None:
+        return parse_size(DEFAULT_MEM, source="the built-in default cap")
+    raw, path = found
+    if is_uncapped(raw):
+        raise MemCapError(
+            f"{path}: mem = {raw!r} is not allowed in a project file — an "
+            "uncapped session must be asked for explicitly with `--mem none`"
+        )
+    return parse_size(raw, source=str(path))

--- a/tools/pocketshell/src/pocketshell/sessions.py
+++ b/tools/pocketshell/src/pocketshell/sessions.py
@@ -52,6 +52,7 @@ import click
 
 from . import aplexer as _aplexer
 from . import config as _config
+from . import memcap as _memcap
 from . import resume as _resume
 from . import session_enum as _session_enum
 
@@ -486,7 +487,10 @@ def sessions_resume(
 # (tmuxctl >= 0.3.0), which wraps the session shell in a memory-capped
 # cgroup-v2 systemd `--user` scope under `robust.slice`, so sessions
 # PocketShell starts can never trigger the OOM-kill cascade that wiped the
-# agent team. `create-detached` is already idempotent (a no-op when the
+# agent team. The aplexer arm gets the SAME guarantee from the same
+# `cgroups.toml` policy via `a start --memory` (issue #2562, `memcap.py`);
+# until then it passed no memory parameter at all and every aplexer-backed
+# session ran uncapped. `create-detached` is already idempotent (a no-op when the
 # session exists) — that contract is tmuxctl's, not re-implemented here.
 #
 # Since the aplexer adoption (simplification plan §B.3) the same command is
@@ -645,6 +649,17 @@ def _create_on_tmux(
     unparseable (observed on the dev box, not hypothetical). Its output is
     relayed to stderr instead, so nothing is lost.
     """
+    if _memcap.is_uncapped(mem):
+        # `--mem none` is the aplexer arm's explicit "this host cannot enforce
+        # a cap" escape hatch (issue #2562). tmuxctl has no such spelling —
+        # forwarding it would make tmuxctl reject the size, and DROPPING it
+        # would quietly create a session capped at the project default while
+        # the caller believes they asked for no cap. Refuse instead.
+        raise _CreateError(
+            "pocketshell: `--mem none` is only supported on the aplexer "
+            "backend; the tmux arm is always capped by tmuxctl.",
+            exit_code=2,
+        )
     tmuxctl_path = _resolve_tmuxctl_binary()
     if tmuxctl_path is None:
         raise _CreateError(_tmuxctl_missing_message(), exit_code=127)
@@ -752,6 +767,7 @@ def aplexer_start_argv(
     tag: str,
     engine: Optional[str],
     profile: Optional[str],
+    memory_bytes: Optional[int],
 ) -> list[str]:
     """Build ``a --json start --workspace <ws> --tag <tag> [--engine …]``.
 
@@ -759,12 +775,24 @@ def aplexer_start_argv(
     subcommand exactly like :func:`pocketshell.aplexer.run_json` does — one
     spelling across the codebase. ``--engine`` is omitted for a plain shell
     session so aplexer applies its own configured default.
+
+    ``memory_bytes`` is the resolved per-session cap (issue #2562), handed to
+    aplexer as ``--memory <bytes>`` so it wraps the workload in a cgroup-v2
+    scope with that ``MemoryMax`` — the containment the tmux arm has had since
+    #726 and this arm had none of. A byte COUNT rather than the raw ``30G``
+    string because aplexer's own size parser is narrower than the one that
+    read the project file (no fractional sizes), and a cap must never be
+    silently reinterpreted between the file and the kernel. ``None`` means the
+    caller asked for an uncapped session with ``--mem none``; that is the only
+    way this argv comes out without ``--memory``.
     """
     argv = [aplexer_path, "--json", "start", "--workspace", workspace, "--tag", tag]
     if engine:
         argv.extend(["--engine", engine])
     if profile:
         argv.extend(["--profile", profile])
+    if memory_bytes is not None:
+        argv.extend(["--memory", str(memory_bytes)])
     return argv
 
 
@@ -903,10 +931,34 @@ def _reap_aplexer_blockers(
     )
 
 
+def _cap_unenforceable_hint(memory_bytes: Optional[int], detail: str) -> str:
+    """Explain an `a start` that failed BECAUSE the host cannot enforce a cap.
+
+    aplexer's limits fail closed (``lib.rs::Cgroup::create``): with no
+    delegated cgroup-v2 user scope — an unprivileged container, a host with no
+    user systemd — ``--memory`` turns the start into an error rather than a
+    silently uncapped session. That is the right default (issue #2562), but
+    the raw message ("systemd did not delegate the memory controller") does
+    not tell the operator what to do, so name the one deliberate escape hatch.
+    """
+    if memory_bytes is None:
+        return ""
+    lowered = detail.lower()
+    if "fail closed" not in lowered and "delegate" not in lowered:
+        return ""
+    return (
+        f" This host could not enforce the {memory_bytes}-byte session memory "
+        "cap (no delegated cgroup-v2 user scope). Fix the host's systemd "
+        "--user setup, or create the session explicitly uncapped with "
+        "`--mem none`."
+    )
+
+
 def _create_on_aplexer(
     *,
     name: str,
     cwd: Optional[str],
+    mem: Optional[str],
     engine: Optional[str],
     profile: Optional[str],
 ) -> dict[str, Any]:
@@ -919,6 +971,13 @@ def _create_on_aplexer(
     ``name`` is the row's listing name (``<workspace-basename>:<tag>``, from
     ``session_enum.aplexer_display_name``) so it round-trips with what
     `sessions list --json` shows.
+
+    The session's memory cap (issue #2562) is resolved from the workspace's
+    project policy — the very ``cgroups.toml`` the tmux arm's cap comes from —
+    BEFORE anything is started, reaped or probed: an unresolvable cap must
+    refuse the create outright, not fail halfway through it, and certainly not
+    produce an uncapped session (which is what this arm did for every session
+    it ever created).
     """
     resolution = _aplexer.resolve_a()
     aplexer_path = resolution.path
@@ -941,6 +1000,13 @@ def _create_on_aplexer(
             exit_code=127,
         )
     workspace = cwd or os.getcwd()
+    try:
+        memory_bytes = _memcap.resolve_session_mem_bytes(flag=mem, workspace=workspace)
+    except _memcap.MemCapError as exc:
+        raise _CreateError(
+            f"pocketshell: cannot create {name!r} in {workspace!r}: {exc}",
+            exit_code=2,
+        ) from exc
 
     snapshot = _aplexer_snapshot()
     existing = _aplexer_existing_record(snapshot, workspace=workspace, tag=name)
@@ -988,6 +1054,7 @@ def _create_on_aplexer(
         tag=name,
         engine=engine,
         profile=profile,
+        memory_bytes=memory_bytes,
     )
     code, stdout, stderr = _run_aplexer(argv)
     if code != 0:
@@ -1009,7 +1076,8 @@ def _create_on_aplexer(
                 exit_code=code,
             )
         raise _CreateError(
-            f"pocketshell: `a start --tag {name}` exited {code}: {detail}",
+            f"pocketshell: `a start --tag {name}` exited {code}: {detail}"
+            + _cap_unenforceable_hint(memory_bytes, detail),
             exit_code=code,
         )
     try:
@@ -1069,9 +1137,12 @@ def _emit_create_failure(
     "--mem",
     default=None,
     help=(
-        "Memory cap for the session's tmuxctl scope, e.g. 24G. "
-        "DEFAULT: unset — tmuxctl resolves the per-project cap from the repo's "
-        "cgroups.toml (PocketShell's is 30G). Only pass this to override that policy."
+        "Memory cap for the new session, e.g. 24G. DEFAULT: unset — the "
+        "per-project cap is resolved from the workspace's cgroups.toml "
+        "(PocketShell's is 30G), falling back to 12G for a project that "
+        "declares none. Only pass this to override that policy. `--mem none` "
+        "creates an UNCAPPED session and is only accepted on the aplexer "
+        "backend, for hosts that cannot delegate a cgroup-v2 user scope."
     ),
 )
 @click.option(
@@ -1130,11 +1201,16 @@ def sessions_create(
     `[backends].agent` and a plain session `[backends].shell` from
     `~/.config/pocketshell/config.toml` (both default to tmux).
 
-    On tmux the session is created inside tmuxctl's cgroup-v2 systemd `--user`
-    scope (capped under `robust.slice`); with `--engine` the agent launch line
-    is then sent into it server-side. `--mem` is intentionally UNSET by
-    default so tmuxctl resolves the per-project cap from the repo's
-    `cgroups.toml` (PocketShell's is 30G).
+    Both backends cap the session's memory (issue #2562). On tmux the session
+    is created inside tmuxctl's cgroup-v2 systemd `--user` scope (capped under
+    `robust.slice`), with tmuxctl resolving the per-project cap; on aplexer the
+    same `cgroups.toml` cap is resolved here (`pocketshell.memcap`) and passed
+    as `a start --memory`, which wraps the workload in its own capped scope.
+    `--mem` is intentionally UNSET by default so the repo's committed policy
+    (PocketShell's `cgroups.toml` says 30G) is what applies; a cap that cannot
+    be resolved refuses the create rather than starting an uncapped session.
+    With `--engine` the agent launch line is then sent into the tmux session
+    server-side.
 
     The create is idempotent: an existing session is a success that reports
     `"created": false` and starts no second agent in it.
@@ -1144,7 +1220,7 @@ def sessions_create(
         resolved = _route_backend(engine, backend, config)
         if resolved == _config.BACKEND_APLEXER:
             result = _create_on_aplexer(
-                name=name, cwd=cwd, engine=engine, profile=profile
+                name=name, cwd=cwd, mem=mem, engine=engine, profile=profile
             )
         elif resolved == _config.BACKEND_TMUX:
             result = _create_on_tmux(

--- a/tools/pocketshell/tests/test_sessions_create_routing.py
+++ b/tools/pocketshell/tests/test_sessions_create_routing.py
@@ -32,9 +32,16 @@ import pytest
 from click.testing import CliRunner
 
 from pocketshell import config as psconfig
+from pocketshell import memcap as psmemcap
 from pocketshell import session_enum
 from pocketshell import sessions
 from pocketshell.sessions import _route_backend, sessions_group
+
+#: The cap a workspace with no project policy of its own resolves to
+#: (issue #2562). Derived from the production constant, not retyped.
+FALLBACK_CAP_BYTES = psmemcap.parse_size(
+    psmemcap.DEFAULT_MEM, source="the built-in default cap"
+)
 
 
 # ----- fixtures -------------------------------------------------------
@@ -723,6 +730,11 @@ def test_aplexer_arm_start_argv(monkeypatch: pytest.MonkeyPatch) -> None:
             "--tag", "work",
             "--engine", "claude",
             "--profile", "work",
+            # Issue #2562: every aplexer create carries the resolved memory
+            # cap. This workspace does not exist, so no project `cgroups.toml`
+            # applies and the documented fallback does — never "no cap".
+            # `tests/test_sessions_mem_cap.py` owns the resolution itself.
+            "--memory", str(FALLBACK_CAP_BYTES),
         ]
     ]
 
@@ -740,7 +752,12 @@ def test_aplexer_arm_omits_engine_for_a_shell_session(
 
     assert result.exit_code == 0, result.output
     assert start.calls == [
-        ["/fake/a", "--json", "start", "--workspace", "/home/me/proj", "--tag", "work"]
+        [
+            "/fake/a", "--json", "start",
+            "--workspace", "/home/me/proj",
+            "--tag", "work",
+            "--memory", str(FALLBACK_CAP_BYTES),
+        ]
     ]
 
 
@@ -1219,7 +1236,10 @@ def test_cli_engine_routes_via_backends_agent_config(
     assert result.exit_code == 0, result.output
     assert envelope(result)["manager"] == "aplexer"
     assert len(start.calls) == 1
-    assert tmuxctl.calls == []
+    # Nothing was routed to tmuxctl. (`subprocess.run` is patched process-wide
+    # here, so the cap resolver's `git rev-parse --show-toplevel` workspace
+    # probe lands in this stub too — filter on the binary, not on emptiness.)
+    assert [call for call in tmuxctl.calls if call[0] == "/fake/tmuxctl"] == []
 
 
 def test_cli_shell_session_ignores_backends_agent_config(

--- a/tools/pocketshell/tests/test_sessions_mem_cap.py
+++ b/tools/pocketshell/tests/test_sessions_mem_cap.py
@@ -15,22 +15,47 @@ file pins the fix on both arms:
   session's own cgroup must carry the expected `memory.max`.
 
 The stubbed arms reuse the seams `test_sessions_create_routing` already owns,
-so nothing here touches a real `a`, tmuxctl or tmux server. The one real
-transport test drives the production CLI (`python -m pocketshell`) against a
-throwaway aplexer instance (`APLEXER_CONFIG` / `APLEXER_STATE_DIR` /
+so nothing here touches a real `a`, tmuxctl or tmux server. The real-transport
+test drives the production CLI (`python -m pocketshell`) against a throwaway
+aplexer instance (`APLEXER_CONFIG` / `APLEXER_STATE_DIR` /
 `APLEXER_RUNTIME_DIR`), never the maintainer's live sessions.
+
+Two environments, deliberately (PR #2590's red CI)
+--------------------------------------------------
+
+Reading `memory.max` needs a delegated cgroup-v2 systemd `--user` scope. A
+GitHub hosted runner does not have one — it creates the scope fine and then
+cannot move the workload into it (`spawn workload: Permission denied`, because
+the runner's process tree sits outside `user@<uid>.service` and cgroup-v2
+requires write access to the common ancestor). So this file splits the proof:
+
+* `test_production_cli_hands_the_resolved_cap_to_a_start` — environment
+  independent, runs everywhere: the real CLI subprocess must pass
+  `--memory <resolved bytes>` to `a start`. This is what keeps CI able to catch
+  a regression at all.
+* `test_real_aplexer_session_cgroup_carries_the_resolved_cap` — the kernel as
+  the oracle, on a host that can delegate. Where it cannot, it skips NAMING the
+  missing capability (`probe_cgroup_delegation`), and
+  `scripts/check-cgroup-cap-proof.sh` turns that skip back into a failure on a
+  host that can — with `test_the_kernel_proof_can_only_be_skipped_through_that_one_helper`
+  guarding against someone parking a blanket `@pytest.mark.skip` on it.
 """
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import tomllib
+import uuid
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import pytest
 from click.testing import CliRunner
@@ -52,6 +77,10 @@ from tests.test_sessions_create_routing import (  # shared process seams
     use_aplexer_backend,
     use_tmux_backend,
 )
+
+#: Reason text for the platform guard, named so the decorator guard below
+#: compares against a stable shape rather than a free-form string.
+REASON_LINUX_ONLY = "aplexer ships Linux wheels only"
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PROJECT_CGROUPS_TOML = REPO_ROOT / "cgroups.toml"
@@ -302,6 +331,223 @@ def test_mem_none_is_rejected_on_the_tmux_arm(
     assert tmuxctl.calls == []
 
 
+# ----- environment-independent: the cap reaches `a start`'s argv -------------
+#
+# The kernel read below is the strongest evidence in this file, and it can only
+# run on a host that can delegate a cgroup-v2 user scope — which GitHub's hosted
+# runners cannot (PR #2590: `a start --memory` failed there with `spawn
+# workload: Permission denied`). So it must NOT be the only thing standing
+# between a regression and a green CI. This test proves the environment-
+# independent half of the same property, through the SAME production entry
+# point (`python -m pocketshell`, a real subprocess, real config load, real
+# `a` invocation): the cap is resolved from `cgroups.toml` and handed to
+# `a start` as `--memory <bytes>`. It needs no cgroups at all, so it runs
+# everywhere the suite runs.
+
+
+def _recording_stub_a(path: Path, record_to: Path) -> Path:
+    """An executable stand-in for `a` that records the argv it was given.
+
+    Pointed at with ``APLEXER_BIN`` — the one explicit override
+    ``pocketshell/aplexer.py`` documents, and the seam the rest of the suite
+    already uses for a stub `a`.
+    """
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        f"open({str(record_to)!r}, 'a').write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        "args = sys.argv[1:]\n"
+        "if 'start' in args:\n"
+        "    print(json.dumps({'id': '11111111-2222-3333-4444-555555555555',\n"
+        "                      'workspace': args[args.index('--workspace') + 1],\n"
+        "                      'tag': args[args.index('--tag') + 1],\n"
+        "                      'phase': 'running'}))\n"
+        "else:\n"
+        "    print('[]')\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason=REASON_LINUX_ONLY)
+def test_production_cli_hands_the_resolved_cap_to_a_start(tmp_path: Path) -> None:
+    """`python -m pocketshell sessions create` -> `a start --memory <bytes>`."""
+    workspace = tmp_path / "ws"
+    write_cgroups_toml(workspace, f'mem = "{REAL_CAP}"\n')
+    recorded = tmp_path / "argv.jsonl"
+    stub = _recording_stub_a(tmp_path / "stub-a", recorded)
+
+    created = subprocess.run(
+        [
+            sys.executable, "-m", "pocketshell", "sessions", "create", "cap-argv",
+            "--cwd", str(workspace), "--backend", "aplexer", "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(tmp_path / "home"),
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "APLEXER_BIN": str(stub),
+            "POCKETSHELL_APLEXER": "1",
+        },
+        cwd=str(tmp_path),
+        timeout=120,
+    )
+
+    assert created.returncode == 0, created.stderr or created.stdout
+    calls = [json.loads(line) for line in recorded.read_text().splitlines()]
+    starts = [call for call in calls if "start" in call]
+    assert len(starts) == 1, f"expected one `a start`, got {calls}"
+    argv = starts[0]
+    assert "--memory" in argv, f"the production CLI passed no cap: {argv}"
+    assert argv[argv.index("--memory") + 1] == str(REAL_CAP_BYTES), (
+        f"cap in argv is {argv[argv.index('--memory') + 1]}, expected "
+        f"{REAL_CAP_BYTES} (512M from the workspace's cgroups.toml)"
+    )
+
+
+# ----- the skip mechanism itself (runs everywhere) --------------------------
+
+
+def test_a_missing_capability_skip_names_the_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CI reader must be able to tell "cannot run here" from "stopped running"."""
+    monkeypatch.delenv(CAP_PROOF_MODE_ENV, raising=False)
+    # BaseException + an explicit isinstance, never `pytest.raises(skip…)`:
+    # `Skipped` and `Failed` are both BaseExceptions, so a narrow `raises`
+    # lets the OTHER one propagate and decide this test's outcome for it —
+    # which is exactly how the sibling guard below was green-by-skipping
+    # (round-2 review).
+    with pytest.raises(BaseException) as excinfo:
+        _unavailable("systemd-run is not installed")
+    assert isinstance(excinfo.value, pytest.skip.Exception), (
+        "without the required flag a missing capability must SKIP, got "
+        f"{type(excinfo.value).__name__}"
+    )
+    assert "missing capability: systemd-run is not installed" in str(excinfo.value)
+
+
+def test_required_mode_turns_the_skip_into_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`scripts/check-cgroup-cap-proof.sh`'s teeth.
+
+    This is the guard against the only kernel-level proof of the cap quietly
+    becoming a no-op: on a host that CAN delegate, the script runs the proof
+    with `POCKETSHELL_CGROUP_CAP_PROOF=required`, and a skip is then a hard
+    failure rather than a green line nobody reads.
+    """
+    monkeypatch.setenv(CAP_PROOF_MODE_ENV, "required")
+    with pytest.raises(BaseException) as excinfo:
+        _unavailable("systemd-run is not installed")
+    # The load-bearing line. `pytest.raises(pytest.fail.Exception)` does NOT
+    # catch a propagating `Skipped`, so deleting required mode's conversion
+    # made THIS guard skip — green under `-q` and green under `--self-test`
+    # (round-2 review). Asserting the type turns that mutation red instead.
+    assert isinstance(excinfo.value, pytest.fail.Exception), (
+        "required mode must convert the skip into a FAILURE, got "
+        f"{type(excinfo.value).__name__}: {excinfo.value}"
+    )
+    assert "required" in str(excinfo.value)
+    assert "systemd-run is not installed" in str(excinfo.value)
+
+
+def test_the_probe_names_a_missing_user_runtime_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The probe's first branch, exercised for real (uid with no /run/user)."""
+    monkeypatch.setattr(os, "getuid", lambda: 65534)
+    probe = probe_cgroup_delegation()
+    assert not probe.available
+    assert "no user runtime directory at /run/user/65534" in probe.missing
+
+
+def test_the_probe_reports_a_cgroup_it_cannot_move_a_process_into() -> None:
+    """The step PR #2590's runner failed on, exercised against an unwritable dir.
+
+    `/proc` accepts no new files for anyone, root included, so this branch is
+    deterministic wherever the suite runs — unlike a real cgroup, whose
+    writability is exactly the host property under test.
+    """
+    error = _can_move_a_process_into(Path("/proc"))
+    assert error is not None and "errno" in error
+
+
+def test_the_pr_2590_runner_failure_is_classified_as_a_host_refusal() -> None:
+    """The exact message a GitHub hosted runner produced, verbatim.
+
+    PR #2590's red: the runner creates the scope fine, then cannot move the
+    workload into it. Classifying this is what keeps a hosted runner from being
+    permanently red, and pinning the string here is what keeps the closed list
+    honest if aplexer ever rewords it.
+    """
+    assert host_refused_containment(
+        "pocketshell: `a start --tag ps2562-cap` exited 1: "
+        "a: worker startup failed: spawn workload: Permission denied (os error 13)"
+    )
+
+
+def test_an_ordinary_create_failure_is_not_a_host_refusal() -> None:
+    """A defect in the cap we computed must never be laundered into a skip."""
+    assert not host_refused_containment(
+        "pocketshell: `a start --tag x` exited 1: a: invalid --memory value"
+    )
+    assert not host_refused_containment("pocketshell: `a start --tag x` exited 2: boom")
+
+
+def test_the_kernel_proof_can_only_be_skipped_through_that_one_helper() -> None:
+    """No blanket `@pytest.mark.skip`, no stray `pytest.skip()` in this module.
+
+    The realistic way the kernel proof stops running everywhere is not a subtle
+    probe bug — it is someone disabling it outright while chasing a red CI.
+    This is a source-level guard against exactly that, and it runs on every
+    host, including the ones that cannot execute the proof itself.
+    """
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    skippers: list[str] = []
+    proof: Optional[ast.FunctionDef] = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            if node.name == "test_real_aplexer_session_cgroup_carries_the_resolved_cap":
+                proof = node
+            for inner in ast.walk(node):
+                if (
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Attribute)
+                    and inner.func.attr in {"skip", "xfail"}
+                    and isinstance(inner.func.value, ast.Name)
+                    and inner.func.value.id == "pytest"
+                ):
+                    skippers.append(node.name)
+    assert skippers == ["_unavailable"], (
+        "every skip in this module must go through _unavailable(), which names "
+        f"the missing capability and honours {CAP_PROOF_MODE_ENV}; found "
+        f"skips in {skippers}"
+    )
+    assert proof is not None, "the kernel-level cap proof was renamed or removed"
+    decorators = [ast.unparse(decorator) for decorator in proof.decorator_list]
+    assert len(decorators) == 1, (
+        "the kernel proof carries unexpected decorators — an unconditional "
+        f"skip/xfail here would disable it everywhere: {decorators}"
+    )
+    only = proof.decorator_list[0]
+    assert (
+        isinstance(only, ast.Call)
+        and ast.unparse(only.func) == "pytest.mark.skipif"
+    ), f"the kernel proof's only decorator must stay the platform guard; got {decorators[0]!r}"
+    # The CONDITION is asserted exactly, not merely "mentions sys.platform":
+    # `sys.platform != "linux" or True` satisfies a looser check and disables
+    # the proof everywhere while looking innocent (round-2 review found this).
+    condition = ast.unparse(only.args[0]).replace('"', "'")
+    assert condition == "sys.platform != 'linux'", (
+        "the kernel proof's skip condition must stay exactly the platform "
+        f"guard — anything else can disable it unconditionally; got {condition!r}"
+    )
+
+
 # ----- real transport: the kernel is the oracle -----------------------------
 
 
@@ -314,33 +560,206 @@ def _real_runtime_dir() -> str:
     return f"/run/user/{os.getuid()}"
 
 
-def _skip_unless_user_scopes_work() -> None:
-    """Skip only when this host cannot delegate a memory-capped user scope.
+#: Set to ``required`` to turn every environment skip below into a FAILURE.
+#: `scripts/check-cgroup-cap-proof.sh` sets it; that is what stops the only
+#: kernel-level proof of the cap from quietly becoming a no-op everywhere.
+CAP_PROOF_MODE_ENV = "POCKETSHELL_CGROUP_CAP_PROOF"
 
-    Narrow on purpose: the failure this file exists to catch (no `--memory`
-    passed at all) does NOT hide behind this skip — it shows up as an empty
-    `limits` on a session that was created just fine.
+#: Messages aplexer itself emits when the HOST refuses containment (verified
+#: against `aplexer/src/lib.rs::Cgroup::create` and `worker.rs`'s `spawn
+#: workload`). A create that fails with one of these is an environment gap, not
+#: a defect in the cap we computed — but only ever after the probe below has
+#: already been consulted, and never in `required` mode.
+HOST_REFUSED_CONTAINMENT = (
+    "limits fail closed",
+    "did not delegate",
+    "spawn workload: permission denied",
+    "failed to connect to user scope bus",
+)
+
+
+def host_refused_containment(detail: str) -> bool:
+    """Whether a failed create is the HOST refusing containment.
+
+    Deliberately a closed list of aplexer's own wordings: anything else — a
+    wrong `--memory` value, a bad workspace, a broken CLI — must stay a
+    failure. This is the last line of defence behind
+    :func:`probe_cgroup_delegation`, not a general "create failed, never mind".
+    """
+    lowered = detail.lower()
+    return any(signature in lowered for signature in HOST_REFUSED_CONTAINMENT)
+
+
+@dataclass(frozen=True)
+class DelegationProbe:
+    """Whether this host can do what `a start --memory` needs, and why not."""
+
+    available: bool
+    #: Empty when available; otherwise names the MISSING CAPABILITY, so a CI
+    #: log reader can tell "this environment cannot run it" from "this
+    #: silently stopped running".
+    missing: str = ""
+
+
+def probe_cgroup_delegation() -> DelegationProbe:
+    """Can a process here be moved into a delegated, memory-capped user scope?
+
+    This mirrors what aplexer actually does, step for step, because a cheaper
+    probe was wrong once already: the first version of this file only checked
+    that `systemd-run --user --scope -p MemoryMax=…` EXITS 0, which a GitHub
+    hosted runner does — and then `a start --memory` still failed there with
+    ``spawn workload: Permission denied (os error 13)``, red CI on PR #2590.
+    The step that fails on such a host is the LAST one: aplexer's workload
+    writes its own pgid into the delegated scope's ``cgroup.procs`` from a
+    pre_exec hook (``aplexer/src/worker.rs``), and cgroup-v2 requires write
+    permission on the common ancestor of the writer's cgroup and the target.
+    A runner whose agent lives outside ``user@<uid>.service`` does not have it.
+
+    So the probe creates a real anchored scope, checks the memory controller
+    really was delegated, and then MOVES A THROWAWAY CHILD into it — the exact
+    operation that failed. Everything it creates is torn down here.
     """
     runtime = _real_runtime_dir()
     if not os.path.isdir(runtime):
-        pytest.skip(f"no user runtime dir at {runtime}; systemd --user is unavailable")
+        return DelegationProbe(
+            False,
+            f"no user runtime directory at {runtime} — systemd --user is not "
+            "running for this uid, so no user scope can be created",
+        )
     if shutil.which("systemd-run") is None:
-        pytest.skip("systemd-run is not installed")
-    probe = subprocess.run(
+        return DelegationProbe(False, "systemd-run is not installed")
+    unit = f"pocketshell-capprobe-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": str(Path.home()),
+        "XDG_RUNTIME_DIR": runtime,
+    }
+    anchor = subprocess.Popen(
         [
-            "systemd-run", "--user", "--scope", "--collect", "-p", "Delegate=yes",
-            "-p", "MemoryMax=64M", "--", "/bin/true",
+            "systemd-run", "--user", "--scope", "--collect", f"--unit={unit}",
+            "-p", "Delegate=yes", "-p", "MemoryMax=64M",
+            "--", "sleep", "30",
         ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    try:
+        cgroup = _wait_for_scope_cgroup(unit, env=env, anchor=anchor)
+        if cgroup is None:
+            detail = ""
+            if anchor.poll() is not None and anchor.stderr is not None:
+                detail = f": {anchor.stderr.read().strip()[:200]}"
+            return DelegationProbe(
+                False,
+                "systemd --user could not create a delegated, memory-capped "
+                f"scope{detail}",
+            )
+        if not (cgroup / "memory.max").exists():
+            return DelegationProbe(
+                False,
+                "systemd did not delegate the memory controller (no "
+                f"memory.max under {cgroup})",
+            )
+        moved = _can_move_a_process_into(cgroup)
+        if moved is not None:
+            return DelegationProbe(
+                False,
+                "cannot move a process into the delegated scope's "
+                f"cgroup.procs ({moved}) — cgroup-v2 delegation does not "
+                "reach this process's own cgroup, which is exactly what "
+                "aplexer's workload spawn needs",
+            )
+    finally:
+        _stop_probe_scope(unit, anchor, env=env)
+    return DelegationProbe(True)
+
+
+def _wait_for_scope_cgroup(
+    unit: str, *, env: dict[str, str], anchor: subprocess.Popen, timeout_s: float = 10.0
+) -> Optional[Path]:
+    """The scope unit's cgroup path once systemd has created it, else None."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        shown = subprocess.run(
+            # `.scope` suffix, exactly like aplexer's own
+            # `wait_for_scope_cgroup`: `systemctl show` of a suffix-less name
+            # answers about a nonexistent *.service* and reports an empty
+            # ControlGroup, which would make this probe claim the host cannot
+            # delegate on a host that plainly can.
+            [
+                "systemctl", "--user", "show", f"{unit}.scope",
+                "--property=ControlGroup", "--value",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        value = shown.stdout.strip()
+        if value and value != "/":
+            return Path("/sys/fs/cgroup" + value)
+        if anchor.poll() is not None:
+            return None
+        time.sleep(0.1)
+    return None
+
+
+def _can_move_a_process_into(cgroup: Path) -> Optional[str]:
+    """None when a throwaway child can join ``cgroup``, else the OS error."""
+    child = subprocess.Popen(["sleep", "10"], stdout=subprocess.DEVNULL)
+    try:
+        with open(cgroup / "cgroup.procs", "w", encoding="ascii") as handle:
+            handle.write(str(child.pid))
+    except OSError as exc:
+        return f"{exc.strerror}, errno {exc.errno}"
+    finally:
+        child.kill()
+        child.wait(timeout=10)
+    return None
+
+
+def _stop_probe_scope(
+    unit: str, anchor: subprocess.Popen, *, env: dict[str, str]
+) -> None:
+    """Leave nothing behind: stop the unit, then reap the systemd-run client."""
+    subprocess.run(
+        ["systemctl", "--user", "stop", f"{unit}.scope"],
         capture_output=True,
         text=True,
-        env={"PATH": "/usr/bin:/bin", "XDG_RUNTIME_DIR": runtime, "HOME": str(Path.home())},
-        timeout=60,
+        env=env,
+        timeout=30,
+        check=False,
     )
-    if probe.returncode != 0:
-        pytest.skip(
-            "this host cannot create a memory-capped user scope "
-            f"(systemd-run exited {probe.returncode}: {probe.stderr.strip()})"
+    anchor.kill()
+    try:
+        anchor.wait(timeout=10)
+    except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+        anchor.terminate()
+    if anchor.stderr is not None:
+        anchor.stderr.close()
+
+
+def _cap_proof_required() -> bool:
+    return os.environ.get(CAP_PROOF_MODE_ENV, "").strip().lower() == "required"
+
+
+def _unavailable(missing: str) -> None:
+    """The ONE place this module may skip — and only for a named capability.
+
+    In `required` mode (`scripts/check-cgroup-cap-proof.sh`, run on a host
+    that CAN delegate) the same condition FAILS instead, so "the kernel proof
+    skipped everywhere" cannot pass unnoticed.
+    """
+    message = f"cgroup delegation unavailable — missing capability: {missing}"
+    if _cap_proof_required():
+        pytest.fail(
+            f"{CAP_PROOF_MODE_ENV}=required, but {message}. Run this on a host "
+            "with a systemd --user session, or fix the probe/environment — do "
+            "NOT relax the requirement."
         )
+    pytest.skip(message)
 
 
 def _short_runtime_root() -> str:
@@ -356,7 +775,7 @@ def _short_runtime_root() -> str:
     raise AssertionError("no temp base short enough for an AF_UNIX control socket")
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="aplexer ships Linux wheels only")
+@pytest.mark.skipif(sys.platform != "linux", reason=REASON_LINUX_ONLY)
 def test_real_aplexer_session_cgroup_carries_the_resolved_cap(tmp_path: Path) -> None:
     """End to end: cgroups.toml -> `sessions create` -> the kernel's memory.max.
 
@@ -365,7 +784,9 @@ def test_real_aplexer_session_cgroup_carries_the_resolved_cap(tmp_path: Path) ->
     capped or killed. The session is torn down and its scope's disappearance
     is asserted.
     """
-    _skip_unless_user_scopes_work()
+    probe = probe_cgroup_delegation()
+    if not probe.available:
+        _unavailable(probe.missing)
 
     workspace = tmp_path / "ws"
     write_cgroups_toml(workspace, f'mem = "{REAL_CAP}"\n')
@@ -404,10 +825,22 @@ def test_real_aplexer_session_cgroup_carries_the_resolved_cap(tmp_path: Path) ->
     )
     record: dict = {}
     try:
-        assert created.returncode == 0, (
-            f"`sessions create --backend aplexer` exited {created.returncode}: "
-            f"{created.stderr or created.stdout}"
-        )
+        if created.returncode != 0:
+            detail = (created.stderr or created.stdout).strip()
+            if host_refused_containment(detail):
+                # The probe said the capability was there and the host still
+                # refused containment: an environment gap the probe does not
+                # model yet. Report it as such, naming BOTH facts, so it reads
+                # as "extend the probe", never as a quiet pass. In `required`
+                # mode this is a failure like any other skip.
+                _unavailable(
+                    "the delegation probe passed, but this host still refused "
+                    f"to contain the session: {detail[:300]}"
+                )
+            raise AssertionError(
+                f"`sessions create --backend aplexer` exited "
+                f"{created.returncode}: {detail}"
+            )
         records = sorted((state_dir / "sessions").glob("*/session.json"))
         assert len(records) == 1, f"expected one session record, got {records}"
         record = json.loads(records[0].read_text(encoding="utf-8"))

--- a/tools/pocketshell/tests/test_sessions_mem_cap.py
+++ b/tools/pocketshell/tests/test_sessions_mem_cap.py
@@ -1,0 +1,520 @@
+"""Every session PocketShell creates carries a memory cap (issue #2562).
+
+The tmux arm has been capped since #726: `tmuxctl create-detached` wraps the
+session shell in a cgroup-v2 systemd `--user` scope and resolves the ceiling
+from the repo's committed `cgroups.toml` (PocketShell's is 30G). The aplexer
+arm passed **no** memory parameter at all, so every aplexer-backed session ran
+uncapped — visible on the dev box as `"limits": {}` on every live record. This
+file pins the fix on both arms:
+
+* the resolved value (bytes), not merely the presence of a flag;
+* `--mem` overriding it identically on both backends;
+* a cap that cannot be resolved failing LOUDLY instead of starting an uncapped
+  session (silence is the bug this issue is about);
+* and, against a real isolated aplexer, the KERNEL as the oracle — the created
+  session's own cgroup must carry the expected `memory.max`.
+
+The stubbed arms reuse the seams `test_sessions_create_routing` already owns,
+so nothing here touches a real `a`, tmuxctl or tmux server. The one real
+transport test drives the production CLI (`python -m pocketshell`) against a
+throwaway aplexer instance (`APLEXER_CONFIG` / `APLEXER_STATE_DIR` /
+`APLEXER_RUNTIME_DIR`), never the maintainer's live sessions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from pocketshell import memcap
+from pocketshell.sessions import sessions_group
+
+# The REAL tmuxctl (a hard dependency of this CLI today, `pyproject.toml`) is
+# imported so the "same source of truth" claim is checked against the arm it
+# has to agree with, not asserted. Delete those comparisons together with the
+# tmux arm in #2561; the byte-value assertions against the committed
+# `cgroups.toml` are the ones that must survive it.
+from tmuxctl import robust as tmuxctl_robust
+from tests.test_sessions_create_routing import (  # shared process seams
+    AplexerStub,
+    TmuxStub,
+    TmuxctlStub,
+    envelope,
+    use_aplexer_backend,
+    use_tmux_backend,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROJECT_CGROUPS_TOML = REPO_ROOT / "cgroups.toml"
+
+#: The cap `cgroups.toml` currently commits, in bytes. Derived independently of
+#: the code under test (see `_independent_bytes`) so a bug in our parser cannot
+#: make the expectation agree with itself, and asserted as a LITERAL below so
+#: "the cap silently became something else" is a red test, not a quiet pass.
+REPO_CAP_BYTES = 30 * 1024**3  # 30G
+
+#: The documented fallback for a workspace whose project has no cap of its own
+#: — deliberately the same value tmuxctl falls back to (`robust.DEFAULT_MEM`),
+#: so both arms agree. Never "no cap".
+FALLBACK_CAP_BYTES = 12 * 1024**3  # 12G
+
+
+def _independent_bytes(raw: str) -> int:
+    """Parse `30G` -> bytes WITHOUT the production parser (anti-tautology)."""
+    units = {"K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+    text = raw.strip()
+    assert text[-1].upper() in units, f"unhandled unit in {raw!r}"
+    return int(text[:-1]) * units[text[-1].upper()]
+
+
+def repo_cap_bytes() -> int:
+    """The repo's committed per-project cap, read from `cgroups.toml`."""
+    raw = tomllib.loads(PROJECT_CGROUPS_TOML.read_text(encoding="utf-8"))["mem"]
+    value = _independent_bytes(str(raw))
+    assert value == REPO_CAP_BYTES, (
+        f"cgroups.toml now commits {raw!r} ({value} bytes), not 30G. If that "
+        "change is deliberate, update REPO_CAP_BYTES here in the same commit."
+    )
+    return value
+
+
+def write_cgroups_toml(directory: Path, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "cgroups.toml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def start_argv(start: AplexerStub) -> list[str]:
+    assert len(start.calls) == 1, f"expected exactly one `a start`, got {start.calls}"
+    return start.calls[0]
+
+
+def memory_arg(start: AplexerStub) -> str:
+    argv = start_argv(start)
+    assert "--memory" in argv, f"`a start` ran with no --memory: {argv}"
+    return argv[argv.index("--memory") + 1]
+
+
+def create(*args: str):
+    return CliRunner().invoke(sessions_group, ["create", *args])
+
+
+# ----- the resolved value, on the aplexer arm -------------------------------
+
+
+def test_aplexer_arm_passes_the_repo_project_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session in THIS repo is capped at cgroups.toml's 30G, in bytes."""
+    start = AplexerStub(record={"id": "abc", "workspace": str(REPO_ROOT), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(REPO_ROOT), "--backend", "aplexer", "--json")
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(repo_cap_bytes())
+
+
+def test_aplexer_arm_reads_the_workspace_cgroups_toml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "1G"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(1024**3)
+
+
+def test_aplexer_arm_reads_the_git_root_cgroups_toml_for_a_subdirectory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A session started in a subdir inherits the repo's cap, like tmuxctl."""
+    root = tmp_path / "repo"
+    (root / "sub" / "deep").mkdir(parents=True)
+    write_cgroups_toml(root, 'mem = "2G"\n')
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    start = AplexerStub(record={"id": "abc", "workspace": str(root), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create(
+        "work", "--cwd", str(root / "sub" / "deep"), "--backend", "aplexer", "--json"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(2 * 1024**3)
+
+
+def test_workspace_without_a_project_cap_gets_the_documented_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No cgroups.toml anywhere is still CAPPED, never uncapped."""
+    workspace = tmp_path / "loose"
+    workspace.mkdir()
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "w"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("w", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(FALLBACK_CAP_BYTES)
+
+
+# ----- `--mem` honoured identically on both arms ----------------------------
+
+
+def test_explicit_mem_overrides_the_project_cap_on_the_aplexer_arm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "1G"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create(
+        "work", "--cwd", str(workspace), "--mem", "4G", "--backend", "aplexer", "--json"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert memory_arg(start) == str(4 * 1024**3)
+
+
+def test_explicit_mem_is_forwarded_on_the_tmux_arm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The tmux arm keeps handing `--mem` to tmuxctl, unchanged."""
+    tmuxctl = TmuxctlStub()
+    use_tmux_backend(monkeypatch, tmuxctl=tmuxctl, tmux=TmuxStub())
+
+    result = create(
+        "work", "--cwd", str(tmp_path), "--mem", "4G", "--backend", "tmux", "--json"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ["--mem", "4G"] == tmuxctl.calls[0][-2:]
+
+
+# ----- an unresolvable cap fails LOUDLY -------------------------------------
+
+
+def test_unparseable_project_cap_starts_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "banana"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code != 0
+    assert start.calls == [], "an unresolvable cap must not create a session"
+    assert "banana" in envelope(result)["error"]
+
+
+def test_malformed_project_cgroups_toml_starts_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, "mem = \n")
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code != 0
+    assert start.calls == []
+    assert "cgroups.toml" in envelope(result)["error"]
+
+
+def test_unparseable_mem_flag_starts_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "proj"
+    workspace.mkdir()
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create(
+        "w", "--cwd", str(workspace), "--mem", "lots", "--backend", "aplexer", "--json"
+    )
+
+    assert result.exit_code != 0
+    assert start.calls == []
+
+
+def test_a_project_file_cannot_ask_for_an_uncapped_session(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`none` is an explicit-flag-only escape hatch, never a committed policy."""
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "none"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create("work", "--cwd", str(workspace), "--backend", "aplexer", "--json")
+
+    assert result.exit_code != 0
+    assert start.calls == []
+
+
+def test_explicit_mem_none_is_the_only_uncapped_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Hosts that cannot enforce a cap (containers) opt out AT THE CALL SITE."""
+    workspace = tmp_path / "proj"
+    write_cgroups_toml(workspace, 'mem = "1G"\n')
+    start = AplexerStub(record={"id": "abc", "workspace": str(workspace), "tag": "work"})
+    use_aplexer_backend(monkeypatch, start=start, snapshot=[])
+
+    result = create(
+        "work", "--cwd", str(workspace), "--mem", "none", "--backend", "aplexer", "--json"
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "--memory" not in start_argv(start)
+
+
+def test_mem_none_is_rejected_on_the_tmux_arm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    tmuxctl = TmuxctlStub()
+    use_tmux_backend(monkeypatch, tmuxctl=tmuxctl, tmux=TmuxStub())
+
+    result = create(
+        "work", "--cwd", str(tmp_path), "--mem", "none", "--backend", "tmux", "--json"
+    )
+
+    assert result.exit_code != 0
+    assert tmuxctl.calls == []
+
+
+# ----- real transport: the kernel is the oracle -----------------------------
+
+
+REAL_CAP = "512M"
+REAL_CAP_BYTES = 512 * 1024**2
+
+
+def _real_runtime_dir() -> str:
+    """The user's REAL XDG_RUNTIME_DIR — `systemd-run --user` needs its bus."""
+    return f"/run/user/{os.getuid()}"
+
+
+def _skip_unless_user_scopes_work() -> None:
+    """Skip only when this host cannot delegate a memory-capped user scope.
+
+    Narrow on purpose: the failure this file exists to catch (no `--memory`
+    passed at all) does NOT hide behind this skip — it shows up as an empty
+    `limits` on a session that was created just fine.
+    """
+    runtime = _real_runtime_dir()
+    if not os.path.isdir(runtime):
+        pytest.skip(f"no user runtime dir at {runtime}; systemd --user is unavailable")
+    if shutil.which("systemd-run") is None:
+        pytest.skip("systemd-run is not installed")
+    probe = subprocess.run(
+        [
+            "systemd-run", "--user", "--scope", "--collect", "-p", "Delegate=yes",
+            "-p", "MemoryMax=64M", "--", "/bin/true",
+        ],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "XDG_RUNTIME_DIR": runtime, "HOME": str(Path.home())},
+        timeout=60,
+    )
+    if probe.returncode != 0:
+        pytest.skip(
+            "this host cannot create a memory-capped user scope "
+            f"(systemd-run exited {probe.returncode}: {probe.stderr.strip()})"
+        )
+
+
+def _short_runtime_root() -> str:
+    """A throwaway APLEXER_RUNTIME_DIR short enough for AF_UNIX sun_path."""
+    suffix = len("/sessions/") + 36 + len("/control.sock")
+    for base in (tempfile.gettempdir(), "/dev/shm"):
+        if not os.path.isdir(base):
+            continue
+        root = tempfile.mkdtemp(prefix="ps2562-", dir=base)
+        if len(root) + suffix < 108:
+            return root
+        os.rmdir(root)
+    raise AssertionError("no temp base short enough for an AF_UNIX control socket")
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="aplexer ships Linux wheels only")
+def test_real_aplexer_session_cgroup_carries_the_resolved_cap(tmp_path: Path) -> None:
+    """End to end: cgroups.toml -> `sessions create` -> the kernel's memory.max.
+
+    Drives the production CLI against an ISOLATED aplexer instance (its own
+    config/state/runtime), so the maintainer's live sessions are never read,
+    capped or killed. The session is torn down and its scope's disappearance
+    is asserted.
+    """
+    _skip_unless_user_scopes_work()
+
+    workspace = tmp_path / "ws"
+    write_cgroups_toml(workspace, f'mem = "{REAL_CAP}"\n')
+    state_dir = tmp_path / "aplexer-state"
+    home = tmp_path / "home"
+    for directory in (state_dir, home):
+        directory.mkdir()
+    config = tmp_path / "aplexer.toml"
+    config.write_text("version = 1\n", encoding="utf-8")
+    runtime_root = _short_runtime_root()
+    tag = "ps2562-cap"
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": str(home),
+        "TERM": "dumb",
+        "XDG_RUNTIME_DIR": _real_runtime_dir(),
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        "APLEXER_CONFIG": str(config),
+        "APLEXER_STATE_DIR": str(state_dir),
+        "APLEXER_RUNTIME_DIR": runtime_root,
+        "POCKETSHELL_APLEXER": "1",
+    }
+
+    def run_cli(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "-m", "pocketshell", *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(tmp_path),
+            timeout=120,
+        )
+
+    created = run_cli(
+        "sessions", "create", tag, "--cwd", str(workspace), "--backend", "aplexer", "--json"
+    )
+    record: dict = {}
+    try:
+        assert created.returncode == 0, (
+            f"`sessions create --backend aplexer` exited {created.returncode}: "
+            f"{created.stderr or created.stdout}"
+        )
+        records = sorted((state_dir / "sessions").glob("*/session.json"))
+        assert len(records) == 1, f"expected one session record, got {records}"
+        record = json.loads(records[0].read_text(encoding="utf-8"))
+
+        assert record["limits"] == {"memory_bytes": REAL_CAP_BYTES}, (
+            "the created aplexer session records NO memory cap: "
+            f"limits={record['limits']!r}"
+        )
+        cgroup = record.get("containment_cgroup")
+        assert cgroup, "the session has no containment cgroup, so nothing caps it"
+        memory_max = Path(cgroup, "memory.max").read_text(encoding="utf-8").strip()
+        assert memory_max == str(REAL_CAP_BYTES), (
+            f"kernel says memory.max={memory_max} for {cgroup}, "
+            f"expected {REAL_CAP_BYTES}"
+        )
+    finally:
+        # Tear the session down whatever the assertions did, then PROVE the
+        # teardown: a test that leaks a scope onto the maintainer's box is a
+        # bug of its own.
+        killed = None
+        if record.get("id"):
+            killed = run_cli("sessions", "kill", str(record["id"]), "--json")
+        shutil.rmtree(runtime_root, ignore_errors=True)
+    assert killed is not None and killed.returncode == 0, (
+        f"cleanup kill failed: {killed.stderr if killed else 'no record to kill'}"
+    )
+    leftover = record.get("containment_cgroup")
+    assert leftover and not Path(leftover).exists(), (
+        f"the test's own cgroup {leftover} outlived the session"
+    )
+
+
+# ----- the resolver itself, and its agreement with the tmux arm -------------
+#
+# "Don't hardcode a second copy of the limit" (#2562) is only true if both arms
+# read the same file the same way, so these compare against the real tmuxctl.
+
+SIZE_TABLE = ("30G", "512M", "1.5G", "12G", "2GiB", "1T", "8gb")
+
+
+@pytest.mark.parametrize("raw", SIZE_TABLE)
+def test_size_parsing_agrees_with_tmuxctl(raw: str) -> None:
+    assert memcap.parse_size(raw, source="test") == tmuxctl_robust.parse_size(raw)
+
+
+def test_the_fallback_cap_is_the_same_one_tmuxctl_falls_back_to() -> None:
+    """A capless workspace must resolve identically on both backends."""
+    assert memcap.DEFAULT_MEM == tmuxctl_robust.DEFAULT_MEM
+    assert FALLBACK_CAP_BYTES == tmuxctl_robust.parse_size(tmuxctl_robust.DEFAULT_MEM)
+
+
+def test_project_lookup_agrees_with_tmuxctl_on_this_repo() -> None:
+    found = memcap.read_project_mem(REPO_ROOT)
+    assert found is not None
+    raw, path = found
+    assert raw == tmuxctl_robust.read_project_mem(cwd=REPO_ROOT)
+    assert path == PROJECT_CGROUPS_TOML
+
+
+def test_resolving_this_repo_yields_the_committed_cap() -> None:
+    resolved = memcap.resolve_session_mem_bytes(flag=None, workspace=str(REPO_ROOT))
+    assert resolved == repo_cap_bytes() == 32212254720  # 30G
+
+
+def test_pyproject_tool_tmuxctl_is_a_cap_source(tmp_path: Path) -> None:
+    """Python projects declare the cap in pyproject.toml; tmuxctl reads it too."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.tmuxctl]\nmem = "3G"\n', encoding="utf-8"
+    )
+    assert memcap.resolve_session_mem_bytes(flag=None, workspace=str(tmp_path)) == (
+        3 * 1024**3
+    )
+    assert tmuxctl_robust.read_project_mem(cwd=tmp_path) == "3G"
+
+
+def test_a_dedicated_cgroups_toml_wins_over_pyproject(tmp_path: Path) -> None:
+    write_cgroups_toml(tmp_path, 'mem = "5G"\n')
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.tmuxctl]\nmem = "3G"\n', encoding="utf-8"
+    )
+    assert memcap.resolve_session_mem_bytes(flag=None, workspace=str(tmp_path)) == (
+        5 * 1024**3
+    )
+
+
+def test_a_malformed_pyproject_still_leaves_the_session_capped(tmp_path: Path) -> None:
+    """pyproject.toml is not primarily a cap file, so a broken one is skipped.
+
+    The session is still capped by the fallback — the outcome that must never
+    happen is "no cap", not "the fallback cap".
+    """
+    (tmp_path / "pyproject.toml").write_text("[tool.tmuxctl\n", encoding="utf-8")
+    assert memcap.resolve_session_mem_bytes(flag=None, workspace=str(tmp_path)) == (
+        FALLBACK_CAP_BYTES
+    )
+
+
+def test_a_bare_number_below_the_floor_is_a_typo_not_a_policy() -> None:
+    """`mem = "30"` (meaning 30G) must not silently become 30 BYTES."""
+    with pytest.raises(memcap.MemCapError) as excinfo:
+        memcap.parse_size("30", source="cgroups.toml")
+    assert "floor" in str(excinfo.value)
+
+
+def test_only_an_explicit_flag_can_ask_for_no_cap(tmp_path: Path) -> None:
+    assert memcap.resolve_session_mem_bytes(flag="none", workspace=str(tmp_path)) is None
+    assert memcap.resolve_session_mem_bytes(flag="NONE", workspace=str(tmp_path)) is None
+    write_cgroups_toml(tmp_path, 'mem = "none"\n')
+    with pytest.raises(memcap.MemCapError):
+        memcap.resolve_session_mem_bytes(flag=None, workspace=str(tmp_path))


### PR DESCRIPTION
Closes #2562. Reviewer-`APPROVED` after three rounds. Supersedes #2590, whose branch holds a pre-rebase head.

## The gap

The tmux arm of `sessions create` caps each session in a cgroup-v2 systemd `--user` scope, resolving the per-project limit from `cgroups.toml` (PocketShell's is **30G**). The aplexer arm passed **no memory parameter at all** — live records showed `"limits": {}`. `sessions.py`'s own comment states the stakes: *"so sessions PocketShell starts can never trigger the OOM-kill cascade that wiped the agent team."* After #2561 every session is aplexer-backed, so nothing would be capped.

## Design, settled in round 1

`memcap.py` resolves from the same source, in the same order, from the same effective workspace as the tmux arm. Its 12G fallback is **tmuxctl's own `DEFAULT_MEM` literal**, not a second number, and is reached exactly when tmuxctl would also have fallen back (measured: repo → 30G, capless → 12G, both arms). Two deliberate divergences, both **stricter**: an unreadable project file raises where tmuxctl silently degrades, and the floor is tighter.

`--mem none` is the only route to uncapped and cannot be reached by accident — 13 flag shapes and 5 project-file shapes probed; unset/empty/whitespace all fall through, and the tmux arm rejects it with exit 2. Its fixture use is **necessary**: an unprivileged container cannot delegate a scope, and `a start --memory` exits 1 there where the same start without it exits 0.

## Rounds 2-3: the test could not run on CI, and the gate that was meant to catch that could lie

**Round 2** — CI was red. The runner is a *third* environment: `systemd-run --user --scope` **succeeds** there, so the original probe passed and let the test proceed. What fails is aplexer's next step — the workload writing its pgid into the scope's `cgroup.procs` from a `pre_exec` hook, denied when the writer's cgroup shares no writable ancestor. The probe modelled the wrong syscall; it now spawns a real child and writes its pid into the scope.

**Round 3** — the reviewer found the anti-vacuous machinery was itself vacuous: `pytest` exits 0 on a skip, so `check-cgroup-cap-proof.sh` printed `PASS` for a test that never ran, reachable via an always-true `skipif` **or by anyone on a non-Linux host**. The teeth-guard test had the same defect — `pytest.raises(fail.Exception)` does not catch a propagating `skip.Exception`, so it went green under both `-q` and `--self-test`.

Now every mode asserts the **reported counts** rather than the exit code, and the AST guard pins the skip *condition* exactly.

## The reviewer's own attack matrix, after the fix

| mutation | AST guard | required | `--if-supported` |
|---|---|---|---|
| always-true `skipif` (the round-2 hole) | **FAILED** | **exit 1** | **exit 1** |
| `skipif(True)` spoofing the capability reason | **FAILED** | **exit 1** | exit 0 (NOT PROVEN) |
| `pytest.skip()` in body, spoofed reason | **FAILED** | **exit 1** | exit 0 (NOT PROVEN) |
| class-level `@pytest.mark.skip` | passed | **exit 4** | **exit 4** |
| **genuine defect** — `--memory` not emitted | passed | **exit 1** | **exit 1** |

No route to PASS-on-skip found.

## Enforcement, and its honest limit

**No CI lane we own can run the kernel proof** — all three are `ubuntu-latest`. Recorded in `docs/testing.md` rather than hidden behind a skip.

What CI *does* prove on every lane is environment-independent: the CLI computes and passes `--memory <bytes>`. Verified to bite — removing the two lines reddens it.

The kernel proof is wired into `pre-release-confidence-gate.sh`, which the release owner runs from this box, so it fires **every release**. `--if-supported` rather than required for a traced reason: that same script runs from `release-emulator-validation.yml`'s `ubuntu-latest` job, and that workflow never installs `uv` (`grep -c uv` = 0) — required mode would fail every hosted release validation.

## Evidence

Kernel oracle, reviewer's own value: `mem = "768M"` → record `805306368` → `memory.max: 805306368`. Suite **1376 passed / 4 skipped**, confirmed from a tree carrying no live mutation; `1375/5` on a simulated non-delegating host, which also confirms **exactly one** test depends on delegation.

## Pre-merge (mine)

Rebased onto `8480b9f77`. The reviewer flagged that commit changes *which app2 lanes get selected for `tools/pocketshell` changes* — checked on the rebased tree: `shared path 'tests/docker/agents-aplexer-selfcheck.py' changed -> selecting ALL lanes`, so nothing is under-selected. Mem-cap suite 36/36 and `check-cgroup-cap-proof.sh --self-test` green post-rebase.

## Residuals the reviewer named rather than let be discovered

`--if-supported`'s marker check is a *reason* check, not a provenance check (its integrity rests on the AST guard, which does run on every lane); the class-level skip is invisible per-PR and caught only at the release gate; node-id selection tolerates a parametrized suffix; and the box's own proof is contingent on `uv` being present.