### PR TITLE
fix: stop the composer wedging in a fake recording state

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/composer/J08VoiceDictationJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/composer/J08VoiceDictationJourney.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.dao.PendingTranscriptionDao
 import com.pocketshell.core.storage.entity.HostEntity
@@ -204,6 +205,86 @@ class J08VoiceDictationJourney {
         assertEquals(emptyList<Any>(), remaining)
     }
 
+    /**
+     * #2598, the maintainer's report, end to end: dictate, tap Send while the
+     * mic is still live, then reopen the composer.
+     *
+     * On the broken build the send dropped the recognizer with the SILENT
+     * release meant for a composer that is going away, so the state stayed
+     * [RecordingState.Recording] for good — every later open of the sheet
+     * came up on a waveform with no recognizer behind it, over the draft
+     * field, with Discard and the sheet's dismiss both no-ops. Here the
+     * reopened composer must be an ordinary editable composer.
+     */
+    @Test
+    fun sendingWhileDictatingLeavesTheComposerEditable() {
+        openSession()
+        grantRecordAudio()
+        openComposer()
+
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).performClick()
+        awaitTag(COMPOSER_WAVEFORM_TAG, "the recording surface")
+        ScriptedSpeechRecognitionProvider.partial(SENT_WHILE_RECORDING)
+        compose.awaitIdle("after a partial transcript")
+        JourneyScreenshots.capture("04-recording-before-send", JOURNEY)
+
+        // Send is enabled mid-dictation — this is the ordinary voice flow.
+        compose.onNodeWithTag(COMPOSER_SEND_TAG).performClick()
+        compose.awaitIdle("after sending mid-dictation")
+        awaitGone(COMPOSER_TAG, "the composer sheet after a send")
+
+        // The bytes really left: the dictated text is on the remote pane.
+        awaitPaneText(SENT_WHILE_RECORDING)
+
+        openComposer()
+        JourneyScreenshots.capture("05-reopened-after-voice-send", JOURNEY)
+
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG).assertIsDisplayed()
+        compose.onAllNodesWithTag(COMPOSER_WAVEFORM_TAG).assertCountEquals(0)
+        compose.onAllNodesWithTag(COMPOSER_TIMER_TAG).assertCountEquals(0)
+        compose.onAllNodesWithTag(COMPOSER_DISCARD_RECORDING_TAG).assertCountEquals(0)
+        // ...and the idle chrome is back, mic included.
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).assertIsDisplayed()
+
+        // The composer is usable again: type and the field takes it.
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG).performTextInput(TYPED_AFTER_SEND)
+        compose.awaitIdle("after typing into the reopened composer")
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG)
+            .assertTextContains(TYPED_AFTER_SEND, substring = true)
+    }
+
+    /**
+     * The other half of #2598 ("no way to stop it"): the recording surface's
+     * Stop control ends the dictation and hands the transcript back as an
+     * editable draft — Recording → Transcribing → Idle — without throwing the
+     * text away the way Discard does.
+     */
+    @Test
+    fun theStopControlEndsTheDictationAndKeepsTheText() {
+        openSession()
+        grantRecordAudio()
+        openComposer()
+
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).performClick()
+        awaitTag(COMPOSER_WAVEFORM_TAG, "the recording surface")
+        ScriptedSpeechRecognitionProvider.partial(STOPPED_TRANSCRIPT)
+        compose.awaitIdle("after a partial transcript")
+
+        compose.onNodeWithTag(COMPOSER_STOP_RECORDING_TAG).performClick()
+        compose.awaitIdle("after tapping stop")
+        // The recognizer was asked to transcribe, not abandoned.
+        awaitTag(COMPOSER_TRANSCRIBING_TAG, "the transcribing surface")
+
+        ScriptedSpeechRecognitionProvider.final(STOPPED_TRANSCRIPT)
+        compose.awaitIdle("after the final transcript")
+        JourneyScreenshots.capture("06-stopped-editable", JOURNEY)
+
+        compose.onNodeWithTag(COMPOSER_DRAFT_TAG)
+            .assertTextContains(STOPPED_TRANSCRIPT, substring = true)
+        compose.onAllNodesWithTag(COMPOSER_WAVEFORM_TAG).assertCountEquals(0)
+        compose.onNodeWithTag(COMPOSER_MIC_TAG).assertIsDisplayed()
+    }
+
     // --- helpers ----------------------------------------------------------
 
     private fun openSession() {
@@ -227,6 +308,33 @@ class J08VoiceDictationJourney {
             instrumentation.targetContext.packageName,
             Manifest.permission.RECORD_AUDIO,
         )
+    }
+
+    /** Waits for [tag] to leave the tree (a sheet closing, a surface going away). */
+    private fun awaitGone(tag: String, what: String = tag) {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            compose.awaitIdle("gone poll: $what")
+            if (compose.onAllNodesWithTag(tag).fetchSemanticsNodes().isEmpty()) return
+            SystemClock.sleep(POLL_MS)
+        }
+        val shot = JourneyScreenshots.capture("failure-gone-${what.replace(' ', '-')}", JOURNEY)
+        throw AssertionError("$what never went away within ${TIMEOUT_MS}ms. Screenshot: ${shot.absolutePath}")
+    }
+
+    /**
+     * The independent oracle: what the REMOTE pane holds, read over its own
+     * SSH connection rather than off the device's screen.
+     */
+    private fun awaitPaneText(text: String) {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        var pane = ""
+        while (SystemClock.elapsedRealtime() < deadline) {
+            pane = AgentsFixture.exec("tmux -S $SOCKET capture-pane -p -t '=$SESSION:'")
+            if (pane.contains(text)) return
+            SystemClock.sleep(POLL_MS)
+        }
+        throw AssertionError("the pane never showed \"$text\". Last capture:\n$pane")
     }
 
     private fun awaitTag(tag: String, what: String = tag) {
@@ -254,9 +362,16 @@ class J08VoiceDictationJourney {
         const val DEFAULT_OFFLINE_TRANSCRIPT = "unused-default-transcript"
         const val OFFLINE_TRANSCRIPT = "queued while the subway had no signal"
 
+        /** #2598: dictated, then sent while the mic was still live. */
+        const val SENT_WHILE_RECORDING = "echo j08-sent-mid-dictation"
+        const val TYPED_AFTER_SEND = "typed after the voice send"
+        const val STOPPED_TRANSCRIPT = "stop but keep what I said"
+
         val HOST_IDS: Map<String, Long> = mapOf(
             "micTapDictatesIntoTheComposerDraft" to 9_801L,
             "aQueuedOfflineDictationDeliversOnForegroundResume" to 9_802L,
+            "sendingWhileDictatingLeavesTheComposerEditable" to 9_803L,
+            "theStopControlEndsTheDictationAndKeepsTheText" to 9_804L,
         )
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/composer/AndroidSpeechRecognitionDelegate.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/AndroidSpeechRecognitionDelegate.kt
@@ -107,30 +107,77 @@ internal class AndroidSpeechRecognitionDelegate(
         callbacks.onState(RecordingState.Recording)
     }
 
-    /** The user tapped stop: transcribe what was said. */
+    /**
+     * The user tapped stop: transcribe what was said.
+     *
+     * With no recognizer left, this reports [RecordingState.Idle] rather than
+     * doing nothing — see [cancel] for why a live composer is never left
+     * holding a state the delegate cannot end (#2598).
+     */
     fun stop() {
-        val running = session ?: return
+        val running = session
+        if (running == null) {
+            callbacks.onState(RecordingState.Idle)
+            return
+        }
         callbacks.onState(RecordingState.Transcribing)
         runCatching { running.stopListening() }.onFailure { failure ->
             fail(failure.message ?: UNAVAILABLE_MESSAGE)
         }
     }
 
-    /** The user tapped discard: drop the recording AND everything it typed. */
+    /**
+     * The user tapped discard: drop the recording AND everything it typed.
+     *
+     * ALWAYS ends at [RecordingState.Idle], recognizer or not. This used to
+     * early-return on a null session, which made Discard — and the sheet's
+     * dismiss, which is the same call — a no-op whenever the composer's state
+     * said "recording" but the recognizer was already gone. That combination
+     * is #2598: a waveform over the draft field with nothing behind it and no
+     * control that could put it away.
+     *
+     * The pre-dictation draft is restored only when a recording was genuinely
+     * live. Without a session there is no [baseDraft] to go back to (it is
+     * cleared with the recognizer), so writing it would delete whatever the
+     * user has typed since.
+     */
     fun cancel() {
-        if (session == null) return
-        val restored = baseDraft
+        val restored = baseDraft.takeIf { session != null }
         clear()
-        callbacks.onDraft(restored)
+        restored?.let(callbacks::onDraft)
         callbacks.onState(RecordingState.Idle)
     }
 
-    /** The screen went away. Silent — no state callbacks into a dead composer. */
+    /**
+     * The screen went away. Silent — no state callbacks into a dead composer.
+     *
+     * For a composer that is still on screen, use [releaseToIdle]: silence is
+     * correct only when nothing is left to tell.
+     */
     fun release() {
         val running = session
         session = null
         generation += 1
         runCatching { running?.cancel() }
+    }
+
+    /**
+     * The draft is being committed while the mic is live (Insert / Send).
+     *
+     * Same silent drop of the recognizer as [release] — no late partial may
+     * type into a draft that is about to be cleared — but the composer is
+     * still on screen, so it is told the dictation is over. [release]'s
+     * silence here is exactly what wedged the composer in #2598: the session
+     * went, the state stayed [RecordingState.Recording], and every reopen of
+     * the sheet showed a recording surface for a recognizer that had been
+     * gone since the send.
+     *
+     * Whatever the transcript already put on screen stays; only the recognizer
+     * goes.
+     */
+    fun releaseToIdle() {
+        clear()
+        callbacks.onState(RecordingState.Idle)
     }
 
     private fun isCurrent(candidate: Long): Boolean = session != null && generation == candidate

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerBar.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
@@ -61,6 +62,7 @@ const val COMPOSER_INSERT_TAG: String = "composer-insert"
 const val COMPOSER_ATTACH_TAG: String = "composer-attach"
 const val COMPOSER_MIC_TAG: String = "composer-mic"
 const val COMPOSER_DISCARD_RECORDING_TAG: String = "composer-discard-recording"
+const val COMPOSER_STOP_RECORDING_TAG: String = "composer-stop-recording"
 const val COMPOSER_HISTORY_TAG: String = "composer-history"
 const val COMPOSER_PREVIEW_TAG: String = "composer-preview"
 const val COMPOSER_PREVIEW_VIEW_TAG: String = "composer-preview-view"
@@ -72,12 +74,21 @@ const val COMPOSER_SLASH_TAG: String = "composer-slash"
 const val COMPOSER_SLASH_TRIGGER_TAG: String = "composer-slash-trigger"
 const val COMPOSER_TIMER_TAG: String = "composer-timer"
 const val COMPOSER_WAVEFORM_TAG: String = "composer-waveform"
+const val COMPOSER_TRANSCRIBING_TAG: String = "composer-transcribing"
 const val COMPOSER_CONTROLS_ROW_TAG: String = "composer-controls-row"
 
 fun composerSlashRowTag(command: String): String = "composer-slash-row:$command"
 
 /** The text a send that never left the device puts on screen. */
 const val COMPOSER_UNDELIVERED_TEXT: String = "Not delivered — session offline. Your draft was kept."
+
+/**
+ * The Stop control's accessible name (#2598).
+ *
+ * Spelled out because "stop" alone reads like Discard's twin: this is the one
+ * that KEEPS what was heard and hands it back as an editable draft.
+ */
+const val COMPOSER_STOP_RECORDING_DESCRIPTION: String = "Stop dictating and keep the text"
 
 /** Shown when RECORD_AUDIO is denied; dictation is not started. */
 const val COMPOSER_RECORD_AUDIO_DENIED_TEXT: String =
@@ -387,6 +398,14 @@ private fun ControlsRow(
                     recording = true,
                     modifier = Modifier.testTag(COMPOSER_SEND_TAG),
                 )
+                // #2598: the way out that keeps the text. It sits in the mic's
+                // own slot — the trailing edge — because that is where the
+                // thumb that started the dictation already is, and a tap here
+                // is the same mic toggle, now meaning "stop".
+                StopRecordingButton(
+                    onClick = onMicTap,
+                    modifier = Modifier.testTag(COMPOSER_STOP_RECORDING_TAG),
+                )
             }
             RecordingState.Transcribing -> {
                 DiscardRecordingButton(
@@ -556,6 +575,40 @@ private fun DiscardRecordingButton(
     }
 }
 
+/**
+ * Ends a dictation and keeps the transcript (#2598).
+ *
+ * A filled accent disc with a stop square, in the same slot and at the same
+ * size as [MicTriggerButton]: the mic turns into its own stop, which is the
+ * idiom every voice recorder uses. Deliberately NOT the [DiscardRecordingButton]
+ * outline — one of these two throws the user's words away and the other keeps
+ * them, so they must not look alike.
+ */
+@Composable
+private fun StopRecordingButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(ComposerIdlePillHeight)
+            .clip(CircleShape)
+            .background(color = PocketShellColors.Accent, shape = CircleShape)
+            .clickable(role = Role.Button, onClick = onClick)
+            .semantics { contentDescription = COMPOSER_STOP_RECORDING_DESCRIPTION },
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(COMPOSER_STOP_GLYPH_SIZE)
+                .background(
+                    color = PocketShellColors.OnAccent,
+                    shape = RoundedCornerShape(COMPOSER_STOP_GLYPH_RADIUS),
+                ),
+        )
+    }
+}
+
 @Composable
 private fun MicTriggerButton(
     onClick: () -> Unit,
@@ -577,6 +630,8 @@ private val ComposerDraftFontSize = 15.sp
 private val ComposerIdlePillHeight = 44.dp
 private val ComposerRecordingPillHeight = 48.dp
 private val COMPOSER_ACTION_ICON_BUTTON_SIZE = 40.dp
+private val COMPOSER_STOP_GLYPH_SIZE = 15.dp
+private val COMPOSER_STOP_GLYPH_RADIUS = 3.dp
 
 /**
  * The `/`-command list, rendered above the field so it never sits under the

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerRecordingSurfaces.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerRecordingSurfaces.kt
@@ -114,6 +114,7 @@ internal fun TranscribingSurface(modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .testTag(COMPOSER_TRANSCRIBING_TAG)
             .heightIn(min = 68.dp)
             .background(
                 color = PocketShellColors.SurfaceElev,

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
@@ -284,9 +284,12 @@ class ComposerViewModel @Inject constructor(
         if (!current.canSend || current.busy) return
         val target = sink ?: return
         // Insert/Send while the mic is live must not leave a recognizer
-        // writing partials into the draft we are about to clear. Silent
-        // release keeps the on-screen text (including the latest partial).
-        dictation.release()
+        // writing partials into the draft we are about to clear — and must
+        // not leave the composer LOOKING like it is still recording either
+        // (#2598). The recognizer goes silently, keeping the on-screen text
+        // (including the latest partial); the composer, which is still on
+        // screen, goes back to Idle so the user gets their draft field back.
+        dictation.releaseToIdle()
 
         val body = ComposerText.compose(current.draft.trim(), current.attachments.map { it.remotePath })
         val delivered = target.isLive
@@ -376,12 +379,24 @@ class ComposerViewModel @Inject constructor(
 
     // --------------------------------------------------------------- dictation
 
-    /** Mic tap: start dictating, or stop and transcribe. */
+    /**
+     * Mic tap: start dictating, or stop and transcribe.
+     *
+     * The stop half is also the recording surface's Stop control — the
+     * "end this dictation and give me back an editable draft" action that
+     * #2598 found missing, distinct from Discard, which throws the transcript
+     * away.
+     *
+     * A tap while the state says recording but no recognizer is live
+     * normalises that state instead of starting a SECOND dictation on top of
+     * it: the only way out of a stale recording surface must never be another
+     * recording.
+     */
     fun onMicTap() {
-        if (dictation.isRecording) {
-            dictation.stop()
-        } else {
-            dictation.start(language = recognizerLanguage())
+        when {
+            dictation.isRecording -> dictation.stop()
+            _state.value.recording != RecordingState.Idle -> dictation.cancel()
+            else -> dictation.start(language = recognizerLanguage())
         }
     }
 
@@ -399,7 +414,14 @@ class ComposerViewModel @Inject constructor(
         notify(ComposerNotice.Problem(COMPOSER_RECORD_AUDIO_DENIED_TEXT))
     }
 
-    /** Discard the recording and restore the draft as it was before the mic opened. */
+    /**
+     * Discard the recording and restore the draft as it was before the mic
+     * opened.
+     *
+     * Also the sheet's dismiss path, and the one guaranteed way back to an
+     * ordinary composer: it ends at [RecordingState.Idle] whether or not a
+     * recognizer is live (#2598).
+     */
     fun cancelRecording() = dictation.cancel()
 
     /**

--- a/app2/src/test/java/com/pocketshell/next/composer/AndroidSpeechRecognitionDelegateTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/AndroidSpeechRecognitionDelegateTest.kt
@@ -1,0 +1,134 @@
+package com.pocketshell.next.composer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [AndroidSpeechRecognitionDelegate]'s state machine, at the seam
+ * [ComposerViewModel] cannot reach: what happens when the recognizer is
+ * already gone but the composer still thinks it is listening.
+ *
+ * That gap is #2598. `deliver()` dropped the session with the silent
+ * [AndroidSpeechRecognitionDelegate.release] meant for a composer that is
+ * going away, and `cancel()` early-returned when there was no session left —
+ * so nothing could move the composer out of [RecordingState.Recording] again.
+ * The rule these tests pin: the delegate never leaves a LIVE composer in a
+ * recording state it has no recognizer for.
+ */
+class AndroidSpeechRecognitionDelegateTest {
+
+    private val provider = FakeSpeechRecognitionProvider()
+    private val callbacks = RecordingCallbacks()
+    private val delegate = AndroidSpeechRecognitionDelegate(provider, callbacks)
+
+    @Test
+    fun `a discard with no recognizer live still reports Idle`() {
+        delegate.cancel()
+
+        assertEquals(listOf(RecordingState.Idle), callbacks.states)
+    }
+
+    /**
+     * The ghost case, in the shape the user hits it: the recording ended
+     * behind the composer's back, then Discard (or the sheet's dismiss) is
+     * tapped. It must normalise the state and leave the draft ALONE — there
+     * is no pre-dictation text to restore any more, and restoring the stale
+     * one would delete whatever has been typed since.
+     */
+    @Test
+    fun `a discard after the recognizer was already dropped keeps the draft`() {
+        callbacks.draft = "before the mic"
+        delegate.start()
+        provider.partial("dictated words")
+        assertEquals("before the mic dictated words", callbacks.draft)
+
+        delegate.releaseToIdle()
+        callbacks.draft = "typed after the send"
+        callbacks.states.clear()
+
+        delegate.cancel()
+
+        assertEquals(listOf(RecordingState.Idle), callbacks.states)
+        assertEquals("typed after the send", callbacks.draft)
+    }
+
+    /** A live discard is unchanged: the pre-dictation draft comes back. */
+    @Test
+    fun `a discard during a live dictation restores the pre-dictation draft`() {
+        callbacks.draft = "before the mic"
+        delegate.start()
+        provider.partial("dictated words")
+
+        delegate.cancel()
+
+        assertEquals("before the mic", callbacks.draft)
+        assertEquals(listOf(RecordingState.Recording, RecordingState.Idle), callbacks.states)
+        assertTrue(provider.cancelled)
+    }
+
+    /** The stop affordance's safety valve: nothing to stop still means Idle. */
+    @Test
+    fun `a stop with no recognizer live reports Idle`() {
+        delegate.stop()
+
+        assertEquals(listOf(RecordingState.Idle), callbacks.states)
+    }
+
+    /**
+     * The Insert/Send path: the recognizer goes so no late partial can type
+     * into a draft that is being cleared, the transcript already on screen
+     * stays, and the composer — still very much alive — goes back to Idle.
+     */
+    @Test
+    fun `releaseToIdle drops the recognizer, keeps the text and reports Idle`() {
+        callbacks.draft = "before the mic"
+        delegate.start()
+        provider.partial("dictated words")
+        callbacks.states.clear()
+
+        delegate.releaseToIdle()
+
+        assertEquals(listOf(RecordingState.Idle), callbacks.states)
+        assertEquals("before the mic dictated words", callbacks.draft)
+        assertTrue(provider.cancelled)
+        // A late partial from the dropped session cannot type any more.
+        provider.partial("too late")
+        assertEquals("before the mic dictated words", callbacks.draft)
+    }
+
+    /**
+     * [AndroidSpeechRecognitionDelegate.release] stays silent — its callers
+     * (a session hand-off, `onCleared`) have no composer left to talk to.
+     */
+    @Test
+    fun `release reports no state at all`() {
+        delegate.start()
+        callbacks.states.clear()
+
+        delegate.release()
+
+        assertEquals(emptyList<RecordingState>(), callbacks.states)
+        assertTrue(provider.cancelled)
+    }
+
+    private class RecordingCallbacks : AndroidSpeechRecognitionDelegate.Callbacks {
+        var draft: String = ""
+        val states = mutableListOf<RecordingState>()
+        val errors = mutableListOf<String>()
+
+        override fun currentDraft(): String = draft
+
+        override fun onDraft(text: String) {
+            draft = text
+        }
+
+        override fun onState(state: RecordingState) {
+            states += state
+        }
+
+        override fun onError(message: String) {
+            errors += message
+        }
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerBarTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerBarTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -15,6 +16,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
 /**
  * The rendered composer on the host JVM (Robolectric).
@@ -259,7 +261,100 @@ class ComposerBarTest {
         composeRule.onNodeWithTag(COMPOSER_SLASH_TRIGGER_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(COMPOSER_MIC_TAG).assertDoesNotExist()
 
-        assertSameRow(COMPOSER_DISCARD_RECORDING_TAG, COMPOSER_INSERT_TAG, COMPOSER_SEND_TAG)
+        assertSameRow(
+            COMPOSER_DISCARD_RECORDING_TAG,
+            COMPOSER_INSERT_TAG,
+            COMPOSER_SEND_TAG,
+            COMPOSER_STOP_RECORDING_TAG,
+        )
+    }
+
+    /**
+     * #2598: "there is no way to stop it". The recording row shipped
+     * Discard / Insert / Send and no stop control, so a dictation could only
+     * be ended by throwing the text away or committing it — never by handing
+     * it back as an editable draft.
+     */
+    @Test
+    fun `the recording row has a stop control that is not discard`() {
+        var micTaps = 0
+        var discards = 0
+        setContent(
+            ComposerUiState(recording = RecordingState.Recording, micAvailable = true),
+            onMicTap = { micTaps += 1 },
+            onCancelRecording = { discards += 1 },
+        )
+
+        composeRule.onNodeWithTag(COMPOSER_STOP_RECORDING_TAG).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(COMPOSER_STOP_RECORDING_DESCRIPTION)
+            .assertIsDisplayed()
+
+        composeRule.onNodeWithTag(COMPOSER_STOP_RECORDING_TAG).performClick()
+
+        assertEquals("stop ends the dictation", 1, micTaps)
+        assertEquals("stop is not discard", 0, discards)
+
+        composeRule.onNodeWithTag(COMPOSER_DISCARD_RECORDING_TAG).performClick()
+        assertEquals(1, discards)
+        assertEquals(1, micTaps)
+    }
+
+    /**
+     * Transcribing is its own surface, and the recording controls that only
+     * make sense while the mic is live are gone from it — Cancel is the way
+     * out, not a second stop.
+     */
+    @Test
+    fun `transcribing shows its own surface without the recording controls`() {
+        setContent(ComposerUiState(recording = RecordingState.Transcribing, micAvailable = true))
+
+        composeRule.onNodeWithTag(COMPOSER_TRANSCRIBING_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(COMPOSER_WAVEFORM_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_STOP_RECORDING_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_DRAFT_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_DISCARD_RECORDING_TAG).assertIsDisplayed()
+    }
+
+    /**
+     * The stop control has to FIT: a `Row` does not overflow, it SQUASHES —
+     * a recording row one button too wide for a phone silently shrinks its
+     * last child instead of pushing it off-screen, which would be the same
+     * "no way out" bug with a stop button too small to hit.
+     *
+     * Stop is measured last, so its full 44dp square is the canary for the
+     * whole row having room.
+     */
+    @Test
+    @Config(qualifiers = "w360dp-h800dp")
+    fun `the recording row fits a phone width`() {
+        setContent(ComposerUiState(recording = RecordingState.Recording, micAvailable = true))
+
+        val row = composeRule.onNodeWithTag(COMPOSER_CONTROLS_ROW_TAG)
+            .fetchSemanticsNode().boundsInRoot
+        val density = composeRule.density.density
+        val controls = listOf(
+            COMPOSER_DISCARD_RECORDING_TAG,
+            COMPOSER_INSERT_TAG,
+            COMPOSER_SEND_TAG,
+            COMPOSER_STOP_RECORDING_TAG,
+        ).associateWith { tag ->
+            composeRule.onNodeWithTag(tag).fetchSemanticsNode().boundsInRoot
+        }
+
+        controls.forEach { (tag, bounds) ->
+            assertTrue(
+                "$tag is outside the controls row: $bounds vs $row",
+                bounds.left >= row.left - 0.5f && bounds.right <= row.right + 0.5f,
+            )
+        }
+        val stop = controls.getValue(COMPOSER_STOP_RECORDING_TAG)
+        assertEquals(
+            "the stop control is squashed — the recording row has run out of width",
+            44f,
+            stop.width / density,
+            0.5f,
+        )
+        assertEquals(44f, stop.height / density, 0.5f)
     }
 
     @Test
@@ -285,6 +380,8 @@ class ComposerBarTest {
         onInsert: () -> Unit = {},
         onRemoveAttachment: (String) -> Unit = {},
         onToggleHistory: () -> Unit = {},
+        onMicTap: () -> Unit = {},
+        onCancelRecording: () -> Unit = {},
     ) {
         composeRule.setContent {
             PocketShellTheme {
@@ -294,8 +391,8 @@ class ComposerBarTest {
                     onSend = onSend,
                     onInsert = onInsert,
                     onAttach = {},
-                    onMicTap = {},
-                    onCancelRecording = {},
+                    onMicTap = onMicTap,
+                    onCancelRecording = onCancelRecording,
                     onToggleHistory = onToggleHistory,
                     onTogglePreview = {},
                     onRemoveAttachment = onRemoveAttachment,

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
@@ -885,6 +885,151 @@ class ComposerViewModelTest {
         assertEquals(null, stack.speech.lastLanguage)
     }
 
+    // -------------------------------------- a dictation always ends at Idle
+
+    /**
+     * #2598 reproduce-first: the ordinary voice flow — dictate, tap Send —
+     * left `recording` on [RecordingState.Recording] for good.
+     *
+     * `deliver()` dropped the recognizer with the SILENT release meant for a
+     * composer that is going away, so the session was gone while the state
+     * still said "listening". Reopening the sheet then showed a live-looking
+     * waveform with nothing behind it, over the draft field the user needed,
+     * and no control on that surface could get back out of it.
+     */
+    @Test
+    fun `a send while dictating ends the recording instead of wedging the composer`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onMicTap()
+            stack.speech.partial("ship the fix")
+            advanceUntilIdle()
+            assertEquals(RecordingState.Recording, viewModel.state.value.recording)
+
+            viewModel.send()
+            advanceUntilIdle()
+
+            assertEquals(
+                "a send while dictating must leave the composer editable again",
+                RecordingState.Idle,
+                viewModel.state.value.recording,
+            )
+            assertEquals(listOf("ship the fix", "\r"), sink.sentText())
+            assertEquals("", viewModel.state.value.draft)
+            assertTrue("the recognizer must really be released", stack.speech.cancelled)
+        }
+
+    /** Insert takes the same path, and the sheet stays open on the draft field. */
+    @Test
+    fun `an insert while dictating ends the recording too`() = runTest(dispatcher) {
+        val viewModel = bound()
+        viewModel.onMicTap()
+        stack.speech.partial("ship the fix")
+        advanceUntilIdle()
+
+        viewModel.insert()
+        advanceUntilIdle()
+
+        assertEquals(RecordingState.Idle, viewModel.state.value.recording)
+        assertEquals(listOf("ship the fix"), sink.sentText())
+        assertEquals("", viewModel.state.value.draft)
+    }
+
+    /**
+     * The second half of the wedge: once the state was a ghost, `Discard` and
+     * the sheet's dismiss (both [ComposerViewModel.cancelRecording]) did
+     * nothing at all, because the delegate early-returned on a null session.
+     *
+     * Cancelling with no recognizer live must normalise the state AND leave
+     * the draft alone — there is no pre-dictation text to restore, so
+     * restoring one would delete what the user typed after the send.
+     */
+    @Test
+    fun `discarding after a send that ended the dictation cannot leave a ghost recording`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onMicTap()
+            stack.speech.partial("ship the fix")
+            advanceUntilIdle()
+            viewModel.send()
+            advanceUntilIdle()
+
+            viewModel.onDraftChange("and now type something else")
+            viewModel.cancelRecording()
+            advanceUntilIdle()
+
+            assertEquals(RecordingState.Idle, viewModel.state.value.recording)
+            assertEquals("and now type something else", viewModel.state.value.draft)
+        }
+
+    /**
+     * The stop affordance (#2598): end the dictation, KEEP what was heard, and
+     * hand the text back as an editable draft — Recording → Transcribing →
+     * Idle. Distinct from Discard, which throws the transcript away.
+     */
+    @Test
+    fun `stopping a dictation keeps the transcript and returns to the editable draft`() =
+        runTest(dispatcher) {
+            val viewModel = bound()
+            viewModel.onMicTap()
+            stack.speech.partial("run the tests")
+            advanceUntilIdle()
+
+            viewModel.onMicTap()
+            advanceUntilIdle()
+            assertTrue("the recognizer must be asked to transcribe", stack.speech.stopped)
+            assertEquals(RecordingState.Transcribing, viewModel.state.value.recording)
+
+            stack.speech.final("run the tests now")
+            advanceUntilIdle()
+
+            assertEquals(RecordingState.Idle, viewModel.state.value.recording)
+            assertEquals("run the tests now", viewModel.state.value.draft)
+        }
+
+    /**
+     * G2 class coverage for #2598: it is not the send that has to end at
+     * [RecordingState.Idle], it is EVERY way out of a dictation. A composer
+     * left in any other state is a composer with no draft field and no way
+     * back to one.
+     */
+    @Test
+    fun `every exit from a live dictation ends at Idle`() = runTest(dispatcher) {
+        val exits: List<Pair<String, (ComposerViewModel) -> Unit>> = listOf(
+            "a final transcript" to { _: ComposerViewModel -> stack.speech.final("all done") },
+            "a recognizer error" to { _: ComposerViewModel -> stack.speech.error("recognizer died") },
+            "discard" to { vm: ComposerViewModel -> vm.cancelRecording() },
+            // The sheet's dismiss is exactly this call (PromptComposerSheet).
+            "the sheet being dismissed" to { vm: ComposerViewModel -> vm.cancelRecording() },
+            "insert" to { vm: ComposerViewModel -> vm.insert() },
+            "send" to { vm: ComposerViewModel -> vm.send() },
+            "a session hand-off" to { vm: ComposerViewModel -> vm.bind(hostId, OTHER_SESSION, sink) },
+        )
+
+        for ((what, exit) in exits) {
+            val viewModel = bound()
+            viewModel.onDraftChange("something to send")
+            advanceUntilIdle()
+            viewModel.onMicTap()
+            stack.speech.partial("and something dictated")
+            advanceUntilIdle()
+            assertEquals(
+                "precondition: $what must start from a live dictation",
+                RecordingState.Recording,
+                viewModel.state.value.recording,
+            )
+
+            exit(viewModel)
+            advanceUntilIdle()
+
+            assertEquals(
+                "$what must leave the composer at Idle",
+                RecordingState.Idle,
+                viewModel.state.value.recording,
+            )
+        }
+    }
+
     // ------------------------------------------------ offline-queued dictation
 
     /**


### PR DESCRIPTION
Closes #2598. Reviewer-`APPROVED` at this tree, rebased onto `f58ae4911` (the intervening commits changed `process.md`, `docs/lessons-learned.md` and `scripts/test-agents-fixture-aplexer.sh` — **zero** `.kt`/`.java` files, so the review evidence still describes this code).

## The bug

A voice send left the composer permanently showing a recording surface — waveform, running timer, Discard/Insert/Send — with no recognizer behind it and no control that could put it away. Reopening the sheet brought it straight back, so dictation was unusable after the first send until the session was switched or the app restarted. Reported from a maintainer screen recording; the frame is attached to the issue.

`deliver()` (Insert/Send) dropped the recognizer with `release()`, which is deliberately silent so a dead composer is never called back into — but the composer is not dead there, the sheet is still on screen. The session went while `_state.recording` stayed `Recording` forever, and Send is enabled during a dictation, so "dictate, tap Send" hit it every time. Nothing could then clear it: `cancel()` early-returned on a null session, making Discard and the sheet's dismiss (the same call) no-ops, and the Recording row had no mic at all — Discard throws the transcript away, Insert/Send commit it, and nothing merely ended the dictation.

## The fix

- `releaseToIdle()` drops the recognizer silently but reports `Idle`, for a composer still on screen. `release()` keeps its silence for `handOff`/`onCleared`, where there is genuinely nothing to tell.
- `cancel()` and `stop()` always end at `Idle`, restoring the pre-dictation draft only when a recording was genuinely live (without a session there is no `baseDraft` to go back to, and writing it would delete what the user typed since).
- `onMicTap()` normalises a stale recording state rather than starting a second dictation on top of it — the way out of a stale recording surface must never be another recording.
- A **Stop** control in the mic's own slot on the Recording row: ends the dictation, keeps the transcript, hands back an editable draft. Filled accent disc with a stop square, deliberately unlike Discard's outline, since one of the two keeps the user's words and the other throws them away.

## Evidence

Implementer and reviewer both drove it red→green independently, on both surfaces.

- **JVM red on base**: 12/73 failing with `expected:<Idle> but was:<Recording>`. Green after the fix.
- **Device red on base**: `Assert failed: The component is not displayed!` — the maintainer's wedged composer, no draft field on reopen, on hardware. Green after the fix.
- **Emulator, full unfiltered app2 set**: `executed=59 skipped=1 failures=0`. The skip verified **by name** as `J12UsagePanelJourney#theSessionPillFocusesTheSessionsDetectedAgentAndDropsTheWindowToken` (#2586's quarantine, the only registry row), and both new J08 methods verified by name in the executed set — a count alone would not distinguish "my journeys ran" from "two other methods drifted into the total".
- **Mutation-liveness check** (reviewer-added): widening `DiscardRecordingButton`'s padding to 90dp made the row-width guard fail with `the stop control is squashed … expected:<44.0> but was:<39.0>`, so it is a live assertion rather than a structural proxy. Reverted.
- **G2 class coverage**: every exit from `Recording` — final transcript, recognizer error, discard, sheet dismiss, insert, send, session hand-off — asserted to end at `Idle`.

Orchestrator gate on the rebased tree: `scripts/assemble-debug.sh` PASS; `:app2:testDebugUnitTest --tests 'com.pocketshell.next.composer.*'` → **127 tests, 0 failures, 0 errors, 0 skipped**; `git diff --check` clean. Load average at the time was 20.77 (this box's elapsed times are not a property of the code alone — `2b8579114`).

Reviewer artifacts: `/home/alexey/agent-artifacts/issue-2598-review/` (red/green logs, `full-run-by-name.txt`, `mutation-width.log`, and screenshots `05-reopened-after-voice-send.png`, `06-stopped-editable.png`).

## Known follow-up, not blocking

The reviewer flagged a #1245-class adjacency risk: the new Stop disc uses the same `Accent`/`OnAccent` as `SendButton` and sits next to it, so the recording row now ends in two adjacent accent-coloured controls that do opposite things. Shape and glyph differ and the content description is spelled out, and the acceptance criteria explicitly ask for a stop control in that row — but it wants the maintainer's eye on the real app, so it is filed separately rather than held here behind a fix for a wedge that blocks daily use.
