### PR TITLE
test: bound the Compose frame spin so a slow host cannot hang the lane

### DIFF
--- a/app2/build.gradle.kts
+++ b/app2/build.gradle.kts
@@ -383,6 +383,13 @@ dependencies {
     androidTestImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit4)
+    // Issue #2549: the journey harness bounds `waitForIdle()` with Espresso's
+    // idling policies plus an IdlingResource tripwire, so Espresso has to be a
+    // COMPILE dependency here, not just a runtime transitive of
+    // compose-ui-test-junit4. This also BUMPS the resolved espresso version for
+    // this source set from 3.5.0 (what ui-test-android 1.8.1 requires) to 3.6.1
+    // — see the catalog entry for why that is deliberate.
+    androidTestImplementation(libs.androidx.espresso.core)
     // The journey's INDEPENDENT host-key oracle dials the fixture with sshj
     // directly (sshj itself is `api` on core-transport, so it is already on this
     // classpath). BouncyCastle is only an `implementation` detail there, so the

--- a/app2/src/androidTest/java/com/pocketshell/next/connect/BoundedWait.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/connect/BoundedWait.kt
@@ -1,18 +1,23 @@
 package com.pocketshell.next.connect
 
+import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.android.ComposeNotIdleException
+import androidx.test.espresso.AppNotIdleException
+import androidx.test.espresso.IdlingPolicies
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.IdlingResource
+import androidx.test.espresso.IdlingResourceTimeoutException
 import java.util.WeakHashMap
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.Executors
-import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * A wall-clock bound around a harness wait that has no bound of its own.
  *
- * ## Why this exists (issue #2479)
+ * ## What has to be bounded (issue #2479)
  *
  * Every journey in this suite polls for its oracle inside a bounded loop:
  *
@@ -27,99 +32,168 @@ import java.util.concurrent.TimeoutException
  * ```
  *
  * The deadline is only as real as the calls inside the loop body, and
- * `ComposeTestRule.waitForIdle()` is not one of them: it blocks until Compose
- * agrees the app has settled, with no timeout of its own. When Compose's idling
- * machinery never agrees — as it did not, twice on CI and repeatedly locally,
- * after the second rotation in `J03AttachAndTypeJourney` — the "60 second"
- * deadline becomes unreachable and the FIRST iteration of the loop consumes the
- * whole job.
+ * `ComposeTestRule.waitForIdle()` is not one of them. `waitForIdle()` is three
+ * waits, and only the first is bounded on its own
+ * (`AndroidComposeUiTestEnvironment`, compose-ui-test 1.8.1):
  *
- * The cost of that is much larger than one red test. The instrumentation
- * process never exits, Gradle is killed by the job's step timeout 45 minutes
- * later, and no `TEST-*.xml` is written AT ALL — so the fifteen journeys that
- * genuinely passed before the wedge produce zero evidence and
- * `scripts/check-app2-lane-execution.py` correctly reports the whole lane as
- * unproven. One intermittent wait turns a suite into a coin flip with no
- * salvage.
+ * ```
+ * composeRootRegistry.waitForComposeRoots(...)  // bounded: 2s / 500ms latch
+ * idlingStrategy.runUntilIdle()                 // = Espresso.onIdle()
+ * waitForNextChoreographerFrame()               // <- UNBOUNDED, see below
+ * ```
  *
- * ## What this does about it
+ * `waitForNextChoreographerFrame` (`ComposeUiTest.android.kt:402`, bytecode
+ * offsets 182-212) is:
  *
- * The blocking call runs on a worker thread and the caller waits on a
- * [Future] with an explicit budget. When the budget expires the caller gets
- * `false` and CONTINUES — the poll loop then re-checks its own deadline, keeps
- * polling its real oracle without the idle sync, and fails with its usual
- * screenshot and diagnosis at the time it promised to. A wedged idle-check
- * becomes a red test with evidence instead of a dead job.
+ * ```
+ * root.postOnAnimation { root.post { frameReceived = true } }
+ * while (!frameReceived) { idlingStrategy.runUntilIdle() }   // no deadline
+ * ```
  *
- * Two details are load bearing:
+ * — a spin on a REAL vsync callback. So `waitForIdle()` has a hard floor of one
+ * Choreographer frame, and on a starved swiftshader emulator (issue #2549 run
+ * #3 logged `app_time_stats avg=60012.00ms`, i.e. a 60-SECOND frame) that floor
+ * is measured in minutes. That run parked a single `awaitIdle` for **961
+ * seconds on a 15-second budget** and cost the lane 24 of its 52 tests.
  *
- *  - **One worker thread, and never a queue behind a stuck wait.** If the
- *    previous submission has not returned, the next [run] returns `false`
- *    immediately rather than submitting more work. A wedge therefore costs at
- *    most ONE parked thread per instance for the rest of the test, not one per
- *    poll iteration — and the poll loop spins at its normal [Future]-free cost
- *    once it has been told the wait is hopeless.
- *  - **The worker is a daemon.** A thread parked forever inside Compose's
- *    idling machinery must not keep the instrumentation process alive after
- *    JUnit has recorded the failure and moved on.
+ * No amount of `IdlingPolicies` tuning fixes that by itself: each individual
+ * `Espresso.onIdle()` inside the spin can be bounded, but Compose's loop simply
+ * calls it again, and when nothing is busy `onIdle()` returns normally instead
+ * of timing out. The bound has to make the NEXT `onIdle()` throw. That is what
+ * [DeadlineTripwire] below does.
  *
- * This is a harness bound, deliberately NOT a fix for whatever makes Compose
- * refuse to go idle (#2479 stays open for that). It makes the symptom cheap and
- * observable — a 60-second failure carrying [stuckDiagnosis] — rather than
- * silent and total.
+ * ## Why it does NOT use a worker thread (issue #2549)
+ *
+ * The first version of this class ran `waitForIdle()` on a daemon worker and let
+ * the caller walk away from it when the budget expired. That is not safe.
+ *
+ * `Espresso.onIdle()` called off the main thread posts a
+ * `loopMainThreadUntilIdle` task to the main looper and blocks on its future.
+ * That task runs `Interrogator.loopAndInterrogate`, which sets a thread-local
+ * `interrogating` flag on the main thread and then *dispatches main-queue
+ * messages itself*. Espresso's `UiController` is single-caller by contract: when
+ * a second thread calls `onIdle()` while the first one's task is still
+ * interrogating, its task is dispatched BY that interrogation loop, re-enters
+ * `loopAndInterrogate`, and `checkSanity()` throws
+ * `IllegalStateException: Already interrogating!` — surfacing on the second
+ * caller as
+ * `RuntimeException: ExecutionException: IllegalStateException: Already interrogating!`.
+ *
+ * Abandoning a parked `waitForIdle()` therefore leaves an interrogation running
+ * on the main thread with nobody tracking it, and the next Espresso/Compose call
+ * from ANY thread — a semantics read, a click, or the Compose rule's own
+ * teardown `waitForIdle()` — blows up in the harness rather than on a product
+ * assertion. That is issue #2549: three CI runs lost to a harness error in
+ * `J03AttachAndTypeJourney`, the class that uses the largest budgets here.
+ *
+ * So there are two hard requirements, and both have to hold at once:
+ *
+ * > **1. Never return from a wait while a main-thread interrogation we started
+ * >    is still outstanding.**
+ * > **2. Always return within the budget.**
+ *
+ * ## How both hold
+ *
+ * [block] runs on the CALLER's thread, so there is only ever one thread inside
+ * Espresso — requirement 1 is structural, not probabilistic. Requirement 2 is
+ * enforced by making Espresso itself refuse to be idle once the budget is gone,
+ * so the wait ends by THROWING out of the caller's own stack rather than by
+ * being abandoned:
+ *
+ *  - **The deadline tripwire.** [DeadlineTripwire] is a real Espresso
+ *    [IdlingResource], registered for the duration of the call, that reports
+ *    idle until the budget expires and busy for ever after. Espresso re-polls a
+ *    currently-idle resource on every pass
+ *    (`IdlingResourceRegistry.allResourcesAreIdle`, offsets 47-64), so the first
+ *    `Espresso.onIdle()` after the deadline sees a busy resource, enters
+ *    `loopUntil` with `DYNAMIC_TASKS_HAVE_IDLED` unsignalled, hits the (now
+ *    short) idling-resource timeout and throws [IdlingResourceTimeoutException]
+ *    **from the main-thread task**, which the caller rethrows. Any loop that
+ *    goes back through `onIdle()` — Compose's frame spin, Espresso's own
+ *    `loopMainThreadUntilIdle` `do/while`, a journey's poll — is broken by it,
+ *    and it is broken at a point where the main-thread task has already
+ *    completed, so requirement 1 is untouched.
+ *  - **Idling policies as the inner bound.** `IdlingPolicies` is lowered to the
+ *    budget for the call and restored after, so a single `loopUntil` cannot
+ *    outlive the budget either; on trip they drop to [TRIPPED_TIMEOUT_MS] so the
+ *    tripwire converts into a throw promptly rather than after another full
+ *    budget.
+ *  - **The deadline nudge.** `Interrogator` reaches its deadline check only when
+ *    it dispatches a message, so a queue that drains while something is still
+ *    busy parks `MessageQueue.next()` with nothing to wake it. After the
+ *    deadline (and only then) the watchdog posts a no-op to the main looper
+ *    every [NUDGE_PERIOD_MS] so the check always runs.
+ *
+ * Nothing above runs before the deadline: the tripwire reports idle, the
+ * policies are a plain per-call override, and no message is posted. A healthy
+ * wait is the wait it always was.
+ *
+ * ## The one thing still not bounded, stated plainly
+ *
+ * If the main thread wedges inside a SINGLE message dispatch — an app-side
+ * deadlock — nothing here helps: the tripwire cannot be observed, because
+ * observing it requires Espresso to run on the main thread. That case is
+ * unbounded by construction and no caller-owned mechanism can change it; the
+ * old worker thread only appeared to bound it, by returning a `false` the caller
+ * could not act on without corrupting the interrogator. Every wedge that keeps
+ * the main thread dispatching — which is every wedge #2479 and #2549 actually
+ * observed, including the 961-second frame spin — is bounded.
+ *
+ * ## This class owns process-global state
+ *
+ * [IdlingPolicies] is static and [IdlingRegistry] is a process singleton, while
+ * [run] synchronises per instance. That is safe only because instrumentation
+ * runs one test thread at a time; two concurrent [run] calls would interleave
+ * their save/restore. Do not call this from a worker — which is also
+ * requirement 1.
  */
 class BoundedWait(private val name: String) {
 
-    private val worker = Executors.newSingleThreadExecutor { runnable ->
-        Thread(runnable, "bounded-wait-$name").apply { isDaemon = true }
-    }
-
-    private var pending: Future<*>? = null
     private var stuckLabel: String? = null
     private var stuckSince: Long = 0L
     private var timeouts: Int = 0
 
     /**
-     * Runs [block] on the worker and waits at most [budgetMs] for it.
+     * Runs [block] on the calling thread, bounded to [budgetMs].
      *
-     * @return `true` when [block] completed inside the budget, `false` when it
-     *   did not (or when an earlier call is still parked). Anything [block]
-     *   throws is rethrown to the caller unchanged, so a real assertion failure
+     * @return `true` when [block] completed, `false` when Espresso gave up
+     *   because the app never went idle inside the budget. Anything else
+     *   [block] throws is rethrown unchanged, so a real assertion failure
      *   inside a wrapped wait is not swallowed by the bound.
      */
     @Synchronized
     fun run(label: String, budgetMs: Long, block: () -> Unit): Boolean {
-        val outstanding = pending
-        if (outstanding != null) {
-            if (!outstanding.isDone) {
-                // Still parked from an earlier call. Submitting now would queue
-                // behind it and hand the caller a bound it cannot enforce.
-                return false
-            }
-            pending = null
-        }
-
-        val future = worker.submit(Runnable { block() })
-        pending = future
+        val master = IdlingPolicies.getMasterIdlingPolicy()
+        val dynamic = IdlingPolicies.getDynamicIdlingResourceErrorPolicy()
+        val tripwire = DeadlineTripwire(name)
+        IdlingRegistry.getInstance().register(tripwire)
+        IdlingPolicies.setMasterPolicyTimeout(budgetMs, TimeUnit.MILLISECONDS)
+        IdlingPolicies.setIdlingResourceTimeout(budgetMs, TimeUnit.MILLISECONDS)
+        val watchdog = DeadlineWatchdog(name, budgetMs, tripwire).also { it.start() }
         return try {
-            future.get(budgetMs, TimeUnit.MILLISECONDS)
-            pending = null
+            block()
             true
-        } catch (timeout: TimeoutException) {
+        } catch (failure: Throwable) {
+            if (!isNotIdle(failure)) throw failure
             timeouts += 1
             if (stuckLabel == null) {
                 stuckLabel = label
                 stuckSince = SystemClock.elapsedRealtime()
             }
             println(
-                "BOUNDED_WAIT_TIMEOUT $name: `$label` did not return within ${budgetMs}ms " +
-                    "(see issue #2479). Continuing without it so the caller's own " +
-                    "deadline can still fire.",
+                "BOUNDED_WAIT_TIMEOUT $name: `$label` did not go idle within ${budgetMs}ms " +
+                    "(see issues #2479/#2549). Espresso ended its own interrogation and threw " +
+                    "${failure.javaClass.simpleName}, so the caller's deadline can still fire.",
             )
             false
-        } catch (failure: ExecutionException) {
-            pending = null
-            throw failure.cause ?: failure
+        } finally {
+            // Order matters: the watchdog also writes IdlingPolicies, so it has
+            // to be stopped and joined before the restore, and the tripwire has
+            // to leave the registry before any later wait can observe it.
+            watchdog.stop()
+            IdlingRegistry.getInstance().unregister(tripwire)
+            IdlingPolicies.setMasterPolicyTimeout(master.idleTimeout, master.idleTimeoutUnit)
+            IdlingPolicies.setIdlingResourceTimeout(dynamic.idleTimeout, dynamic.idleTimeoutUnit)
         }
     }
 
@@ -138,26 +212,162 @@ class BoundedWait(private val name: String) {
     @Synchronized
     fun stuckDiagnosis(): String {
         val label = stuckLabel ?: return ""
-        val parked = pending?.isDone == false
         val elapsed = SystemClock.elapsedRealtime() - stuckSince
         return "NOTE (#2479): `$label` blew its wait budget ${timeouts}x, first " +
-            "${elapsed}ms ago, and is ${if (parked) "STILL parked" else "no longer parked"}. " +
-            "The wait was abandoned rather than allowed to consume this test's deadline."
+            "${elapsed}ms ago. Espresso was made non-idle so the sync would throw " +
+            "rather than consume this test's deadline."
+    }
+
+    /**
+     * Reports idle until [budgetMs] have passed, and busy from then on.
+     *
+     * The whole bound rests on this: an `Espresso.onIdle()` with a busy resource
+     * registered cannot return normally, it can only time out and throw. Espresso
+     * re-polls `isIdleNow()` on every pass for a resource it currently believes
+     * idle, so no callback is needed to make the flip visible.
+     *
+     * The name carries a per-instance counter because Espresso's
+     * `IdlingResourceRegistry` refuses a duplicate name and only logs about it —
+     * a collision would silently disable the bound rather than fail.
+     */
+    private class DeadlineTripwire(owner: String) : IdlingResource {
+
+        private val resourceName = "pocketshell-bounded-wait-$owner-${COUNTER.incrementAndGet()}"
+
+        @Volatile
+        private var tripped = false
+
+        override fun getName(): String = resourceName
+
+        override fun isIdleNow(): Boolean = !tripped
+
+        override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback) {
+            // Deliberately ignored. This resource never transitions BACK to idle,
+            // so there is nothing to announce; Espresso's timeout is the exit.
+        }
+
+        fun trip() {
+            tripped = true
+        }
+
+        companion object {
+            val COUNTER = AtomicInteger(0)
+        }
+    }
+
+    /**
+     * Trips [tripwire] once the budget is gone, then keeps the main looper
+     * waking up so Espresso notices.
+     *
+     * A plain daemon thread rather than anything cleverer: it never touches the
+     * calling thread, never interrupts anything and never calls into Espresso's
+     * `UiController`, so it cannot violate requirement 1. All it does is flip a
+     * boolean, lower two static timeouts and post no-op messages.
+     */
+    private class DeadlineWatchdog(
+        private val owner: String,
+        private val budgetMs: Long,
+        private val tripwire: DeadlineTripwire,
+    ) {
+
+        private val handler = Handler(Looper.getMainLooper())
+
+        @Volatile
+        private var running = true
+
+        private val nudge = Runnable { }
+
+        private val thread = Thread({ watch() }, "bounded-wait-deadline-$owner").apply {
+            isDaemon = true
+        }
+
+        fun start() = thread.start()
+
+        fun stop() {
+            running = false
+            thread.interrupt()
+            thread.join(JOIN_MS)
+            handler.removeCallbacks(nudge)
+        }
+
+        private fun watch() {
+            if (!sleepFor(budgetMs)) return
+            tripwire.trip()
+            IdlingPolicies.setMasterPolicyTimeout(TRIPPED_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            IdlingPolicies.setIdlingResourceTimeout(TRIPPED_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            while (running) {
+                // Wakes a `MessageQueue.next()` parked on an empty queue so the
+                // Interrogator reaches its deadline check. `stop()` may race one
+                // already-posted no-op past `removeCallbacks`; that is harmless
+                // because it is an empty Runnable, and because a message due
+                // 100ms out is well outside `Interrogator.LOOKAHEAD_MILLIS` (15)
+                // and so is not even counted as queue activity.
+                handler.post(nudge)
+                if (!sleepFor(NUDGE_PERIOD_MS)) return
+            }
+        }
+
+        /** @return `false` when [stop] cut the sleep short. */
+        private fun sleepFor(millis: Long): Boolean =
+            try {
+                Thread.sleep(millis)
+                running
+            } catch (interrupted: InterruptedException) {
+                false
+            }
+
+        private companion object {
+            const val JOIN_MS = 5_000L
+        }
+    }
+
+    private companion object {
+
+        /**
+         * How long Espresso may keep trying once the tripwire has been trodden.
+         *
+         * Small, because at this point the answer is already known — it only
+         * has to be long enough for `loopUntil` to enter, dispatch, and report
+         * the timeout rather than to race with its own setup.
+         */
+        const val TRIPPED_TIMEOUT_MS = 200L
+
+        /** How often the nudge re-posts once the budget has already expired. */
+        const val NUDGE_PERIOD_MS = 100L
+
+        /**
+         * True when [failure] (or anything it wraps) is Espresso/Compose saying
+         * "the app never went idle", as opposed to a real failure from `block`.
+         */
+        fun isNotIdle(failure: Throwable): Boolean {
+            var cause: Throwable? = failure
+            val seen = HashSet<Throwable>()
+            while (cause != null && seen.add(cause)) {
+                if (cause is AppNotIdleException ||
+                    cause is IdlingResourceTimeoutException ||
+                    cause is ComposeNotIdleException
+                ) {
+                    return true
+                }
+                cause = cause.cause
+            }
+            return false
+        }
     }
 }
 
 /**
  * The bounded form of [ComposeTestRule.waitForIdle], one budget per rule.
  *
- * Keyed on the rule instance (identity, via a [WeakHashMap]) so the "a wait is
- * already parked" state resets automatically between tests: JUnit builds a new
- * test-class instance — and therefore a new rule — per method, and a wedge in
- * one method must not silently disable idle syncing for the next one.
+ * Keyed on the rule instance (identity, via a [WeakHashMap]) so the "a wait blew
+ * its budget" state resets automatically between tests: JUnit builds a new test
+ * class instance — and therefore a new rule — per method, and a wedge in one
+ * method must not carry its diagnosis into the next one.
  */
 object ComposeIdle {
 
     /**
-     * How long ONE idle sync may take before the caller gives up on it.
+     * How long ONE idle sync may take before Espresso is made non-idle.
      *
      * Two orders of magnitude above a healthy `waitForIdle()` (milliseconds,
      * even on a contended emulator with an IME animation in flight) and well

--- a/app2/src/androidTest/java/com/pocketshell/next/connect/BoundedWaitTest.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/connect/BoundedWaitTest.kt
@@ -1,79 +1,210 @@
 package com.pocketshell.next.connect
 
+import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.IdlingPolicies
+import androidx.test.espresso.IdlingRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * The bound in [BoundedWait] is the thing #2479 asked for, so it is asserted
- * against a wait that genuinely never returns — not eyeballed.
+ * against an app that genuinely never goes idle — not eyeballed.
  *
  * ## Why these run on the device rather than the JVM
  *
  * [BoundedWait] is journey-harness code and lives in `app2/src/androidTest`,
- * which the JVM unit lane does not compile; and its callers pass it
- * `ComposeTestRule.waitForIdle`, which only exists on a device. Wiring is
+ * which the JVM unit lane does not compile; the bound it enforces is built out
+ * of Espresso's idling machinery, which only exists on a device. Wiring is
  * automatic: `.github/workflows/app2.yml`'s `app2-journey` job runs
  * `:app2:connectedDebugAndroidTest` ONCE, unfiltered, so every class under
- * `app2/src/androidTest/` runs. These four cases add ~4 seconds to that lane
- * and need no fixture, no Activity and no network.
+ * `app2/src/androidTest/` runs. These cases need no fixture host, none of the
+ * app's own screens and no network.
  *
- * The budgets here are deliberately small (hundreds of milliseconds against a
- * wait parked for hours) — the property under test is "the caller regains
- * control at its deadline", and a small budget proves it as well as a 15-second
- * one while keeping the lane fast.
+ * ## Three wedge shapes, because they fail differently
+ *
+ * A `waitForIdle()` can fail to return for three structurally different reasons,
+ * and the bound has to cover all of them:
+ *
+ *  - the main queue never drains ([BusyMainLooper]) — `Interrogator` keeps
+ *    dispatching, so it reaches its own deadline check;
+ *  - the main queue drains but an idling resource stays busy
+ *    ([BusyIdlingResource]) — `MessageQueue.next()` parks with nothing to wake
+ *    it, so only the deadline nudge ends the wait;
+ *  - everything is idle and Compose is simply waiting for the next
+ *    **Choreographer frame** — nothing times out at all, `Espresso.onIdle()`
+ *    returns normally, and Compose spins on it. This is the shape that cost
+ *    issue #2549's review run 24 of its 52 tests, and only the deadline tripwire
+ *    breaks it.
+ *
+ * The budgets here are deliberately small (hundreds of milliseconds against an
+ * app busy for seconds) — the property under test is "the caller regains control
+ * at its deadline", and a small budget proves it as well as a 15-second one
+ * while keeping the lane fast.
  */
 @RunWith(AndroidJUnit4::class)
 class BoundedWaitTest {
 
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val busyLooper = BusyMainLooper()
+    private val busyResource = BusyIdlingResource("pocketshell-busy-idling-fixture")
+
+    @Before
+    fun registerTheResourceWedge() {
+        IdlingRegistry.getInstance().register(busyResource)
+    }
+
     /**
-     * The #2479 shape itself: a wait that never returns must not consume more
-     * than its budget.
+     * Unlike [ComposeIdleReentrancyTest], nothing here uses the Compose rule's
+     * teardown as an oracle, so both wedges are released as soon as the
+     * assertions are done and the lane does not pay for their timers.
+     */
+    @After
+    fun releaseTheWedges() {
+        busyLooper.release()
+        busyResource.release()
+        IdlingRegistry.getInstance().unregister(busyResource)
+    }
+
+    /**
+     * The regression for issue #2549's blocking review finding.
      *
-     * `Long.MAX_VALUE` rather than a long sleep on purpose — a wait that
-     * "eventually" returns could pass this by accident.
+     * The first fix bounded a `waitForIdle()` with `IdlingPolicies` alone, and a
+     * reviewer's unfiltered run then parked one `awaitIdle` for **961 seconds on
+     * a 15-second budget** and lost 24 of the lane's 52 tests. The thread dump
+     * put the calling thread in
+     * `AndroidComposeUiTestEnvironment.waitForNextChoreographerFrame`, which is
+     * (`ComposeUiTest.android.kt:402`, bytecode 182-212) exactly:
+     *
+     * ```
+     * root.postOnAnimation { root.post { frameReceived = true } }
+     * while (!frameReceived) { idlingStrategy.runUntilIdle() }   // Espresso.onIdle()
+     * ```
+     *
+     * An idling policy cannot bound that: with nothing busy, every
+     * `Espresso.onIdle()` in the loop returns normally and Compose immediately
+     * calls it again, so the wait's real floor is one vsync — 60 seconds on the
+     * starved swiftshader emulator that run was on.
+     *
+     * The block below is that loop verbatim, with the "frame" put [FRAME_MS]
+     * away instead of one vsync, because a 60-second frame is a property of a
+     * starved GPU and cannot be manufactured on demand. What is being asserted
+     * is the thing that failed: the caller gets control back on ITS budget, not
+     * on the frame's schedule.
      */
     @Test
-    fun aWaitThatNeverReturnsGivesUpWithinItsBudget() {
-        val bounded = BoundedWait("never-returns")
+    fun aSpinBetweenChoreographerFramesIsBoundedByTheBudget() {
+        showSomething()
+        val frameReceived = AtomicBoolean(false)
+        Handler(Looper.getMainLooper()).postDelayed({ frameReceived.set(true) }, FRAME_MS)
+        val bounded = BoundedWait("frame-spin")
         val started = SystemClock.elapsedRealtime()
 
-        val completed = bounded.run("parked-forever", budgetMs = 500L) {
-            parkForever()
+        val completed = bounded.run("frame spin", budgetMs = BUDGET_MS) {
+            while (!frameReceived.get()) {
+                Espresso.onIdle()
+            }
         }
 
         val elapsed = SystemClock.elapsedRealtime() - started
-        assertFalse("a wait that never returns must not report completion", completed)
-        assertTrue("the budget must actually bound the call (took ${elapsed}ms)", elapsed < 5_000L)
+        assertFalse("a spin waiting on a frame must not report completion", completed)
+        assertTrue(
+            "the budget must end the spin, not the frame ${FRAME_MS}ms away " +
+                "(took ${elapsed}ms)",
+            elapsed < FRAME_MS,
+        )
+        assertTrue("the wedge must be reported for the failure message", bounded.isStuck())
+    }
+
+    /**
+     * The #2479 shape: an app that will not go idle must not consume more than
+     * the budget.
+     */
+    @Test
+    fun aWaitOnABusyMainLooperGivesUpWithinItsBudget() {
+        val bounded = BoundedWait("never-idle")
+        showSomething()
+        busyLooper.beBusyFor(BUSY_MS)
+        val started = SystemClock.elapsedRealtime()
+
+        val completed = bounded.run("busy-queue", budgetMs = BUDGET_MS) {
+            compose.waitForIdle()
+        }
+
+        val elapsed = SystemClock.elapsedRealtime() - started
+        assertFalse("a wait on a busy app must not report completion", completed)
+        assertTrue(
+            "the budget must bound the call, not the fixture's own ${BUSY_MS}ms " +
+                "timer (took ${elapsed}ms)",
+            elapsed < BUSY_MS,
+        )
         assertTrue("the wedge must be reported for the failure message", bounded.isStuck())
         assertTrue(
             "the diagnosis must name the wait: ${bounded.stuckDiagnosis()}",
-            bounded.stuckDiagnosis().contains("parked-forever"),
+            bounded.stuckDiagnosis().contains("busy-queue"),
         )
     }
 
     /**
-     * The regression this issue is actually about, in miniature: a poll loop
-     * shaped exactly like `J03AttachAndTypeJourney.rotate()` — bounded loop,
-     * blocking wait in the body, condition that never comes true — must reach
-     * its own deadline and fail.
+     * The wedge Espresso's own 60-second policy cannot break: a main queue with
+     * nothing due plus a busy idling resource parks `MessageQueue.next()`, so
+     * `Interrogator` never reaches the deadline check that would end the wait.
      *
-     * Before the fix the equivalent loop parked on its FIRST iteration and
-     * never came back; the whole point is that the loop below still owns its
+     * This is the case the deadline nudge exists for. If the nudge stopped being
+     * posted, this would take [BUSY_MS] and fail here.
+     */
+    @Test
+    fun aWaitParkedOnAnEmptyQueueGivesUpWithinItsBudget() {
+        val bounded = BoundedWait("parked-on-an-empty-queue")
+        showSomething()
+        busyResource.beBusyFor(BUSY_MS)
+        val started = SystemClock.elapsedRealtime()
+
+        val completed = bounded.run("empty-queue", budgetMs = BUDGET_MS) {
+            compose.waitForIdle()
+        }
+
+        val elapsed = SystemClock.elapsedRealtime() - started
+        assertFalse("a wait on a busy resource must not report completion", completed)
+        assertTrue(
+            "the deadline nudge must wake the parked queue inside the budget " +
+                "(took ${elapsed}ms against a ${BUSY_MS}ms fixture)",
+            elapsed < BUSY_MS,
+        )
+        assertTrue("the wedge must be reported for the failure message", bounded.isStuck())
+    }
+
+    /**
+     * The regression this bound is actually about, in miniature: a poll loop
+     * shaped exactly like `J03AttachAndTypeJourney.rotate()` — bounded loop,
+     * blocking idle sync in the body, condition that never comes true — must
+     * reach its own deadline and fail.
+     *
+     * Before the bound existed the equivalent loop parked on its FIRST iteration
+     * and never came back; the whole point is that the loop below still owns its
      * clock.
      */
     @Test
     fun aPollLoopWithAWedgedWaitStillReachesItsDeadline() {
         val bounded = BoundedWait("wedged-poll")
-        val loopBudgetMs = 3_000L
+        showSomething()
+        busyLooper.beBusyFor(LOOP_BUDGET_MS + 2_000L)
         val started = SystemClock.elapsedRealtime()
-        val deadline = started + loopBudgetMs
+        val deadline = started + LOOP_BUDGET_MS
         var iterations = 0
         // The oracle `rotate()` polls for, standing in for "the terminal laid
         // out landscape": here it never comes true, so only the loop's own
@@ -81,7 +212,7 @@ class BoundedWaitTest {
         val laidOut = { false }
 
         while (SystemClock.elapsedRealtime() < deadline) {
-            bounded.run("idle-sync", budgetMs = 400L) { parkForever() }
+            bounded.run("idle-sync", budgetMs = 400L) { compose.waitForIdle() }
             iterations += 1
             if (laidOut()) break
             SystemClock.sleep(50L)
@@ -91,21 +222,26 @@ class BoundedWaitTest {
         assertFalse("the fixture's condition never comes true", laidOut())
         assertTrue(
             "the loop must exit at its own deadline, not the wait's (took ${elapsed}ms)",
-            elapsed in loopBudgetMs..(loopBudgetMs + 5_000L),
+            elapsed in LOOP_BUDGET_MS..(LOOP_BUDGET_MS + 5_000L),
         )
-        // The first iteration pays the 400 ms budget; every later one is told
-        // immediately that the wait is already parked, which is what keeps the
-        // remaining budget available for real polling.
-        assertTrue("the loop must keep polling after the wedge ($iterations)", iterations > 3)
+        assertTrue("the loop must keep polling through the wedge ($iterations)", iterations > 3)
     }
 
     /** A healthy wait is unchanged: it completes, and nothing is reported stuck. */
     @Test
     fun aWaitThatReturnsIsReportedComplete() {
         val bounded = BoundedWait("healthy")
+        showSomething()
         var ran = 0
 
-        repeat(3) { assertTrue(bounded.run("quick", budgetMs = 5_000L) { ran += 1 }) }
+        repeat(3) {
+            assertTrue(
+                bounded.run("quick", budgetMs = 15_000L) {
+                    compose.waitForIdle()
+                    ran += 1
+                },
+            )
+        }
 
         assertEquals("the block must run every time", 3, ran)
         assertFalse("nothing timed out, so nothing is stuck", bounded.isStuck())
@@ -114,8 +250,8 @@ class BoundedWaitTest {
 
     /**
      * A real failure inside a wrapped wait must reach the test, not be laundered
-     * into "the wait timed out" or swallowed on the worker thread — otherwise
-     * the bound would hide the assertion failures it wraps.
+     * into "the wait timed out" — otherwise the bound would hide the assertion
+     * failures it wraps.
      */
     @Test
     fun aFailureInsideTheWaitReachesTheCaller() {
@@ -130,8 +266,112 @@ class BoundedWaitTest {
         assertFalse("a thrown block is not a wedge", bounded.isStuck())
     }
 
-    /** A wait that outlives its budget and never returns; the worker is a daemon. */
-    private fun parkForever() {
-        CountDownLatch(1).await(1L, TimeUnit.DAYS)
+    /**
+     * The bound must not leave Espresso's global idling policies lowered on ANY
+     * exit path: every unbounded `onNodeWithTag`/`performClick` in every later
+     * journey runs on them, and a 400 ms master policy left behind would redden
+     * a slow-but-healthy emulator suite-wide.
+     *
+     * All three paths, because the two that matter are the ones a success-only
+     * test never reaches — the give-up path lowers the policies twice (once per
+     * call, once on trip) and the throwing path unwinds through `finally` from a
+     * different stack.
+     */
+    @Test
+    fun theBoundRestoresEspressosGlobalIdlingPoliciesOnEveryPath() {
+        showSomething()
+        val masterBefore = masterTimeoutMs()
+        val resourceBefore = resourceTimeoutMs()
+
+        BoundedWait("policy-success").run("quick", budgetMs = 5_000L) { compose.waitForIdle() }
+        assertEquals("after a completed wait: master", masterBefore, masterTimeoutMs())
+        assertEquals("after a completed wait: resource", resourceBefore, resourceTimeoutMs())
+
+        busyLooper.beBusyFor(BUSY_MS)
+        val completed = BoundedWait("policy-giveup")
+            .run("wedged", budgetMs = BUDGET_MS) { compose.waitForIdle() }
+        assertFalse("the give-up path must actually be taken", completed)
+        assertEquals("after a give-up: master", masterBefore, masterTimeoutMs())
+        assertEquals("after a give-up: resource", resourceBefore, resourceTimeoutMs())
+        busyLooper.release()
+
+        runCatching {
+            BoundedWait("policy-throw").run("boom", budgetMs = 5_000L) {
+                throw IllegalStateException("boom")
+            }
+        }
+        assertEquals("after a thrown block: master", masterBefore, masterTimeoutMs())
+        assertEquals("after a thrown block: resource", resourceBefore, resourceTimeoutMs())
+    }
+
+    /**
+     * The tripwire must leave the registry on every path too.
+     *
+     * A leaked one is worse than no bound at all: it reports busy for ever, so
+     * the NEXT journey's every Espresso call would time out against a resource
+     * belonging to a test that finished minutes ago.
+     */
+    @Test
+    fun theBoundLeavesNoIdlingResourceBehind() {
+        showSomething()
+
+        BoundedWait("leak-success").run("quick", budgetMs = 5_000L) { compose.waitForIdle() }
+        assertEquals("after a completed wait", emptyList<String>(), tripwiresInRegistry())
+
+        busyLooper.beBusyFor(BUSY_MS)
+        val completed = BoundedWait("leak-giveup")
+            .run("wedged", budgetMs = BUDGET_MS) { compose.waitForIdle() }
+        assertFalse("the give-up path must actually be taken", completed)
+        assertEquals("after a give-up", emptyList<String>(), tripwiresInRegistry())
+        busyLooper.release()
+
+        runCatching {
+            BoundedWait("leak-throw").run("boom", budgetMs = 5_000L) {
+                throw IllegalStateException("boom")
+            }
+        }
+        assertEquals("after a thrown block", emptyList<String>(), tripwiresInRegistry())
+    }
+
+    /**
+     * Names of any [BoundedWait] tripwire still registered.
+     *
+     * The prefix is [BoundedWait]'s, not this test's — the busy-resource wedge
+     * above deliberately uses a different one, because a fixture that shared the
+     * prefix would make this assertion fail against its own fixture rather than
+     * against a leak (it did, first time).
+     */
+    private fun tripwiresInRegistry(): List<String> =
+        IdlingRegistry.getInstance().resources
+            .map { it.name }
+            .filter { it.startsWith("pocketshell-bounded-wait-") }
+
+    private fun masterTimeoutMs(): Long =
+        IdlingPolicies.getMasterIdlingPolicy().let { it.idleTimeoutUnit.toMillis(it.idleTimeout) }
+
+    private fun resourceTimeoutMs(): Long =
+        IdlingPolicies.getDynamicIdlingResourceErrorPolicy()
+            .let { it.idleTimeoutUnit.toMillis(it.idleTimeout) }
+
+    private fun showSomething() {
+        compose.setContent { Text("bounded wait fixture") }
+        compose.waitForIdle()
+    }
+
+    private companion object {
+
+        /** Comfortably longer than every budget below, so no budget can be met. */
+        const val BUSY_MS = 4_000L
+
+        const val BUDGET_MS = 500L
+
+        const val LOOP_BUDGET_MS = 3_000L
+
+        /**
+         * Stands in for the 60-second frame the reviewer's emulator was taking.
+         * Far enough above [BUDGET_MS] that "the budget ended it" and "the frame
+         * ended it" cannot be confused for one another.
+         */
+        const val FRAME_MS = 20_000L
     }
 }

--- a/app2/src/androidTest/java/com/pocketshell/next/connect/BusyIdlingResource.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/connect/BusyIdlingResource.kt
@@ -1,0 +1,57 @@
+package com.pocketshell.next.connect
+
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import androidx.test.espresso.IdlingResource
+
+/**
+ * An Espresso [IdlingResource] that reports BUSY for a chosen wall-clock window.
+ *
+ * The harness tests for [BoundedWait] need "the app is not idle right now" to be
+ * a fact they control, not a hope about emulator timing: a wedge produced by
+ * hammering the UI is a coin flip, while a resource that is busy for exactly
+ * four seconds makes "the idle sync cannot complete inside a one-second budget"
+ * true on every run and on every machine.
+ *
+ * Deliberately busy on a TIMER rather than until something releases it. The
+ * re-entrancy this exists to reproduce (#2549) only exists while an
+ * interrogation is still outstanding, so a resource a teardown could release
+ * would hide the bug — the interrogation has to outlive the caller that
+ * abandoned it, exactly as a real wedge does.
+ *
+ * The idle transition is announced from a `postDelayed` on the main looper,
+ * which is also how a real resource behaves: it both wakes the parked
+ * `MessageQueue.next()` Espresso is sitting in and tells Espresso to re-check.
+ */
+class BusyIdlingResource(private val resourceName: String) : IdlingResource {
+
+    @Volatile
+    private var idleAt: Long = 0L
+
+    @Volatile
+    private var callback: IdlingResource.ResourceCallback? = null
+
+    override fun getName(): String = resourceName
+
+    override fun isIdleNow(): Boolean = SystemClock.elapsedRealtime() >= idleAt
+
+    override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback) {
+        this.callback = callback
+    }
+
+    /** Reports busy for the next [millis], then announces the transition to idle. */
+    fun beBusyFor(millis: Long) {
+        idleAt = SystemClock.elapsedRealtime() + millis
+        Handler(Looper.getMainLooper()).postDelayed(
+            { callback?.onTransitionToIdle() },
+            millis,
+        )
+    }
+
+    /** Reports idle from now on, for a teardown that must not leave Espresso waiting. */
+    fun release() {
+        idleAt = 0L
+        Handler(Looper.getMainLooper()).post { callback?.onTransitionToIdle() }
+    }
+}

--- a/app2/src/androidTest/java/com/pocketshell/next/connect/BusyMainLooper.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/connect/BusyMainLooper.kt
@@ -1,0 +1,61 @@
+package com.pocketshell.next.connect
+
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+
+/**
+ * Keeps the main looper's queue non-empty for a chosen wall-clock window.
+ *
+ * This is the wedge shape the journeys actually hit — a screen that keeps
+ * posting work (a rotation, an IME animation, a terminal repainting a burst of
+ * output) so Espresso's `Interrogator` never sees an empty queue and
+ * `waitForIdle()` never completes. #2479 is the bound for it, and #2549 is what
+ * the first attempt at that bound did wrong.
+ *
+ * It also picks the exact Espresso failure #2549 reported. Every Espresso idle
+ * pass registers callbacks on any idle-notifier that is currently BUSY before
+ * interrogating, so a wedge made of a busy `IdlingResource` makes the second,
+ * colliding caller trip `IllegalStateException: Callback has already been
+ * registered` first. With nothing busy except the queue itself, both callers
+ * skip registration and go straight to `Interrogator.loopAndInterrogate`, and
+ * the second one trips the guard the CI runs printed:
+ * `IllegalStateException: Already interrogating!`.
+ *
+ * The re-post delay is deliberately inside `Interrogator.LOOKAHEAD_MILLIS` (15)
+ * so the queue always looks like it has work due now, while still costing the
+ * main thread ~200 wakeups a second rather than a hard spin — this runs on a
+ * shared, contended emulator.
+ */
+class BusyMainLooper {
+
+    private val handler = Handler(Looper.getMainLooper())
+
+    @Volatile
+    private var busyUntil: Long = 0L
+
+    private val churn = object : Runnable {
+        override fun run() {
+            if (SystemClock.elapsedRealtime() < busyUntil) {
+                handler.postDelayed(this, REPOST_DELAY_MS)
+            }
+        }
+    }
+
+    /** Keeps the queue occupied for the next [millis]. */
+    fun beBusyFor(millis: Long) {
+        val alreadyRunning = SystemClock.elapsedRealtime() < busyUntil
+        busyUntil = SystemClock.elapsedRealtime() + millis
+        if (!alreadyRunning) handler.post(churn)
+    }
+
+    /** Lets the queue drain again, for a teardown that must not wait it out. */
+    fun release() {
+        busyUntil = 0L
+        handler.removeCallbacks(churn)
+    }
+
+    private companion object {
+        const val REPOST_DELAY_MS = 5L
+    }
+}

--- a/app2/src/androidTest/java/com/pocketshell/next/connect/ComposeIdleReentrancyTest.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/connect/ComposeIdleReentrancyTest.kt
@@ -1,0 +1,165 @@
+package com.pocketshell.next.connect
+
+import android.os.SystemClock
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Issue #2549 — a bounded idle wait that gives up must not leave an Espresso
+ * interrogation running behind it.
+ *
+ * ## The failure being reproduced
+ *
+ * `J03AttachAndTypeJourney` failed three times in CI (a v0.5.2 release cut, a
+ * scheduled run, and a post-merge `main` run) with no product assertion
+ * involved:
+ *
+ * ```
+ * java.lang.RuntimeException: java.util.concurrent.ExecutionException:
+ *   java.lang.IllegalStateException: Already interrogating!
+ *   at androidx.test.espresso.Espresso.onIdle(Espresso.java:18)
+ *   at androidx.compose.ui.test.EspressoLink.runUntilIdle(EspressoLink.android.kt:82)
+ *   at androidx.compose.ui.test.AndroidComposeUiTestEnvironment.runTest(...)
+ *   at androidx.compose.ui.test.junit4.AndroidComposeTestRule$apply$1.evaluate(...)
+ * ```
+ *
+ * `Already interrogating!` is `Interrogator.checkSanity()` refusing a nested
+ * main-thread interrogation. `Espresso.onIdle()` called off the main thread
+ * posts a `loopMainThreadUntilIdle` task to the main looper and blocks on its
+ * future; that task sets a thread-local `interrogating` flag on the main thread
+ * and then dispatches main-queue messages ITSELF. So when a second thread calls
+ * `onIdle()` while the first one's task is still interrogating, the second
+ * one's task is dispatched from inside the first one's loop and the guard fires.
+ *
+ * The old [BoundedWait] created that state by design — it ran `waitForIdle()` on
+ * a daemon worker and let the caller continue when the budget expired, leaving
+ * the worker's interrogation outstanding with nobody tracking it. The next
+ * Espresso call from the test thread then blew up in the harness rather than on
+ * a product assertion: a semantics read, an action, or (as above) the Compose
+ * rule's own teardown.
+ *
+ * ## The three shapes, all from the same defect
+ *
+ * Each test below abandons a wait and then does one of the three things a
+ * journey does next. All three failed before the fix; the fix is that
+ * [BoundedWait] never abandons an interrogation at all — it bounds the wait
+ * with Espresso's own deadline, on the calling thread.
+ *
+ * ## Why a [BusyMainLooper] rather than a busy UI
+ *
+ * The wedge has to be a fact rather than emulator luck, and it has to be the
+ * right KIND of wedge — see [BusyMainLooper] for why a busy `IdlingResource`
+ * reproduces a sibling Espresso guard (`Callback has already been registered`)
+ * instead of the one CI reported.
+ */
+@RunWith(AndroidJUnit4::class)
+class ComposeIdleReentrancyTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    // Deliberately NO @After that releases the fixture. The looper stays busy on
+    // its own timer, through the Compose rule's teardown: releasing it first
+    // would let a leaked interrogation finish early and hide the bug from the
+    // teardown sync that reported it.
+    private val busy = BusyMainLooper()
+
+    private fun wedgeTheIdleSync() {
+        compose.setContent { Text(ON_SCREEN) }
+        compose.waitForIdle()
+        busy.beBusyFor(BUSY_MS)
+
+        val started = SystemClock.elapsedRealtime()
+        val completed = compose.awaitIdle("wedged idle sync", budgetMs = BUDGET_MS)
+        val elapsed = SystemClock.elapsedRealtime() - started
+
+        assertFalse(
+            "the wait must give up: the main looper is busy for ${BUSY_MS}ms " +
+                "against a ${BUDGET_MS}ms budget",
+            completed,
+        )
+        assertTrue(
+            "the budget must bound the wait, not the fixture's own ${BUSY_MS}ms " +
+                "timer (took ${elapsed}ms)",
+            elapsed < BUSY_MS,
+        )
+    }
+
+    /**
+     * The exact reported stack. `AndroidComposeUiTestEnvironment.runTest`
+     * (`ComposeUiTest.android.kt:363`) ends every test in this suite with a
+     * plain `waitForIdle()`, and that is the frame CI printed — so the call
+     * below is the reported failure, made explicit rather than left to the rule
+     * to perform after the last line of the method.
+     *
+     * Making it explicit is deliberate: the leak from an earlier method also
+     * poisons LATER methods and later classes, so leaving this to the teardown
+     * would let the red land on whatever test happened to run next instead of
+     * on the one that caused it.
+     */
+    @Test
+    fun aGiveUpLeavesTheNextIdleSyncWorking() {
+        wedgeTheIdleSync()
+
+        compose.waitForIdle()
+    }
+
+    /**
+     * The `J03AttachAndTypeJourney.awaitTag` stack from the first occurrence: a
+     * poll loop that gave up on the idle sync goes straight back to reading the
+     * semantics tree.
+     */
+    @Test
+    fun aGiveUpLeavesTheNextSemanticsReadWorking() {
+        wedgeTheIdleSync()
+
+        compose.onNodeWithText(ON_SCREEN).assertIsDisplayed()
+    }
+
+    /**
+     * The `safeScreenDiagnosis` shape: the failure path wraps its own Compose
+     * reads in a [BoundedWait] too, so a give-up must leave the NEXT bounded
+     * wait usable rather than poisoned.
+     */
+    @Test
+    fun aGiveUpLeavesTheNextBoundedWaitWorking() {
+        wedgeTheIdleSync()
+
+        val diagnosis = BoundedWait("reentrancy-diagnosis")
+        var nodes = 0
+        val read = diagnosis.run("semantics read", DIAGNOSIS_BUDGET_MS) {
+            nodes = compose.onAllNodesWithText(ON_SCREEN).fetchSemanticsNodes().size
+        }
+
+        assertTrue("the diagnosis read must complete, not be refused", read)
+        assertTrue("the diagnosis must see the tree it read ($nodes)", nodes > 0)
+    }
+
+    private companion object {
+
+        const val ON_SCREEN = "reentrancy fixture"
+
+        /** Long enough that the budget below cannot be met by any timing luck. */
+        const val BUSY_MS = 4_000L
+
+        /** Short enough that three tests plus teardowns stay a few seconds. */
+        const val BUDGET_MS = 1_000L
+
+        /**
+         * Generous on purpose. The assertion is that the wrapped read COMPLETES
+         * — the looper is still busy when it starts, so a tight budget would
+         * only re-prove the bound and would never reach the Compose call whose
+         * re-entrancy is the subject here.
+         */
+        const val DIAGNOSIS_BUDGET_MS = 15_000L
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,17 +82,20 @@ androidx-test-core = "1.6.1"
 androidx-test-ext-junit = "1.2.1"
 androidx-test-runner = "1.6.2"
 
-# espresso-intents (issue #175). Used by the connected
-# TerminalSurfaceComposeIntegrationTest to assert that tapping a URL in the
-# terminal scrollback fires an `Intent.ACTION_VIEW` with the URL as data.
-# Recording-callback fakes are not enough — the reviewer requires that the
-# full production path (PocketShellTerminalViewClient.onSingleTapUp →
-# onTapMaybeUrl → openUrlWithFallback → Context.startActivity) be exercised,
-# and the only way to assert ACTION_VIEW vs ACTION_DIAL non-trivially is via
+# androidx.test.espresso, ONE version for every espresso artifact (issues #175,
+# #2549). Originally added for espresso-intents: the connected
+# TerminalSurfaceComposeIntegrationTest asserts that tapping a URL in the
+# terminal scrollback fires an `Intent.ACTION_VIEW` with the URL as data, and
+# the only way to assert ACTION_VIEW vs ACTION_DIAL non-trivially is via
 # Espresso's intent stubbing/recording. 3.6.1 is the latest stable on the
-# androidx.test.espresso 3.6.x line and aligns with the
-# androidx-test-* versions already pinned above.
-androidx-espresso-intents = "3.6.1"
+# androidx.test.espresso 3.6.x line and aligns with the androidx-test-*
+# versions already pinned above.
+#
+# Deliberately NOT named after one artifact any more (#2549 review): espresso's
+# artifacts are released as a set and must not skew, and a key called
+# `androidx-espresso-intents` shared by espresso-core would have let the next
+# intents bump silently move app2's whole journey harness.
+androidx-espresso = "3.6.1"
 # androidx.activity 1.10.1 is already on the classpath via activity-compose;
 # we still declare an explicit entry for `androidx.activity:activity` so the
 # core-terminal connected tests can host TerminalSurface on a real
@@ -212,7 +215,26 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
-androidx-espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "androidx-espresso-intents" }
+androidx-espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "androidx-espresso" }
+# espresso-core (issue #2549). app2's androidTest classpath had Espresso only as
+# a RUNTIME transitive of compose-ui-test-junit4, so the harness could depend on
+# Espresso's behaviour but could not name its types. `BoundedWait` bounds a
+# `waitForIdle()` through `IdlingPolicies` plus a real `IdlingResource`
+# tripwire, and catches `AppNotIdleException`/`IdlingResourceTimeoutException`;
+# `BusyIdlingResource` wedges Espresso deterministically through
+# `IdlingRegistry` — all compile-time references.
+#
+# THIS IS A VERSION BUMP, not just a new compile handle.
+# `androidx.compose.ui:ui-test-android:1.8.1`'s module metadata requires
+# espresso-core/espresso-idling-resource 3.5.0, and espresso-intents is declared
+# only on :shared:core-terminal — so before this, :app2's androidTest resolved
+# Espresso at 3.5.0. Declaring 3.6.1 here moves it for all eight journeys and
+# every harness class. That is deliberate: 3.6.1 is the line already pinned for
+# espresso-intents and the one that matches the androidx-test 1.6.x stack app2
+# already uses, and the #2549 red->green and the full unfiltered journey sweep
+# were both run on 3.6.1, so the classpath under test is the shipping one.
+# Test-only; nothing ships in the APK.
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "androidx-activity" }
 
 # core-terminal (issue #7). Used by the vendored Termux sources.


### PR DESCRIPTION
Closes #2549. Reviewer-`APPROVED` after two rounds and one `BLOCKED`.

## The flake

`Already interrogating!` was the harness running `Espresso.onIdle()` on **two threads at once**. `BoundedWait` ran `compose.waitForIdle()` on a daemon worker and, on budget expiry, returned while that worker's interrogation was still live. Off-main `onIdle()` posts a task that sets `Interrogator`'s thread-local flag and then dispatches main-queue messages itself, so the next caller's task is dispatched from inside the first loop and `checkSanity()` throws.

That explains the rotating victim method — it is whoever runs *next*, not whoever caused it — and why `AgentsFixture.kt:247` in the original report is only a caller frame, not the site. The reviewer confirmed all of this by decompiling `espresso-core-3.6.1`, down to the `catch (ExecutionException) -> throw new RuntimeException(ee)` at offsets 175-206 that produces the reported wrapper.

## Two fixes, because the first would have removed the bound

Running `BoundedWait.run()` on the calling thread makes the re-entrancy structurally impossible — one thread in Espresso. Public API unchanged, so all eight journeys are fixed at once without touching them.

But review found a method parked **961 s against a 15 s budget** with no timeout logged. `AndroidComposeUiTestEnvironment.waitForNextChoreographerFrame` is an unbounded spin on a real vsync callback, and that emulator logged `app_time_stats avg=60012.00ms` — a 60-second frame. So `compose.waitForIdle()` has a hard floor of one frame, and **`IdlingPolicies` can never bound it**: with nothing busy, `onIdle()` returns *normally*, so there is no timeout to lower and Compose simply calls it again.

The call now registers an `IdlingResource` that reports idle until the budget expires and busy for ever after. `IdlingResourceRegistry.allResourcesAreIdle` re-polls idle resources every pass, so the next `onIdle()` throws — out of the main-thread task, with that task already complete, so nothing is abandoned and the re-entrancy property survives. The reviewer verified every path back into Espresso passes the tripwire and that `Interrogator`'s exception table clears the thread-local before rethrowing.

**Deliberately not fixed, stated in the class doc**: a main thread wedged inside a *single* message dispatch stays unbounded, because observing the tripwire requires Espresso to run on the main thread.

## Evidence

- **G1 red→green, reviewer-run**: `aSpinBetweenChoreographerFramesIsBoundedByTheBudget` FAILED at **21.491 s against a 500 ms budget (43×)** on round-1 code — and was the **only** failure of eight, so the test is specific to the defect rather than a blanket assertion. **4.314 s PASS** with the fix.
- **Full unfiltered sweep**: `executed=57 skipped=1 failures=0 errors=0`. The skip is #2586's J12 quarantine, confirmed still `@Ignore`d on `main`.
- **Rotation 36.620 s**, against 961.658 s on round 1 (53.6 s CI, 56.1 s clean J03-only healthy). Still the slowest method, which is right for a double-rotation test.

## On load, stated as the weaker claim

The sweep ran at mean load **23.8** against the **50-68** that produced the park, so it is *corroboration, not proof* — the outlier is absent under materially lighter load.

The reviewer argued, correctly, that the sweep is **not** the primary evidence, because two things here are load-**independent**: the red→green fixture uses `Handler.postDelayed(..., 20_000)` rather than a real vsync, so 21.5 s → 4.3 s is wall-clock and a busy box moves it by seconds, not two orders of magnitude; and the round-2 bound has no load-sensitive term by construction, where round 1's was *inherently* load-dependent. They declined a second sweep rather than manufacture load 47 on a box the maintainer is using from their phone, and named the post-merge `app2-journey` run as the genuinely load-matched check.

The general lesson is recorded in `docs/ci-pitfalls.md` (`2b8579114`).

## Also

`espresso-core` moves **3.5.0 → 3.6.1** across app2's whole androidTest classpath — a version bump, not a new compile handle, which is why validation was an unfiltered sweep. An earlier claim that nothing on the runtime classpath moved was false and has been corrected in `gradle/libs.versions.toml`.

Post-rebase onto `2b8579114`: `:app2:compileDebugAndroidTestKotlin` exit 0, test-validity and hygiene guards pass. The reviewer notes their sweep validated the suite at `8480b9f77`, so the post-merge lane is the confirming run for the post-rebase composition.