### PR TITLE
Ship quiet redesign and aplexer-only sessions

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/hosts/J17HostToolsJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/hosts/J17HostToolsJourney.kt
@@ -131,6 +131,8 @@ class J17HostToolsJourney {
         compose.onNodeWithTag(SSH_KEYS_PASTE_FIELD_TAG)
             .performTextInput(AgentsFixture.privateKeyPem())
         compose.onNodeWithTag(SSH_KEYS_IMPORT_CONFIRM_TAG).performClick()
+        awaitTag(SSH_KEYS_IMPORT_REVIEW_TAG)
+        compose.onNodeWithTag(SSH_KEYS_IMPORT_REVIEW_CONFIRM_TAG).performClick()
         awaitText("Added", substring = true)
         capture("05-ssh-key-imported")
 

--- a/app2/src/main/java/com/pocketshell/next/MainActivity.kt
+++ b/app2/src/main/java/com/pocketshell/next/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.pocketshell.next
 
+import android.graphics.Color as AndroidColor
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
@@ -14,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -25,6 +27,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.fragment.app.FragmentActivity
+import androidx.core.view.WindowCompat
 import androidx.navigation.navArgument
 import com.pocketshell.next.connect.ConnectGate
 import com.pocketshell.next.connect.ConnectionsRegistry
@@ -111,6 +114,15 @@ class MainActivity : FragmentActivity() {
         // WindowInsets.ime, so sheets/forms that opt into imePadding keep
         // working. The session column must not consume those insets.
         enableEdgeToEdge()
+        WindowCompat.getInsetsController(window, window.decorView).apply {
+            isAppearanceLightStatusBars = false
+            isAppearanceLightNavigationBars = false
+        }
+        window.statusBarColor = AndroidColor.rgb(16, 23, 30)
+        window.navigationBarColor = AndroidColor.rgb(16, 23, 30)
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
         setContent {
             PocketShellTheme {
@@ -139,10 +151,12 @@ class MainActivity : FragmentActivity() {
                     val settingsViewModel: SettingsViewModel = hiltViewModel()
                     val appSettings by settingsViewModel.state.collectAsState()
                     CompositionLocalProvider(LocalAppSettings provides appSettings) {
-                        AppNavHost(
-                            modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
-                            connections = connections,
-                        )
+                            AppNavHost(
+                                modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
+                                connections = connections,
+                                startupHostId = appSettings.defaultHostId,
+                                onHostOpened = settingsViewModel::setDefaultHostId,
+                            )
                     }
                 }
             }
@@ -211,6 +225,10 @@ fun AppNavHost(
     navController: NavHostController = rememberNavController(),
     modifier: Modifier = Modifier,
     connections: ConnectionsRegistry? = null,
+    /** Last host to resume; null keeps the Hosts landing screen. */
+    startupHostId: Long? = null,
+    /** Persists the host selection without making the host list own settings. */
+    onHostOpened: (Long) -> Unit = {},
     hostsScreen: @Composable (HostListActions) -> Unit = { actions ->
         HostListRoute(
             onOpenHost = actions.onOpenHost,
@@ -424,7 +442,10 @@ fun AppNavHost(
             ) { onOpenHost ->
                 hostsScreen(
                     HostListActions(
-                        onOpenHost = onOpenHost,
+                        onOpenHost = { hostId ->
+                            onHostOpened(hostId)
+                            onOpenHost(hostId)
+                        },
                         // Task P-6: the management routes are plain
                         // navigations, deliberately NOT gated by the connect
                         // gate — editing a host must work while the host is
@@ -770,5 +791,13 @@ fun AppNavHost(
             val hostId = entry.arguments?.getLong(Destination.ARG_HOST_ID) ?: 0L
             hostUsageScreen(hostId) { navController.popBackStack() }
         }
+    }
+
+    LaunchedEffect(startupHostId) {
+        val hostId = startupHostId ?: return@LaunchedEffect
+        if (hostId <= 0L || navController.currentDestination?.route != Destination.Hosts.pattern) {
+            return@LaunchedEffect
+        }
+        navController.navigate(Destination.Workspaces.route(hostId))
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerBar.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerBar.kt
@@ -50,7 +50,9 @@ import com.pocketshell.uikit.components.Banner
 import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.MicButton
+import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.icons.PocketShellIcons
 import com.pocketshell.uikit.model.MicButtonState
 import com.pocketshell.uikit.theme.PocketShellColors
@@ -70,6 +72,8 @@ const val COMPOSER_PREVIEW_TAG: String = "composer-preview"
 const val COMPOSER_PREVIEW_VIEW_TAG: String = "composer-preview-view"
 const val COMPOSER_DISCARD_TAG: String = "composer-discard"
 const val COMPOSER_UNDELIVERED_TAG: String = "composer-undelivered"
+const val COMPOSER_DELIVERY_UNCERTAIN_TAG: String = "composer-delivery-uncertain"
+const val COMPOSER_SESSION_ENDED_TAG: String = "composer-session-ended"
 const val COMPOSER_NOTICE_TAG: String = "composer-notice"
 const val COMPOSER_STAGING_TAG: String = "composer-staging"
 const val COMPOSER_SLASH_TAG: String = "composer-slash"
@@ -78,11 +82,15 @@ const val COMPOSER_TIMER_TAG: String = "composer-timer"
 const val COMPOSER_WAVEFORM_TAG: String = "composer-waveform"
 const val COMPOSER_TRANSCRIBING_TAG: String = "composer-transcribing"
 const val COMPOSER_CONTROLS_ROW_TAG: String = "composer-controls-row"
+const val COMPOSER_TOOLS_TAG: String = "composer-tools"
+const val COMPOSER_TOOLS_TRIGGER_TAG: String = "composer-tools-trigger"
 
 fun composerSlashRowTag(command: String): String = "composer-slash-row:$command"
 
 /** The text a send that never left the device puts on screen. */
 const val COMPOSER_UNDELIVERED_TEXT: String = "Not delivered — session offline. Your draft was kept."
+const val COMPOSER_DELIVERY_UNCERTAIN_TEXT: String =
+    "Delivery uncertain — the session connection dropped. Review before resending."
 
 /**
  * The Stop control's accessible name (#2598).
@@ -129,8 +137,12 @@ fun ComposerBar(
     onDismissNotice: () -> Unit,
     onDiscard: () -> Unit,
     modifier: Modifier = Modifier,
+    deliveryEnabled: Boolean = true,
+    deliveryDisabledMessage: String? = null,
+    onOpenHotkeys: () -> Unit = {},
 ) {
     var field by remember { mutableStateOf(TextFieldValue(state.draft, TextRange(state.draft.length))) }
+    var toolsOpen by remember { mutableStateOf(false) }
     // Re-seed only when the ViewModel's draft CHANGES to something the editor
     // did not produce: a send clearing it, a history tap replacing it,
     // dictation rewriting it. Keyed on `state.draft`, so a keystroke (which
@@ -170,6 +182,14 @@ fun ComposerBar(
             .testTag(COMPOSER_TAG),
         verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
     ) {
+        deliveryDisabledMessage?.let { message ->
+            Banner(
+                text = message,
+                role = BannerRole.Warning,
+                maxLines = 3,
+                modifier = Modifier.testTag(COMPOSER_SESSION_ENDED_TAG),
+            )
+        }
         NoticeRow(state.notice, onDismissNotice)
 
         state.staging?.let { progress ->
@@ -228,19 +248,43 @@ fun ComposerBar(
             }
         }
 
+        if (toolsOpen && state.recording == RecordingState.Idle) {
+            ComposerToolsPanel(
+                state = state,
+                onDismiss = { toolsOpen = false },
+                onAttach = {
+                    toolsOpen = false
+                    onAttach()
+                },
+                onHistory = {
+                    toolsOpen = false
+                    onToggleHistory()
+                },
+                onSlash = {
+                    toolsOpen = false
+                    val seeded = SlashCommandAutocomplete.insertText(field, "/")
+                    field = seeded
+                    onDraftChange(seeded.text)
+                },
+                onHotkeys = {
+                    toolsOpen = false
+                    onOpenHotkeys()
+                },
+                onClear = {
+                    toolsOpen = false
+                    onDiscard()
+                },
+            )
+        }
+
         ControlsRow(
             state = state,
             onSend = commitSend,
+            deliveryEnabled = deliveryEnabled,
             onInsert = onInsert,
-            onAttach = onAttach,
+            onOpenTools = { toolsOpen = !toolsOpen },
             onMicTap = onMicTap,
             onCancelRecording = onCancelRecording,
-            onToggleHistory = onToggleHistory,
-            onSlashTap = {
-                val seeded = SlashCommandAutocomplete.insertText(field, "/")
-                field = seeded
-                onDraftChange(seeded.text)
-            },
         )
     }
 }
@@ -263,6 +307,21 @@ private fun NoticeRow(notice: ComposerNotice?, onDismiss: () -> Unit) {
                 )
             },
             modifier = Modifier.testTag(COMPOSER_UNDELIVERED_TAG),
+        )
+
+        ComposerNotice.DeliveryUncertain -> Banner(
+            text = COMPOSER_DELIVERY_UNCERTAIN_TEXT,
+            role = BannerRole.Warning,
+            maxLines = 3,
+            trailingContent = {
+                PocketShellButton(
+                    text = "Dismiss",
+                    onClick = onDismiss,
+                    variant = ButtonVariant.Text,
+                    compact = true,
+                )
+            },
+            modifier = Modifier.testTag(COMPOSER_DELIVERY_UNCERTAIN_TAG),
         )
 
         is ComposerNotice.Problem -> Banner(
@@ -342,12 +401,11 @@ private fun DraftField(value: TextFieldValue, onValueChange: (TextFieldValue) ->
 private fun ControlsRow(
     state: ComposerUiState,
     onSend: () -> Unit,
+    deliveryEnabled: Boolean,
     onInsert: () -> Unit,
-    onAttach: () -> Unit,
+    onOpenTools: () -> Unit,
     onMicTap: () -> Unit,
     onCancelRecording: () -> Unit,
-    onToggleHistory: () -> Unit,
-    onSlashTap: () -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -357,11 +415,9 @@ private fun ControlsRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         if (state.recording == RecordingState.Idle) {
-            ComposerEditingToolsGroup(
+            ComposerToolsTrigger(
                 enabled = !state.busy,
-                onAttach = onAttach,
-                onHistory = onToggleHistory,
-                onSlashTap = onSlashTap,
+                onClick = onOpenTools,
             )
         }
         Spacer(modifier = Modifier.weight(1f))
@@ -369,12 +425,12 @@ private fun ControlsRow(
             RecordingState.Idle -> {
                 InsertButton(
                     onClick = onInsert,
-                    enabled = state.canSend && !state.busy,
+                    enabled = deliveryEnabled && state.canSend && !state.busy,
                     modifier = Modifier.testTag(COMPOSER_INSERT_TAG),
                 )
                 SendButton(
                     onClick = onSend,
-                    enabled = state.canSend && !state.busy,
+                    enabled = deliveryEnabled && state.canSend && !state.busy,
                     modifier = Modifier.testTag(COMPOSER_SEND_TAG),
                 )
                 MicTriggerButton(
@@ -390,13 +446,13 @@ private fun ControlsRow(
                 )
                 InsertButton(
                     onClick = onInsert,
-                    enabled = state.canSend && !state.busy,
+                    enabled = deliveryEnabled && state.canSend && !state.busy,
                     recording = true,
                     modifier = Modifier.testTag(COMPOSER_INSERT_TAG),
                 )
                 SendButton(
                     onClick = onSend,
-                    enabled = state.canSend && !state.busy,
+                    enabled = deliveryEnabled && state.canSend && !state.busy,
                     recording = true,
                     modifier = Modifier.testTag(COMPOSER_SEND_TAG),
                 )
@@ -417,7 +473,7 @@ private fun ControlsRow(
                 )
                 SendButton(
                     onClick = onSend,
-                    enabled = state.canSend && !state.busy,
+                    enabled = deliveryEnabled && state.canSend && !state.busy,
                     recording = true,
                     modifier = Modifier.testTag(COMPOSER_SEND_TAG),
                 )
@@ -427,47 +483,108 @@ private fun ControlsRow(
 }
 
 /**
- * v0.4.47 left tools pill: attachment, history and slash-command icons
- * (#701 / #787 / #2529).
+ * The composer has one quiet entry point for secondary actions. The expanded
+ * panel is rendered inside the existing composer surface, so opening it never
+ * stacks a second modal over the draft.
  */
 @Composable
-private fun ComposerEditingToolsGroup(
+private fun ComposerToolsTrigger(
     enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    ToolGlyphButton(
+        icon = PocketShellIcons.Plus,
+        contentDescription = "Add to input",
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.testTag(COMPOSER_TOOLS_TRIGGER_TAG),
+    )
+}
+
+@Composable
+private fun ComposerToolsPanel(
+    state: ComposerUiState,
+    onDismiss: () -> Unit,
     onAttach: () -> Unit,
     onHistory: () -> Unit,
-    onSlashTap: () -> Unit,
-    modifier: Modifier = Modifier,
+    onSlash: () -> Unit,
+    onHotkeys: () -> Unit,
+    onClear: () -> Unit,
 ) {
-    Row(
-        modifier = modifier
-            .clip(ComposerActionPillShape)
-            .background(PocketShellColors.SurfaceElev, ComposerActionPillShape)
-            .padding(horizontal = 2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(PocketShellColors.SurfaceElev)
+            .testTag(COMPOSER_TOOLS_TAG),
     ) {
-        ToolGlyphButton(
+        SheetHeader(
+            title = "Add to input",
+            onClose = onDismiss,
+            closeContentDescription = "Close input tools",
+        )
+        ComposerToolRow(
+            title = "Attach file",
+            subtitle = "Android document picker",
             icon = PocketShellIcons.Paperclip,
-            contentDescription = "Attach files",
             onClick = onAttach,
-            enabled = enabled,
-            modifier = Modifier.testTag(COMPOSER_ATTACH_TAG),
+            testTag = COMPOSER_ATTACH_TAG,
         )
-        ToolGlyphButton(
+        ComposerToolRow(
+            title = "Recent prompts",
             icon = PocketShellIcons.History,
-            contentDescription = "Message history",
             onClick = onHistory,
-            enabled = enabled,
-            modifier = Modifier.testTag(COMPOSER_HISTORY_TAG),
+            testTag = COMPOSER_HISTORY_TAG,
         )
-        ToolGlyphButton(
+        ComposerToolRow(
+            title = "Slash commands",
+            subtitle = "Insert a supported command into the draft",
             icon = PocketShellIcons.Code,
-            contentDescription = "Slash commands",
-            onClick = onSlashTap,
-            enabled = enabled,
-            modifier = Modifier.testTag(COMPOSER_SLASH_TRIGGER_TAG),
+            onClick = onSlash,
+            testTag = COMPOSER_SLASH_TRIGGER_TAG,
+        )
+        ComposerToolRow(
+            title = "Terminal keys",
+            subtitle = "Send special keys to the current terminal",
+            icon = PocketShellIcons.Keyboard,
+            onClick = onHotkeys,
+            testTag = "composer-tools-hotkeys",
+        )
+        ComposerToolRow(
+            title = "Clear draft",
+            subtitle = if (state.draft.isBlank() && state.attachments.isEmpty()) {
+                "Nothing to clear"
+            } else {
+                "Remove the current text and attachments"
+            },
+            icon = PocketShellIcons.Close,
+            onClick = onClear,
+            testTag = COMPOSER_DISCARD_TAG,
         )
     }
+}
+
+@Composable
+private fun ComposerToolRow(
+    title: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    onClick: () -> Unit,
+    testTag: String,
+    subtitle: String? = null,
+) {
+    ListRow(
+        title = title,
+        subtitle = subtitle,
+        leading = {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = PocketShellColors.TextSecondary,
+                modifier = Modifier.size(20.dp),
+            )
+        },
+        onClick = onClick,
+        modifier = Modifier.testTag(testTag),
+    )
 }
 
 @Composable
@@ -544,12 +661,12 @@ private fun InsertButton(
             .background(PocketShellColors.SurfaceElev, ComposerActionPillShape)
             .border(1.dp, PocketShellColors.Border, ComposerActionPillShape)
             .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
-            .semantics { contentDescription = "Insert without submitting" }
+            .semantics { contentDescription = "Paste without submitting" }
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = "Insert",
+            text = "Paste",
             color = if (enabled) PocketShellColors.Text else PocketShellColors.TextMuted,
             fontSize = 14.sp,
             fontWeight = FontWeight.SemiBold,
@@ -633,9 +750,9 @@ private val ComposerActionPillRadius = 22.dp
 private val ComposerActionPillShape = RoundedCornerShape(ComposerActionPillRadius)
 /** Draft sits between bodyMedium (14) and titleMedium (16); the old field used 15. */
 private val ComposerDraftFontSize = 15.sp
-private val ComposerIdlePillHeight = 44.dp
+private val ComposerIdlePillHeight = 48.dp
 private val ComposerRecordingPillHeight = 48.dp
-private val COMPOSER_ACTION_ICON_BUTTON_SIZE = 40.dp
+private val COMPOSER_ACTION_ICON_BUTTON_SIZE = 48.dp
 private val COMPOSER_STOP_GLYPH_SIZE = 15.dp
 
 /**

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerSheetChrome.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerSheetChrome.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellShapes
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
@@ -57,6 +58,7 @@ internal fun ComposerModalBottomSheet(
         sheetState = sheetState,
         containerColor = PocketShellColors.Surface,
         contentColor = PocketShellColors.Text,
+        shape = PocketShellShapes.large,
         modifier = modifier.composerImeAnchorPolicy(sheetState),
         dragHandle = { ComposerDragHandle() },
         contentWindowInsets = {

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerUiState.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerUiState.kt
@@ -1,5 +1,8 @@
 package com.pocketshell.next.composer
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
 /**
  * Where the composer's send goes (rewrite task P-1).
  *
@@ -21,6 +24,10 @@ interface SessionSink {
 
     /** Writes [bytes] to the session. Must not throw. */
     fun sendBytes(bytes: ByteArray)
+
+    /** Emits when a PTY write failed after the composer thought the session was live. */
+    val sendFailures: Flow<Unit>
+        get() = emptyFlow()
 }
 
 /**
@@ -35,6 +42,9 @@ interface SessionSink {
 sealed interface ComposerNotice {
 
     data object Undelivered : ComposerNotice
+
+    /** PTY input was attempted, but the connection dropped before delivery was knowable. */
+    data object DeliveryUncertain : ComposerNotice
 
     /** Something failed (an upload, a connection) — [message] says what. */
     data class Problem(val message: String) : ComposerNotice
@@ -82,4 +92,6 @@ data class ComposerUiState(
 
     /** The draft survived a send that did not leave the device. */
     val undelivered: Boolean get() = notice is ComposerNotice.Undelivered
+
+    val deliveryUncertain: Boolean get() = notice is ComposerNotice.DeliveryUncertain
 }

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
@@ -137,17 +137,17 @@ class ComposerViewModel @Inject constructor(
      */
     fun bind(hostId: Long, sessionName: String, sink: SessionSink) {
         this.sink = sink
-        failureJob?.cancel()
-        failureJob = viewModelScope.launch {
-            sink.sendFailures.collect { onDeliveryUncertain() }
-        }
         _state.update { it.copy(micAvailable = dictation.isAvailable()) }
         val key = ComposerText.sessionKey(hostId, sessionName)
-        if (sessionKey == key) return
+        if (sessionKey == key) {
+            observeFailures(sink)
+            return
+        }
         handOff()
         this.hostId = hostId
         this.sessionKey = key
         this.homeDir = null
+        observeFailures(sink)
         // Nothing is known about the new session's draft until its load lands
         // (or the user types), so nothing may be written under its key yet.
         draftKnown = false
@@ -171,6 +171,13 @@ class ComposerViewModel @Inject constructor(
             history.recent(key, HISTORY_LIMIT).collectLatest { rows ->
                 _state.update { it.copy(history = rows.map(::toSentMessage)) }
             }
+        }
+    }
+
+    private fun observeFailures(sink: SessionSink) {
+        failureJob?.cancel()
+        failureJob = viewModelScope.launch {
+            sink.sendFailures.collect { onDeliveryUncertain() }
         }
     }
 

--- a/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/ComposerViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -111,6 +112,8 @@ class ComposerViewModel @Inject constructor(
     private var stageJob: Job? = null
     private var historyJob: Job? = null
     private var deliveryJob: Job? = null
+    private var failureJob: Job? = null
+    private var pendingDelivery: PendingDelivery? = null
 
     /**
      * Points the composer at one session and its send path.
@@ -134,6 +137,10 @@ class ComposerViewModel @Inject constructor(
      */
     fun bind(hostId: Long, sessionName: String, sink: SessionSink) {
         this.sink = sink
+        failureJob?.cancel()
+        failureJob = viewModelScope.launch {
+            sink.sendFailures.collect { onDeliveryUncertain() }
+        }
         _state.update { it.copy(micAvailable = dictation.isAvailable()) }
         val key = ComposerText.sessionKey(hostId, sessionName)
         if (sessionKey == key) return
@@ -201,8 +208,11 @@ class ComposerViewModel @Inject constructor(
         val leaving = sessionKey
         loadJob?.cancel()
         stageJob?.cancel()
+        failureJob?.cancel()
+        failureJob = null
         persistJob?.cancel()
         persistJob = null
+        pendingDelivery = null
         dictation.release()
         val outgoing = _state.value
         if (leaving != null && draftKnown) {
@@ -234,8 +244,14 @@ class ComposerViewModel @Inject constructor(
             // Typing is the acknowledgement of an undelivered chip: the user has
             // seen it and moved on. A failure the user cannot dismiss by acting
             // on it is a failure that stays on screen forever.
-            it.copy(draft = text, notice = it.notice.takeUnless { n -> n is ComposerNotice.Undelivered })
+            it.copy(
+                draft = text,
+                notice = it.notice.takeUnless {
+                    it is ComposerNotice.Undelivered || it is ComposerNotice.DeliveryUncertain
+                },
+            )
         }
+        pendingDelivery = null
         persist()
     }
 
@@ -244,11 +260,15 @@ class ComposerViewModel @Inject constructor(
 
     /** Throws away the draft and its staged attachments. */
     fun discard() {
+        pendingDelivery = null
         _state.update { it.copy(draft = "", attachments = emptyList(), notice = null, previewing = false) }
         persistNow()
     }
 
-    fun dismissNotice() = _state.update { it.copy(notice = null) }
+    fun dismissNotice() {
+        pendingDelivery = null
+        _state.update { it.copy(notice = null) }
+    }
 
     // ---------------------------------------------------------------- sending
 
@@ -303,11 +323,13 @@ class ComposerViewModel @Inject constructor(
         record(body, delivered)
 
         if (delivered) {
+            pendingDelivery = PendingDelivery(body)
             _state.update {
                 it.copy(draft = "", attachments = emptyList(), notice = null, previewing = false)
             }
             persistNow()
         } else {
+            pendingDelivery = null
             _state.update { it.copy(notice = ComposerNotice.Undelivered) }
         }
     }
@@ -454,6 +476,7 @@ class ComposerViewModel @Inject constructor(
     }
 
     override fun onCleared() {
+        failureJob?.cancel()
         dictation.release()
         super.onCleared()
     }
@@ -512,7 +535,16 @@ class ComposerViewModel @Inject constructor(
         val delayMs = settings.settings.value.agentSubmitEnterDelayMs.toLong()
         viewModelScope.launch {
             delay(delayMs)
-            target.sendBytes(ComposerText.enterBytes())
+            // The body and Enter are intentionally separate writes. If the
+            // link disappears in that gap, sendBytes() has no channel to write
+            // to and therefore cannot emit its asynchronous failure signal;
+            // surface the same delivery-uncertain state here instead of
+            // silently losing the submit half after clearing the draft.
+            if (target.isLive) {
+                target.sendBytes(ComposerText.enterBytes())
+            } else {
+                onDeliveryUncertain()
+            }
         }
     }
 
@@ -532,6 +564,27 @@ class ComposerViewModel @Inject constructor(
             }
         }
     }
+
+    /** Restores a message for review when a live PTY write later fails. */
+    private fun onDeliveryUncertain() {
+        val pending = pendingDelivery ?: return
+        pendingDelivery = null
+        draftKnown = true
+        _state.update { current ->
+            if (current.draft.isBlank() && current.attachments.isEmpty()) {
+                current.copy(
+                    draft = pending.body,
+                    notice = ComposerNotice.DeliveryUncertain,
+                    previewing = false,
+                )
+            } else {
+                current.copy(notice = ComposerNotice.DeliveryUncertain)
+            }
+        }
+        persistNow()
+    }
+
+    private data class PendingDelivery(val body: String)
 
     /**
      * Debounced draft persistence.

--- a/app2/src/main/java/com/pocketshell/next/composer/MessageHistorySheet.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/MessageHistorySheet.kt
@@ -20,6 +20,7 @@ import com.pocketshell.uikit.components.Pill
 import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.model.PillKind
 import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellSpacing
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -60,6 +61,7 @@ fun MessageHistorySheet(
         sheetState = rememberModalBottomSheetState(),
         containerColor = PocketShellColors.Surface,
         contentColor = PocketShellColors.Text,
+        shape = PocketShellShapes.large,
     ) {
         Column(
             modifier = Modifier

--- a/app2/src/main/java/com/pocketshell/next/composer/PromptComposerSheet.kt
+++ b/app2/src/main/java/com/pocketshell/next/composer/PromptComposerSheet.kt
@@ -5,15 +5,12 @@ import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.core.content.ContextCompat
 import com.pocketshell.uikit.components.SheetHeader
@@ -62,6 +59,7 @@ fun decideMicTap(hasRecordAudioPermission: Boolean, recording: Boolean): MicTapA
 @Composable
 fun PromptComposerSheet(
     state: ComposerUiState,
+    targetLabel: String = "Terminal",
     onDismiss: () -> Unit,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
@@ -77,6 +75,9 @@ fun PromptComposerSheet(
     onPermissionDenied: () -> Unit,
     modifier: Modifier = Modifier,
     hasRecordAudioPermission: (() -> Boolean)? = null,
+    deliveryEnabled: Boolean = true,
+    deliveryDisabledMessage: String? = null,
+    onOpenHotkeys: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val permissionGranted: () -> Boolean = hasRecordAudioPermission ?: {
@@ -101,9 +102,9 @@ fun PromptComposerSheet(
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         modifier = modifier,
     ) {
-        val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
         PromptComposerContent(
             state = state,
+            targetLabel = targetLabel,
             onClose = dismiss,
             onDraftChange = onDraftChange,
             onSend = onSend,
@@ -127,7 +128,9 @@ fun PromptComposerSheet(
             onRemoveAttachment = onRemoveAttachment,
             onDismissNotice = onDismissNotice,
             onDiscard = onDiscard,
-            imeVisible = imeVisible,
+            deliveryEnabled = deliveryEnabled,
+            deliveryDisabledMessage = deliveryDisabledMessage,
+            onOpenHotkeys = onOpenHotkeys,
         )
     }
 }
@@ -139,6 +142,7 @@ fun PromptComposerSheet(
 @Composable
 fun PromptComposerContent(
     state: ComposerUiState,
+    targetLabel: String = "Terminal",
     onClose: () -> Unit,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
@@ -153,21 +157,20 @@ fun PromptComposerContent(
     onDiscard: () -> Unit,
     modifier: Modifier = Modifier,
     imeVisible: Boolean = false,
+    deliveryEnabled: Boolean = true,
+    deliveryDisabledMessage: String? = null,
+    onOpenHotkeys: () -> Unit = {},
 ) {
-    // IME inset is a FLAG (#801/#1622/#790): hide the title row while the
-    // keyboard is up. Do not subtract ime from sheet height and also
-    // imePadding() the same column — Material's sheet already sits on the
-    // keyboard.
+    val title = targetLabel.trim().takeIf { it.isNotEmpty() }?.let { "Input to $it" }
+        ?: COMPOSER_SHEET_TITLE
     Column(modifier = modifier.navigationBarsPadding()) {
-        if (!imeVisible) {
-            SheetHeader(
-                title = COMPOSER_SHEET_TITLE,
-                titleTestTag = COMPOSER_TITLE_TAG,
-                onClose = onClose,
-                closeContentDescription = "Close Prompt Composer",
-                closeTestTag = COMPOSER_CLOSE_TAG,
-            )
-        }
+        SheetHeader(
+            title = title,
+            titleTestTag = COMPOSER_TITLE_TAG,
+            onClose = onClose,
+            closeContentDescription = "Close Prompt Composer",
+            closeTestTag = COMPOSER_CLOSE_TAG,
+        )
         ComposerBar(
             state = state,
             onDraftChange = onDraftChange,
@@ -181,6 +184,9 @@ fun PromptComposerContent(
             onRemoveAttachment = onRemoveAttachment,
             onDismissNotice = onDismissNotice,
             onDiscard = onDiscard,
+            deliveryEnabled = deliveryEnabled,
+            deliveryDisabledMessage = deliveryDisabledMessage,
+            onOpenHotkeys = onOpenHotkeys,
         )
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/connect/ConnectGate.kt
+++ b/app2/src/main/java/com/pocketshell/next/connect/ConnectGate.kt
@@ -214,7 +214,7 @@ private fun ConnectPassphraseSheet(
                 PocketShellSpacing.sm,
             ),
         ) {
-            SheetHeader(title = "Unlock SSH key")
+            SheetHeader(title = "Unlock SSH key", onClose = onDismiss)
             Text(
                 text = "${prompt.hostLabel} needs ${prompt.keyName}.",
                 color = PocketShellColors.Text,

--- a/app2/src/main/java/com/pocketshell/next/crash/CrashReportFormatter.kt
+++ b/app2/src/main/java/com/pocketshell/next/crash/CrashReportFormatter.kt
@@ -10,6 +10,36 @@ import java.time.Instant
  */
 object CrashReportFormatter {
 
+    /**
+     * Removes identity and location data before a report leaves the device.
+     * The local file remains complete for on-device review; this is the default
+     * representation used by both the single-report and archive share paths.
+     */
+    fun redactForSharing(report: String): String = buildString {
+        var inException = false
+        report.lineSequence().forEach { line ->
+            when {
+                line == "Exception" -> {
+                    inException = true
+                    appendLine(line)
+                }
+                inException -> appendLine(redactSensitiveText(line))
+                line.startsWith("Host:") ||
+                    line.startsWith("Hostname:") ||
+                    line.startsWith("User:") ||
+                    line.startsWith("Session:") ||
+                    line.startsWith("Directory:") ||
+                    line.startsWith("Action:") -> appendLine(line.substringBefore(':') + ": [redacted]")
+                line.startsWith("Exception summary:") -> {
+                    val value = line.removePrefix("Exception summary:").trim()
+                    appendLine("Exception summary: ${value.substringBefore(':')}")
+                }
+                line.startsWith("Top frame:") -> appendLine("Top frame: [redacted]")
+                else -> appendLine(redactSensitiveText(line))
+            }
+        }
+    }.trimEnd() + "\n"
+
     fun format(
         throwable: Throwable,
         threadName: String,
@@ -72,4 +102,10 @@ object CrashReportFormatter {
         throwable.printStackTrace(PrintWriter(writer))
         return writer.toString().trimEnd()
     }
+
+    private fun redactSensitiveText(value: String): String = value
+        .replace(Regex("(?i)(/home/|/users/|/var/home/)[^\\s:)]+"), "<path>")
+        .replace(Regex("(?i)~/[^\\s:)]+"), "<path>")
+        .replace(Regex("(?i)(authorization|bearer|password|passphrase|token|secret|private key)\\s*[=:]\\s*[^\\s]+"), "$1=[redacted]")
+        .replace(Regex("-----BEGIN [^-]+ PRIVATE KEY-----.*", RegexOption.IGNORE_CASE), "<private-key-redacted>")
 }

--- a/app2/src/main/java/com/pocketshell/next/crash/CrashReportsScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/crash/CrashReportsScreen.kt
@@ -387,7 +387,13 @@ internal fun DiagnosticReportScreen(
                         ) {
                             PocketShellButton(
                                 text = "Share report",
-                                onClick = { shareReport(context, report, body) },
+                                onClick = {
+                                    shareReport(
+                                        context,
+                                        report,
+                                        CrashReportFormatter.redactForSharing(body),
+                                    )
+                                },
                                 variant = ButtonVariant.Primary,
                                 modifier = Modifier.testTag(CRASH_REPORT_SHARE_TAG),
                             )
@@ -427,15 +433,8 @@ private fun DiagnosticsHeader(
 ) {
     ScreenHeader(
         title = title,
-        leading = {
-            PocketShellButton(
-                text = "Back",
-                onClick = onBack,
-                variant = ButtonVariant.Text,
-                compact = true,
-                modifier = Modifier.testTag(CRASH_REPORTS_BACK_TAG),
-            )
-        },
+        onBack = onBack,
+        backTestTag = CRASH_REPORTS_BACK_TAG,
     )
 }
 

--- a/app2/src/main/java/com/pocketshell/next/crash/CrashReportsViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/crash/CrashReportsViewModel.kt
@@ -106,7 +106,11 @@ internal class CrashReportsViewModel @Inject constructor(
                 val dir = reportArchivesDir()
                 pruneOldReportArchives(dir)
                 val name = ReportsArchive.archiveFileName(deviceLabel(), clock)
-                ReportsArchive.packInto(reportFiles, File(dir, name))
+                ReportsArchive.packInto(
+                    reportFiles = reportFiles,
+                    destination = File(dir, name),
+                    contentTransform = CrashReportFormatter::redactForSharing,
+                )
             }.getOrElse { error ->
                 _shareAllState.value = ShareAllState.Failed(
                     error.message ?: "Could not build the reports archive.",

--- a/app2/src/main/java/com/pocketshell/next/crash/ReportsArchive.kt
+++ b/app2/src/main/java/com/pocketshell/next/crash/ReportsArchive.kt
@@ -50,7 +50,11 @@ object ReportsArchive {
      * Returns [destination] for call-site chaining. The caller owns the
      * lifecycle of [destination].
      */
-    fun packInto(reportFiles: List<File>, destination: File): File {
+    fun packInto(
+        reportFiles: List<File>,
+        destination: File,
+        contentTransform: (String) -> String = { it },
+    ): File {
         destination.parentFile?.mkdirs()
         val usedNames = HashSet<String>()
         ZipOutputStream(destination.outputStream().buffered()).use { zip ->
@@ -58,7 +62,8 @@ object ReportsArchive {
                 if (!file.isFile) continue
                 val entryName = uniqueEntryName(file.name, usedNames)
                 zip.putNextEntry(ZipEntry(entryName))
-                file.inputStream().use { input -> input.copyTo(zip) }
+                val content = file.readText()
+                zip.write(contentTransform(content).toByteArray(Charsets.UTF_8))
                 zip.closeEntry()
             }
         }

--- a/app2/src/main/java/com/pocketshell/next/files/FileExplorerScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/files/FileExplorerScreen.kt
@@ -15,13 +15,16 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
@@ -34,7 +37,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,7 +68,9 @@ import com.pocketshell.uikit.icons.PocketShellIcons
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellSpacing
+import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellType
+import kotlinx.coroutines.flow.collect
 import java.util.concurrent.TimeUnit
 
 /** Stable test tags. Rows are keyed by the host's own file names. */
@@ -288,6 +295,21 @@ fun FileExplorerScreen(
     onDismissNewTextFile: () -> Unit = {},
     onDismissOperationMessage: () -> Unit = {},
 ) {
+    val scrollPositions = remember { mutableStateMapOf<String, Pair<Int, Int>>() }
+    val savedPosition = scrollPositions[state.path]
+    val listState = remember(state.path) {
+        LazyListState(
+            firstVisibleItemIndex = savedPosition?.first ?: 0,
+            firstVisibleItemScrollOffset = savedPosition?.second ?: 0,
+        )
+    }
+    LaunchedEffect(state.path, listState) {
+        snapshotFlow {
+            listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+        }.collect { position ->
+            scrollPositions[state.path] = position
+        }
+    }
     if (state.transfersVisible) {
         TransfersScreen(
             state = state,
@@ -307,38 +329,13 @@ fun FileExplorerScreen(
         ScreenHeader(
             title = state.path.takeIf { it.isNotBlank() }?.let { RemotePath.nameOf(it) } ?: "Files",
             subtitle = state.path.ifBlank { "Opening…" },
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                )
-            },
+            onBack = onBack,
             trailing = {
-                Row {
-                    PocketShellButton(
-                        text = "Up",
-                        onClick = onUp,
-                        variant = ButtonVariant.Text,
-                        compact = true,
-                        enabled = state.path.isNotBlank() && state.path != RemotePath.ROOT,
-                        modifier = Modifier.testTag(FILE_EXPLORER_UP_TAG),
-                    )
-                    PocketShellButton(
-                        text = "Upload",
-                        onClick = onUpload,
-                        variant = ButtonVariant.Primary,
-                        compact = true,
-                        enabled = state.loaded && !state.transferring,
-                        modifier = Modifier.testTag(FILE_EXPLORER_UPLOAD_TAG),
-                    )
-                    KebabTrigger(
-                        contentDescription = "File tools",
-                        onClick = onOpenTools,
-                        triggerTestTag = FILE_EXPLORER_ACTIONS_TAG,
-                    )
-                }
+                KebabTrigger(
+                    contentDescription = "File tools",
+                    onClick = onOpenTools,
+                    triggerTestTag = FILE_EXPLORER_ACTIONS_TAG,
+                )
             },
         )
 
@@ -405,6 +402,7 @@ fun FileExplorerScreen(
                 modifier = Modifier
                     .weight(1f)
                     .testTag(FILE_EXPLORER_LIST_TAG),
+                state = listState,
                 contentPadding = PaddingValues(bottom = PocketShellSpacing.lg),
             ) {
                 items(state.entries, key = { it.path }) { entry ->
@@ -424,6 +422,7 @@ fun FileExplorerScreen(
     if (state.toolsVisible) {
         FileToolsSheet(
             state = state,
+            onUp = onUp,
             onUpload = {
                 onDismissTools()
                 onUpload()
@@ -613,7 +612,7 @@ private fun FileRow(
             if (!entry.isDirectory) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     PocketShellButton(
-                        text = "Save",
+                        text = "Download",
                         onClick = onDownload,
                         variant = ButtonVariant.Text,
                         compact = true,
@@ -649,6 +648,7 @@ private fun FileRow(
 @Composable
 private fun FileToolsSheet(
     state: FileExplorerUiState,
+    onUp: () -> Unit,
     onUpload: () -> Unit,
     onCreateFolder: () -> Unit,
     onNewTextFile: () -> Unit,
@@ -658,11 +658,15 @@ private fun FileToolsSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = PocketShellShapes.large,
         modifier = Modifier.testTag(FILE_EXPLORER_TOOLS_SHEET_TAG),
         containerColor = PocketShellColors.Surface,
     ) {
         FileToolsSheetContent(
             path = state.path,
+            onUp = onUp,
+            canGoUp = state.path.isNotBlank() && state.path != RemotePath.ROOT,
+            canUpload = state.loaded && !state.transferring,
             onUpload = onUpload,
             onCreateFolder = onCreateFolder,
             onNewTextFile = onNewTextFile,
@@ -676,6 +680,9 @@ private fun FileToolsSheet(
 @Composable
 internal fun FileToolsSheetContent(
     path: String,
+    onUp: () -> Unit = {},
+    canGoUp: Boolean = path.isNotBlank() && path != RemotePath.ROOT,
+    canUpload: Boolean = true,
     onUpload: () -> Unit,
     onCreateFolder: () -> Unit,
     onNewTextFile: () -> Unit,
@@ -686,6 +693,8 @@ internal fun FileToolsSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .heightIn(max = 560.dp)
+            .verticalScroll(rememberScrollState())
             .padding(bottom = PocketShellSpacing.lg)
             .testTag(FILE_EXPLORER_TOOLS_SHEET_TAG),
     ) {
@@ -699,10 +708,20 @@ internal fun FileToolsSheetContent(
             onClose = onDismiss,
         )
         FileToolRow(
+            title = "Up to parent",
+            subtitle = "Stay in Files and browse the parent folder",
+            icon = PocketShellIcons.Up,
+            onClick = onUp,
+            enabled = canGoUp,
+            testTag = FILE_EXPLORER_UP_TAG,
+        )
+        FileToolRow(
             title = "Upload files",
             subtitle = "Android document picker",
             icon = PocketShellIcons.Upload,
             onClick = onUpload,
+            enabled = canUpload,
+            testTag = FILE_EXPLORER_UPLOAD_TAG,
         )
         FileToolRow(
             title = "Create folder",
@@ -785,6 +804,7 @@ private fun FileActionSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = PocketShellShapes.large,
         modifier = Modifier.testTag(FILE_EXPLORER_FILE_ACTIONS_TAG),
         containerColor = PocketShellColors.Surface,
     ) {
@@ -859,6 +879,7 @@ private fun CreateFolderSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = PocketShellShapes.large,
         modifier = Modifier.testTag(FILE_EXPLORER_CREATE_FOLDER_TAG),
         containerColor = PocketShellColors.Surface,
     ) {
@@ -900,7 +921,7 @@ internal fun CreateFolderSheetContent(
             .testTag(FILE_EXPLORER_CREATE_FOLDER_TAG),
         verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
     ) {
-        SheetHeader(title = "Create folder", subtitle = parent)
+        SheetHeader(title = "Create folder", subtitle = parent, onClose = onDismiss)
         state.failure?.let { failure ->
             Banner(text = failure, role = BannerRole.Error)
         }
@@ -954,6 +975,7 @@ private fun NewTextFileSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = PocketShellShapes.large,
         modifier = Modifier.testTag(FILE_EXPLORER_NEW_TEXT_FILE_SHEET_TAG),
         containerColor = PocketShellColors.Surface,
     ) {
@@ -976,7 +998,7 @@ private fun NewTextFileSheet(
                 .testTag(FILE_EXPLORER_NEW_TEXT_FILE_SHEET_TAG),
             verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
         ) {
-            SheetHeader(title = "New text file", subtitle = parent)
+            SheetHeader(title = "New text file", subtitle = parent, onClose = onDismiss)
             state.failure?.let { failure ->
                 Banner(text = failure, role = BannerRole.Error)
             }
@@ -1030,6 +1052,7 @@ private fun RenameFileSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = PocketShellShapes.large,
         modifier = Modifier.testTag(FILE_EXPLORER_RENAME_TAG),
         containerColor = PocketShellColors.Surface,
     ) {
@@ -1071,7 +1094,7 @@ internal fun RenameFileSheetContent(
             .testTag(FILE_EXPLORER_RENAME_TAG),
         verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
     ) {
-        SheetHeader(title = "Rename file")
+        SheetHeader(title = "Rename file", onClose = onDismiss)
         state.failure?.let { failure ->
             Banner(text = failure, role = BannerRole.Error)
         }

--- a/app2/src/main/java/com/pocketshell/next/files/TransfersScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/files/TransfersScreen.kt
@@ -57,14 +57,7 @@ fun TransfersScreen(
         ScreenHeader(
             title = "Transfers",
             subtitle = "Remote file transfers",
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                )
-            },
+            onBack = onBack,
         )
 
         if (state.transferRecords.isEmpty()) {

--- a/app2/src/main/java/com/pocketshell/next/files/ViewerScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/files/ViewerScreen.kt
@@ -5,7 +5,6 @@ package com.pocketshell.next.files
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -20,7 +19,9 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -32,12 +33,13 @@ import com.pocketshell.uikit.components.Banner
 import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.EmptyState
-import com.pocketshell.uikit.components.FileTypeIcon
+import com.pocketshell.uikit.components.KebabTrigger
+import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SheetHeader
-import com.pocketshell.uikit.components.fileIconClassForName
 import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellSpacing
 
 /** Stable test tags for the viewer shell. */
@@ -57,6 +59,8 @@ const val VIEWER_CONFLICT_TAG: String = "file-viewer-conflict"
 const val VIEWER_CONFLICT_COPY_TAG: String = "file-viewer-conflict-copy"
 const val VIEWER_CONFLICT_RELOAD_TAG: String = "file-viewer-conflict-reload"
 const val VIEWER_CONFLICT_KEEP_TAG: String = "file-viewer-conflict-keep"
+const val VIEWER_ACTIONS_TAG: String = "file-viewer-actions"
+const val VIEWER_ACTIONS_SHEET_TAG: String = "file-viewer-actions-sheet"
 
 /**
  * Route-level entry point: binds the Hilt-provided [ViewerViewModel] to the
@@ -152,6 +156,8 @@ fun ViewerScreen(
     onReloadRemote: () -> Unit = {},
     onConflictKeepEditing: () -> Unit = onKeepEditing,
 ) {
+    var actionsOpen by remember { mutableStateOf(false) }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -164,16 +170,25 @@ fun ViewerScreen(
         ScreenHeader(
             title = state.name.ifBlank { "File" },
             subtitle = state.path,
-            leading = { FileTypeIcon(iconClass = fileIconClassForName(state.name)) },
+            onBack = onBack,
             trailing = {
-                ViewerActions(
-                    state = state,
-                    onBack = onBack,
-                    onEdit = onEdit,
-                    onSave = onSave,
-                    onCancelEdit = onCancelEdit,
-                    onToggleMarkdown = onToggleMarkdown,
-                )
+                when {
+                    state.editing && state.conflict == null -> PocketShellButton(
+                        text = if (state.saving) "Saving…" else "Save",
+                        onClick = onSave,
+                        variant = ButtonVariant.Primary,
+                        compact = true,
+                        enabled = !state.saving,
+                        modifier = Modifier.testTag(VIEWER_SAVE_TAG),
+                    )
+
+                    state.conflict == null && (state.markdownCapable || state.editable) ->
+                        KebabTrigger(
+                            contentDescription = "File actions",
+                            onClick = { actionsOpen = true },
+                            triggerTestTag = VIEWER_ACTIONS_TAG,
+                        )
+                }
             },
         )
 
@@ -231,6 +246,21 @@ fun ViewerScreen(
             onSave = onSaveAndLeave,
             onDiscard = onDiscardChanges,
             onKeepEditing = onKeepEditing,
+        )
+    }
+
+    if (actionsOpen) {
+        ViewerActionsSheet(
+            state = state,
+            onDismiss = { actionsOpen = false },
+            onEdit = {
+                actionsOpen = false
+                onEdit()
+            },
+            onToggleMarkdown = {
+                actionsOpen = false
+                onToggleMarkdown()
+            },
         )
     }
 }
@@ -292,67 +322,40 @@ private fun ViewerBody(
     }
 }
 
-/**
- * Header actions. Three mutually exclusive sets rather than a kebab: the viewer
- * has at most three affordances at any moment, and a menu to reach two buttons
- * is a tap the user should not have to spend.
- */
+/** File mode actions live in one native sheet so the header stays single-action. */
 @Composable
-private fun ViewerActions(
+private fun ViewerActionsSheet(
     state: ViewerUiState,
-    onBack: () -> Unit,
+    onDismiss: () -> Unit,
     onEdit: () -> Unit,
-    onSave: () -> Unit,
-    onCancelEdit: () -> Unit,
     onToggleMarkdown: () -> Unit,
 ) {
-    Row {
-        if (state.conflict != null) {
-            PocketShellButton(
-                text = "Back",
-                onClick = onBack,
-                variant = ButtonVariant.Text,
-                compact = true,
-            )
-        } else if (state.editing) {
-            PocketShellButton(
-                text = "Cancel",
-                onClick = onCancelEdit,
-                variant = ButtonVariant.Text,
-                compact = true,
-                enabled = !state.saving,
-                modifier = Modifier.testTag(VIEWER_CANCEL_TAG),
-            )
-            PocketShellButton(
-                text = if (state.saving) "Saving…" else "Save",
-                onClick = onSave,
-                variant = ButtonVariant.Primary,
-                compact = true,
-                enabled = !state.saving,
-                modifier = Modifier.testTag(VIEWER_SAVE_TAG),
-            )
-        } else {
-            PocketShellButton(
-                text = "Back",
-                onClick = onBack,
-                variant = ButtonVariant.Text,
-                compact = true,
-            )
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = PocketShellShapes.large,
+        containerColor = PocketShellColors.Surface,
+        modifier = Modifier.testTag(VIEWER_ACTIONS_SHEET_TAG),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = PocketShellSpacing.lg)
+                .padding(top = PocketShellSpacing.lg, bottom = PocketShellSpacing.lg),
+        ) {
+            SheetHeader(title = "File actions", onClose = onDismiss)
             if (state.markdownCapable) {
-                PocketShellButton(
-                    text = if (state.renderMarkdown) "Source" else "Rendered",
+                ListRow(
+                    title = if (state.renderMarkdown) "Show source" else "Show rendered",
                     onClick = onToggleMarkdown,
-                    variant = ButtonVariant.Text,
-                    compact = true,
                     modifier = Modifier.testTag(VIEWER_MARKDOWN_TOGGLE_TAG),
                 )
             }
             if (state.editable) {
-                PocketShellButton(
-                    text = "Edit",
+                ListRow(
+                    title = "Edit",
                     onClick = onEdit,
-                    variant = ButtonVariant.Primary,
-                    compact = true,
                     modifier = Modifier.testTag(VIEWER_EDIT_TAG),
                 )
             }
@@ -434,6 +437,7 @@ private fun UnsavedChangesSheet(
     ModalBottomSheet(
         onDismissRequest = onKeepEditing,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = PocketShellShapes.large,
         modifier = Modifier.testTag(VIEWER_UNSAVED_TAG),
         containerColor = PocketShellColors.Surface,
     ) {
@@ -463,7 +467,7 @@ internal fun UnsavedChangesSheetContent(
             .testTag(VIEWER_UNSAVED_TAG),
         verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
     ) {
-        SheetHeader(title = "Keep your changes?")
+        SheetHeader(title = "Keep your changes?", onClose = onKeepEditing)
         Text(
             text = "${state.name} has unsaved edits. Leaving now will not update the file on the host.",
             color = PocketShellColors.TextSecondary,

--- a/app2/src/main/java/com/pocketshell/next/hosts/AddEditHostScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/hosts/AddEditHostScreen.kt
@@ -148,14 +148,7 @@ fun AddEditHostScreen(
     ) {
         ScreenHeader(
             title = "Connection details",
-            trailing = {
-                PocketShellButton(
-                    text = "Cancel",
-                    onClick = onCancel,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                )
-            },
+            onBack = onCancel,
         )
 
         if (state.loading) {

--- a/app2/src/main/java/com/pocketshell/next/hosts/HostListScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/hosts/HostListScreen.kt
@@ -211,23 +211,11 @@ fun HostListScreen(
                 title = "Your work, from here.",
                 description = "Connect to a development machine to open its workspaces and terminals.",
                 action = {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs),
-                    ) {
-                        PocketShellButton(
-                            text = "Add host",
-                            onClick = { showAddHostMethods = true },
-                            modifier = Modifier.testTag(HOST_LIST_ADD_FOOTER_TAG),
-                        )
-                        PocketShellButton(
-                            text = "Settings",
-                            onClick = onOpenSettings,
-                            variant = ButtonVariant.Text,
-                            compact = true,
-                            modifier = Modifier.testTag(HOST_LIST_SETTINGS_TAG),
-                        )
-                    }
+                    PocketShellButton(
+                        text = "Add host",
+                        onClick = { showAddHostMethods = true },
+                        modifier = Modifier.testTag(HOST_LIST_ADD_FOOTER_TAG),
+                    )
                 },
             )
 
@@ -344,7 +332,7 @@ private fun AddHostMethodSheet(
                 .navigationBarsPadding(),
             verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
         ) {
-            SheetHeader(title = "Add host")
+            SheetHeader(title = "Add host", onClose = onDismiss)
             ListRow(
                 title = "Scan a QR code",
                 subtitle = "Import from your computer",

--- a/app2/src/main/java/com/pocketshell/next/hosts/QrChunkCodec.kt
+++ b/app2/src/main/java/com/pocketshell/next/hosts/QrChunkCodec.kt
@@ -32,11 +32,13 @@ object QrChunkCodec {
     const val ENVELOPE_PREFIX: String = "pocketshell.qr.v1?"
 
     /**
-     * Per-chunk budget in raw bytes, before base64. 1500 raw bytes inflate to
-     * ~2000 base64 chars, plus ~80 for the envelope tokens — comfortably inside
-     * the practical QR limit.
+     * Per-chunk budget for newly emitted envelopes, in raw bytes before
+     * base64. 1000 raw bytes inflate to ~1334 base64 chars, plus the envelope
+     * tokens — enough room for M-level correction in a 720px QR. The decoder
+     * deliberately accepts larger v1 chunks so envelopes emitted by older
+     * clients (up to the former 1500-byte budget) remain compatible.
      */
-    const val CHUNK_SIZE: Int = 1500
+    const val CHUNK_SIZE: Int = 1000
 
     private val encoder: Base64.Encoder = Base64.getUrlEncoder().withoutPadding()
     private val decoder: Base64.Decoder = Base64.getUrlDecoder()

--- a/app2/src/main/java/com/pocketshell/next/hosts/QrScannerScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/hosts/QrScannerScreen.kt
@@ -164,15 +164,8 @@ fun QrScannerScreen(
             .background(PocketShellColors.Background),
     ) {
         ScreenHeader(
-            title = "Scan host QR",
-            trailing = {
-                PocketShellButton(
-                    text = "Close",
-                    onClick = onClose,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                )
-            },
+            title = if (state is QrScannerViewModel.State.Review) "Review import" else "Scan host QR",
+            onBack = onClose,
         )
 
         when (state) {

--- a/app2/src/main/java/com/pocketshell/next/hosts/SshKeyMaterial.kt
+++ b/app2/src/main/java/com/pocketshell/next/hosts/SshKeyMaterial.kt
@@ -130,8 +130,12 @@ object SshKeyMaterial {
      * after the caller has completed the real unlock flow.
      */
     fun publicKeyLine(content: String, passphrase: CharArray? = null): String {
-        ensureBouncyCastle()
         unencryptedOpenSshPublicKeyLine(content)?.let { return it }
+        // An unencrypted OpenSSH key carries its public half in clear text.
+        // Read that record before installing the BC provider: Android may
+        // already expose a platform provider under the same name, and the
+        // private-key parser is unnecessary for this fast, deterministic path.
+        ensureBouncyCastle()
         SSHClient().use { client ->
             val provider = loadKeyProvider(client, content, passphrase)
             val publicKey = provider.public

--- a/app2/src/main/java/com/pocketshell/next/hosts/SshKeysScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/hosts/SshKeysScreen.kt
@@ -73,8 +73,16 @@ const val SSH_KEYS_GENERATE_ED25519_TAG: String = "ssh-keys-generate-ed25519"
 const val SSH_KEYS_GENERATE_RSA_TAG: String = "ssh-keys-generate-rsa"
 const val SSH_KEYS_GENERATE_NO_PASSPHRASE_TAG: String = "ssh-keys-generate-no-passphrase"
 const val SSH_KEYS_GENERATE_PASSPHRASE_TAG: String = "ssh-keys-generate-passphrase"
+const val SSH_KEYS_IMPORT_REVIEW_TAG: String = "ssh-keys-import-review"
+const val SSH_KEYS_IMPORT_REVIEW_CONFIRM_TAG: String = "ssh-keys-import-review-confirm"
 
 fun sshKeyRowTag(keyId: Long): String = "ssh-key-row-$keyId"
+
+/** A private key held briefly while the user reviews its metadata. */
+data class SshKeyImportCandidate(
+    val name: String,
+    val pem: String,
+)
 
 /**
  * Route-level entry point for the key manager.
@@ -103,6 +111,7 @@ fun SshKeysRoute(
     var fallbackPassphrase by remember { mutableStateOf("") }
     var fallbackInFlight by remember { mutableStateOf(false) }
     var fallbackError by remember { mutableStateOf<String?>(null) }
+    var fileImportCandidate by remember { mutableStateOf<SshKeyImportCandidate?>(null) }
     val unlockGate = remember { SshKeyUnlockInFlightGate() }
 
     LaunchedEffect(deviceUnlockAvailable, state.loaded, protectedKeys.map { it.id }) {
@@ -120,11 +129,7 @@ fun SshKeysRoute(
         val text = runCatching {
             context.contentResolver.openInputStream(uri)?.use { it.readBytes().toString(Charsets.UTF_8) }
         }.getOrNull()
-        if (text == null) {
-            viewModel.import(name, "")
-        } else {
-            viewModel.import(name, text)
-        }
+        fileImportCandidate = SshKeyImportCandidate(name = name, pem = text.orEmpty())
     }
 
     if (!unlocked) {
@@ -196,6 +201,8 @@ fun SshKeysRoute(
             onDelete = { keyId -> viewModel.delete(keyId) },
             onLoadPublicKey = viewModel::loadPublicKey,
             onDismissMessage = viewModel::clearMessage,
+            initialImportCandidate = fileImportCandidate,
+            onInitialImportConsumed = { fileImportCandidate = null },
             modifier = modifier,
         )
     }
@@ -224,6 +231,8 @@ fun SshKeysScreen(
     onDismissMessage: () -> Unit,
     onCopyPublicKey: ((String) -> Unit)? = null,
     onCopyFingerprint: ((String) -> Unit)? = null,
+    initialImportCandidate: SshKeyImportCandidate? = null,
+    onInitialImportConsumed: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val clipboard = LocalContext.current.applicationContext
@@ -244,11 +253,16 @@ fun SshKeysScreen(
     var showGenerate by remember { mutableStateOf(false) }
     var showPaste by remember { mutableStateOf(false) }
     var pendingDelete by remember { mutableStateOf<SshKeyRow?>(null) }
+    var pendingImport by remember { mutableStateOf<SshKeyImportCandidate?>(null) }
     var selectedKeyId by remember { mutableStateOf<Long?>(null) }
     val selectedDetail = state.keys.firstOrNull { it.id == selectedKeyId }
 
     LaunchedEffect(selectedKeyId) {
         selectedKeyId?.let { onLoadPublicKey(it, null) }
+    }
+
+    LaunchedEffect(initialImportCandidate) {
+        initialImportCandidate?.let { pendingImport = it }
     }
 
     Column(
@@ -258,14 +272,7 @@ fun SshKeysScreen(
     ) {
         ScreenHeader(
             title = "SSH keys",
-            trailing = {
-                PocketShellButton(
-                    text = "Done",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                )
-            },
+            onBack = onBack,
         )
 
         state.message?.let { message ->
@@ -369,17 +376,39 @@ fun SshKeysScreen(
         PasteKeyDialog(
             onConfirm = { name, pem ->
                 showPaste = false
-                onImportPasted(name, pem)
+                pendingImport = SshKeyImportCandidate(name = name, pem = pem)
             },
             onDismiss = { showPaste = false },
+        )
+    }
+
+    pendingImport?.let { candidate ->
+        KeyImportReviewSheet(
+            candidate = candidate,
+            onConfirm = {
+                pendingImport = null
+                if (initialImportCandidate == candidate) onInitialImportConsumed()
+                onImportPasted(candidate.name, candidate.pem)
+            },
+            onDismiss = {
+                pendingImport = null
+                if (initialImportCandidate == candidate) onInitialImportConsumed()
+            },
         )
     }
 
     pendingDelete?.let { key ->
         ConfirmDialog(
             title = "Delete ${key.name}?",
-            message = "Hosts using this key are removed from this device. " +
-                "The authorized key on the server is not changed.",
+            message = buildString {
+                if (key.dependentHostNames.isEmpty()) {
+                    append("No configured hosts use this key. ")
+                } else {
+                    append("Used by: ${key.dependentHostNames.joinToString()}. ")
+                    append("Those hosts will also be removed from this device. ")
+                }
+                append("The authorized key on the server is not changed.")
+            },
             confirmLabel = "Delete",
             destructive = true,
             onConfirm = {
@@ -396,117 +425,218 @@ fun SshKeysScreen(
             containerColor = PocketShellColors.Surface,
             shape = PocketShellShapes.large,
         ) {
-            Column(
+            SshKeyDetailContent(
+                key = key,
+                copiedKeyId = copiedKeyId,
+                copiedFingerprintKeyId = copiedFingerprintKeyId,
+                onClose = { selectedKeyId = null },
+                onCopyPublicKey = { value ->
+                    copiedKeyId = key.id
+                    copyPublicKeyAction(value)
+                },
+                onCopyFingerprint = { value ->
+                    copiedFingerprintKeyId = key.id
+                    copyFingerprintAction(value)
+                },
+                onLoadPublicKey = onLoadPublicKey,
+                onUseKey = onUseKey?.let { useKey ->
+                    {
+                        selectedKeyId = null
+                        useKey(key.id)
+                    }
+                },
+                onRemove = {
+                    selectedKeyId = null
+                    pendingDelete = key
+                },
+            )
+        }
+    }
+}
+
+/**
+ * The key detail content is separate from the sheet shell so the rendered
+ * actions can be verified without relying on a platform sheet animation in
+ * host-side tests.
+ */
+@Composable
+internal fun SshKeyDetailContent(
+    key: SshKeyRow,
+    copiedKeyId: Long? = null,
+    copiedFingerprintKeyId: Long? = null,
+    onClose: () -> Unit,
+    onCopyPublicKey: (String) -> Unit,
+    onCopyFingerprint: (String) -> Unit,
+    onLoadPublicKey: (Long, CharArray?) -> Unit = { _, _ -> },
+    onUseKey: (() -> Unit)? = null,
+    onRemove: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(horizontal = PocketShellSpacing.lg)
+            .padding(bottom = PocketShellSpacing.lg)
+            .testTag(SSH_KEYS_DETAIL_TAG)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+    ) {
+        SheetHeader(title = key.name, onClose = onClose)
+        val keyAlgorithm = key.algorithm
+            ?: key.publicKey?.let(SshKeyMaterial::keyAlgorithmLabel)
+        val publicFingerprint = key.publicFingerprint
+            ?: key.publicKey?.let { publicKey ->
+                runCatching { SshKeyMaterial.publicKeyFingerprint(publicKey) }.getOrNull()
+            }
+        ListRow(
+            title = "Type",
+            subtitle = keyAlgorithm ?: "Read the public key to identify",
+        )
+        ListRow(
+            title = "Protection",
+            subtitle = if (key.hasPassphrase) "Passphrase required" else "No passphrase",
+        )
+        ListRow(
+            title = "Used by",
+            subtitle = key.dependentHostNames.takeIf { it.isNotEmpty() }?.joinToString()
+                ?: "No configured hosts",
+        )
+        if (publicFingerprint != null) {
+            ListRow(title = "Fingerprint", subtitle = publicFingerprint)
+            PocketShellButton(
+                text = if (copiedFingerprintKeyId == key.id) "Fingerprint copied" else "Copy fingerprint",
+                onClick = { onCopyFingerprint(publicFingerprint) },
+                variant = ButtonVariant.Text,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .navigationBarsPadding()
-                .padding(horizontal = PocketShellSpacing.lg)
-                .padding(bottom = PocketShellSpacing.lg)
-                .testTag(SSH_KEYS_DETAIL_TAG)
-                .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
-            ) {
-                SheetHeader(title = key.name)
-                val keyAlgorithm = key.algorithm
-                    ?: key.publicKey?.let(SshKeyMaterial::keyAlgorithmLabel)
-                val publicFingerprint = key.publicFingerprint
-                    ?: key.publicKey?.let { publicKey ->
-                        runCatching { SshKeyMaterial.publicKeyFingerprint(publicKey) }.getOrNull()
-                    }
-                ListRow(
-                    title = "Type",
-                    subtitle = keyAlgorithm ?: "Read the public key to identify",
+                    .testTag(SSH_KEYS_COPY_FINGERPRINT_TAG),
+            )
+        } else if (key.fingerprint.isNotBlank()) {
+            // The stored digest is for import deduplication. It is not
+            // presented as the server-installable public-key identity until
+            // the public half has been read.
+            ListRow(title = "Stored key digest", subtitle = key.fingerprint)
+        }
+        when {
+            key.publicKeyLoading -> Text(
+                text = "Reading public key…",
+                color = PocketShellColors.TextSecondary,
+            )
+
+            key.publicKey != null -> {
+                val publicKey = key.publicKey
+                Text(
+                    text = "Public key",
+                    color = PocketShellColors.TextSecondary,
                 )
-                ListRow(
-                    title = "Protection",
-                    subtitle = if (key.hasPassphrase) "Passphrase required" else "No passphrase",
-                )
-                if (publicFingerprint != null) {
-                    ListRow(title = "Fingerprint", subtitle = publicFingerprint)
-                    PocketShellButton(
-                        text = if (copiedFingerprintKeyId == key.id) "Fingerprint copied" else "Copy fingerprint",
-                        onClick = {
-                            copiedFingerprintKeyId = key.id
-                            copyFingerprintAction(publicFingerprint)
-                        },
-                        variant = ButtonVariant.Text,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .testTag(SSH_KEYS_COPY_FINGERPRINT_TAG),
-                    )
-                } else if (key.fingerprint.isNotBlank()) {
-                    // The stored digest is for import deduplication. It is not
-                    // presented as the server-installable public-key identity
-                    // until the public half has been read.
-                    ListRow(title = "Stored key digest", subtitle = key.fingerprint)
-                }
-                when {
-                    key.publicKeyLoading -> Text(
-                        text = "Reading public key…",
-                        color = PocketShellColors.TextSecondary,
-                    )
-
-                    key.publicKey != null -> {
-                        val publicKey = key.publicKey
-                        Text(
-                            text = "Public key",
-                            color = PocketShellColors.TextSecondary,
-                        )
-                        SelectionContainer {
-                            Text(
-                                text = key.publicKey,
-                                color = PocketShellColors.Text,
-                            )
-                        }
-                        PocketShellButton(
-                            text = "Copy public key",
-                            onClick = {
-                                copiedKeyId = key.id
-                                copyPublicKeyAction(publicKey)
-                            },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .testTag(SSH_KEYS_COPY_PUBLIC_KEY_TAG),
-                        )
-                        if (copiedKeyId == key.id) {
-                            Text(
-                                text = "Copied public key",
-                                color = PocketShellColors.TextSecondary,
-                            )
-                        }
-                    }
-
-                    key.hasPassphrase -> KeyPassphraseField(
-                        key = key,
-                        onUnlock = { passphrase -> onLoadPublicKey(key.id, passphrase) },
-                    )
-
-                    else -> Text(
-                        text = "The public key is unavailable because the private key file could not be read.",
-                        color = PocketShellColors.TextSecondary,
-                    )
-                }
-                onUseKey?.let { useKey ->
-                    PocketShellButton(
-                        text = "Use this key",
-                        onClick = {
-                            selectedKeyId = null
-                            useKey(key.id)
-                        },
-                        variant = ButtonVariant.Primary,
-                        modifier = Modifier.fillMaxWidth(),
+                SelectionContainer {
+                    Text(
+                        text = publicKey,
+                        color = PocketShellColors.Text,
                     )
                 }
                 PocketShellButton(
-                    text = "Remove key from device",
-                    onClick = {
-                        selectedKeyId = null
-                        pendingDelete = key
-                    },
-                    variant = ButtonVariant.Destructive,
-                    modifier = Modifier.fillMaxWidth(),
+                    text = "Copy public key",
+                    onClick = { onCopyPublicKey(publicKey) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(SSH_KEYS_COPY_PUBLIC_KEY_TAG),
                 )
+                if (copiedKeyId == key.id) {
+                    Text(
+                        text = "Copied public key",
+                        color = PocketShellColors.TextSecondary,
+                    )
+                }
             }
+
+            key.hasPassphrase -> KeyPassphraseField(
+                key = key,
+                onUnlock = { passphrase -> onLoadPublicKey(key.id, passphrase) },
+            )
+
+            else -> Text(
+                text = key.publicKeyError?.let {
+                    "Could not read the public key. Try again."
+                } ?: "The public key is unavailable because the private key file could not be read.",
+                color = PocketShellColors.TextSecondary,
+            )
+        }
+        if (key.publicKeyError != null && !key.hasPassphrase) {
+            PocketShellButton(
+                text = "Retry reading public key",
+                onClick = { onLoadPublicKey(key.id, null) },
+                variant = ButtonVariant.Text,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        onUseKey?.let {
+            PocketShellButton(
+                text = "Use this key",
+                onClick = it,
+                variant = ButtonVariant.Primary,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        PocketShellButton(
+            text = "Remove key from device",
+            onClick = onRemove,
+            variant = ButtonVariant.Destructive,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun KeyImportReviewSheet(
+    candidate: SshKeyImportCandidate,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = PocketShellColors.Surface,
+        shape = PocketShellShapes.large,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = PocketShellSpacing.lg)
+                .padding(bottom = PocketShellSpacing.lg)
+                .testTag(SSH_KEYS_IMPORT_REVIEW_TAG),
+            verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+        ) {
+            SheetHeader(title = "Review key", onClose = onDismiss)
+            Text(
+                text = "Review before saving. The private key text stays on this device and is not shown here.",
+                color = PocketShellColors.TextSecondary,
+            )
+            ListRow(
+                title = candidate.name.trim().ifEmpty { "imported-key" },
+                subtitle = if (candidate.pem.isBlank()) {
+                    "No readable key data"
+                } else {
+                    "Private key ready to validate and save"
+                },
+            )
+            PocketShellButton(
+                text = "Add key",
+                enabled = candidate.pem.isNotBlank(),
+                onClick = onConfirm,
+                variant = ButtonVariant.Primary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(SSH_KEYS_IMPORT_REVIEW_CONFIRM_TAG),
+            )
+            PocketShellButton(
+                text = "Cancel",
+                onClick = onDismiss,
+                variant = ButtonVariant.Text,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/hosts/SshKeysViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/hosts/SshKeysViewModel.kt
@@ -3,6 +3,7 @@ package com.pocketshell.next.hosts
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pocketshell.core.storage.dao.SshKeyDao
+import com.pocketshell.core.storage.dao.SshKeyHostReference
 import com.pocketshell.next.connect.SshKeyUnlocker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -11,7 +12,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -29,6 +29,8 @@ data class SshKeyRow(
     val algorithm: String? = null,
     /** OpenSSH SHA-256 fingerprint, populated with the public half. */
     val publicFingerprint: String? = null,
+    /** Configured hosts that would be removed by the key's cascade delete. */
+    val dependentHostNames: List<String> = emptyList(),
 )
 
 /** What [SshKeysScreen] renders. */
@@ -62,8 +64,21 @@ class SshKeysViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            sshKeyDao.getAll()
-                .map { keys -> keys.map { SshKeyRow(it.id, it.name, it.fingerprint, it.hasPassphrase) } }
+            kotlinx.coroutines.flow.combine(
+                sshKeyDao.getAll(),
+                sshKeyDao.getHostReferences(),
+            ) { keys, references ->
+                val hostsByKey = references.groupBy(SshKeyHostReference::keyId)
+                keys.map {
+                    SshKeyRow(
+                        id = it.id,
+                        name = it.name,
+                        fingerprint = it.fingerprint,
+                        hasPassphrase = it.hasPassphrase,
+                        dependentHostNames = hostsByKey[it.id].orEmpty().map(SshKeyHostReference::hostName),
+                    )
+                }
+            }
                 .collect { rows ->
                     _state.value = _state.value.copy(keys = rows, loaded = true)
                 }
@@ -146,21 +161,21 @@ class SshKeysViewModel @Inject constructor(
      * sheet. [passphrase] is copied only inside the store call and is scrubbed
      * in this finally block; it is never emitted through UI state.
      */
-    fun loadPublicKey(keyId: Long, passphrase: CharArray? = null) {
+    fun loadPublicKey(keyId: Long, passphrase: CharArray? = null): Job {
         val row = _state.value.keys.firstOrNull { it.id == keyId } ?: run {
             passphrase?.fill('\u0000')
-            return
+            return Job()
         }
         if (row.publicKeyLoading) {
             passphrase?.fill('\u0000')
-            return
+            return Job()
         }
         _state.value = _state.value.copy(
             keys = _state.value.keys.map {
                 if (it.id == keyId) it.copy(publicKeyLoading = true, publicKeyError = null) else it
             },
         )
-        viewModelScope.launch {
+        return viewModelScope.launch {
             val result = runCatching {
                 val key = keyStore.lookup(keyId)
                     ?: error("That SSH key is no longer on this device")

--- a/app2/src/main/java/com/pocketshell/next/ports/AddTunnelScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/ports/AddTunnelScreen.kt
@@ -146,14 +146,7 @@ fun AddTunnelScreen(
     ) {
         ScreenHeader(
             title = "Add tunnel",
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                )
-            },
+            onBack = onBack,
         )
         Column(
             modifier = Modifier

--- a/app2/src/main/java/com/pocketshell/next/ports/LocalServiceVerifier.kt
+++ b/app2/src/main/java/com/pocketshell/next/ports/LocalServiceVerifier.kt
@@ -1,0 +1,97 @@
+package com.pocketshell.next.ports
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.pocketshell.core.portfwd.TunnelInfo
+import java.net.HttpURLConnection
+import java.net.Proxy
+import java.net.URL
+
+/**
+ * Checks the device-local end of a forward before offering a browser handoff.
+ *
+ * A listening TCP port is not enough evidence that a browser can use it: an
+ * SSH, database, or arbitrary binary service can be listening there too. A
+ * response from the HTTP stack is the narrow signal needed by the Quiet
+ * Services screen. The probe never leaves the device and never follows a
+ * remote host name.
+ */
+internal object LocalServiceVerifier {
+    private const val TIMEOUT_MS = 1_200
+
+    /** Returns the usable URL, or null when the local port is not HTTP(S). */
+    fun verify(tunnel: TunnelInfo): String? {
+        if (tunnel.status != TunnelInfo.Status.FORWARDING) return null
+        if (tunnel.localPort !in 1..65_535) return null
+
+        listOf("http", "https").forEach { scheme ->
+            val url = "$scheme://127.0.0.1:${tunnel.localPort}"
+            if (respondsAsHttp(url)) return url
+        }
+        return null
+    }
+
+    private fun respondsAsHttp(url: String): Boolean {
+        val connection = runCatching {
+            (URL(url).openConnection(Proxy.NO_PROXY) as HttpURLConnection).apply {
+                connectTimeout = TIMEOUT_MS
+                readTimeout = TIMEOUT_MS
+                instanceFollowRedirects = true
+                requestMethod = "HEAD"
+                setRequestProperty("Connection", "close")
+            }
+        }.getOrNull() ?: return false
+
+        return try {
+            val responseCode = connection.responseCode
+            if (responseCode == HttpURLConnection.HTTP_BAD_METHOD || responseCode == 501) {
+                connection.disconnect()
+                getResponseForGet(url)
+            } else {
+                responseCode in 100..599
+            }
+        } catch (_: Exception) {
+            false
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun getResponseForGet(url: String): Boolean {
+        val connection = runCatching {
+            (URL(url).openConnection(Proxy.NO_PROXY) as HttpURLConnection).apply {
+                connectTimeout = TIMEOUT_MS
+                readTimeout = TIMEOUT_MS
+                instanceFollowRedirects = true
+                requestMethod = "GET"
+                setRequestProperty("Range", "bytes=0-0")
+                setRequestProperty("Connection", "close")
+            }
+        }.getOrNull() ?: return false
+
+        return try {
+            val responseCode = connection.responseCode
+            runCatching { connection.inputStream.use { it.read() } }
+            responseCode in 100..599
+        } catch (_: Exception) {
+            false
+        } finally {
+            connection.disconnect()
+        }
+    }
+}
+
+/** Opens a previously verified local URL in the system browser. */
+internal fun launchServiceUrl(context: Context, url: String) {
+    try {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+    } catch (_: ActivityNotFoundException) {
+    } catch (_: SecurityException) {
+    } catch (_: RuntimeException) {
+    }
+}

--- a/app2/src/main/java/com/pocketshell/next/ports/PortForwardScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/ports/PortForwardScreen.kt
@@ -125,19 +125,9 @@ fun PortForwardScreen(
         ScreenHeader(
             title = state.hostName,
             subtitle = state.hostSubtitle.ifBlank { state.connection.label },
-            leading = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    PocketShellButton(
-                        text = "Back",
-                        onClick = onBack,
-                        variant = ButtonVariant.Text,
-                        compact = true,
-                        modifier = Modifier.testTag(PORT_FORWARD_BACK_TAG),
-                    )
-                    Spacer(Modifier.width(PocketShellSpacing.sm))
-                    StatusDot(status = state.connection.toConnectionStatus(state.enabled))
-                }
-            },
+            onBack = onBack,
+            backTestTag = PORT_FORWARD_BACK_TAG,
+            trailing = { StatusDot(status = state.connection.toConnectionStatus(state.enabled)) },
         )
 
         ForwardingToggleRow(enabled = state.enabled, onEnabledChange = onSetEnabled)
@@ -307,7 +297,7 @@ private fun ShowAllPortsRow(checked: Boolean, hiddenCount: Int, onCheckedChange:
         leading = {
             Checkbox(
                 checked = checked,
-                onCheckedChange = onCheckedChange,
+                onCheckedChange = null,
                 colors = CheckboxDefaults.colors(
                     checkedColor = PocketShellColors.Accent,
                     uncheckedColor = PocketShellColors.TextSecondary,

--- a/app2/src/main/java/com/pocketshell/next/ports/PortForwardViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/ports/PortForwardViewModel.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /**
@@ -46,6 +48,8 @@ data class PortForwardUiState(
     val manualRemotePorts: Set<Int> = emptySet(),
     /** Durable Quiet labels for manually added tunnels, keyed by remote port. */
     val manualTunnelNames: Map<Int, String> = emptyMap(),
+    /** Remote port to a locally verified HTTP(S) URL, for the browser handoff. */
+    val verifiedHttpServices: Map<Int, String> = emptyMap(),
     val showAllPorts: Boolean = false,
     /** Rows the default filter is hiding right now. */
     val hiddenCount: Int = 0,
@@ -91,6 +95,8 @@ class PortForwardViewModel @Inject constructor(
      * still re-filter immediately instead of waiting for the next emission.
      */
     private var allTunnels: List<TunnelInfo> = emptyList()
+    private var verificationJob: Job? = null
+    private var verificationKey: List<Pair<Int, Int>> = emptyList()
 
     init {
         viewModelScope.launch {
@@ -168,6 +174,31 @@ class PortForwardViewModel @Inject constructor(
     fun setShowAllPorts(showAll: Boolean) {
         _state.value = _state.value.copy(showAllPorts = showAll).reFiltered()
         viewModelScope.launch { showAllPortsStore.setShowAll(showAll) }
+    }
+
+    /**
+     * Verifies active local forwards before the UI offers an external browser
+     * handoff. The result is deliberately ephemeral: it must be checked again
+     * when the forward or its local port changes.
+     */
+    fun verifyHttpServices(tunnels: List<TunnelInfo>) {
+        val candidates = tunnels
+            .filter { it.status == TunnelInfo.Status.FORWARDING }
+            .distinctBy { it.remotePort }
+        val key = candidates.map { it.remotePort to it.localPort }
+        if (key == verificationKey) return
+
+        verificationKey = key
+        verificationJob?.cancel()
+        _state.value = _state.value.copy(verifiedHttpServices = emptyMap())
+        verificationJob = viewModelScope.launch(Dispatchers.IO) {
+            val verified = candidates.mapNotNull { tunnel ->
+                LocalServiceVerifier.verify(tunnel)?.let { tunnel.remotePort to it }
+            }.toMap()
+            if (key == verificationKey) {
+                _state.value = _state.value.copy(verifiedHttpServices = verified)
+            }
+        }
     }
 
     /**

--- a/app2/src/main/java/com/pocketshell/next/ports/ServicesScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/ports/ServicesScreen.kt
@@ -53,6 +53,7 @@ const val SERVICES_ACTIVE_TAG = "services_active_tunnels"
 const val SERVICES_AVAILABLE_TAG = "services_available"
 
 fun servicesRowTag(remotePort: Int): String = "service-row-$remotePort"
+fun serviceOpenTag(remotePort: Int): String = "service-open-$remotePort"
 
 /** The host-scoped Quiet entry point for forwarding and discovered services. */
 @Composable
@@ -65,6 +66,8 @@ fun ServicesRoute(
 ) {
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
+    val discovered = state.discoveredRows.ifEmpty { state.rows }
+    val activeForVerification = discovered.filter { it.status == TunnelInfo.Status.FORWARDING }
     // Keep the Quiet route on the same real foreground-service lifecycle as the
     // original port-forward route. The Room-backed enabled flag is read again
     // after process death, so reopening this destination remounts every enabled
@@ -72,12 +75,17 @@ fun ServicesRoute(
     LaunchedEffect(state.enabled) {
         if (state.enabled) ForwardService.resume(context)
     }
+    LaunchedEffect(activeForVerification.map { it.remotePort to it.localPort }) {
+        viewModel.verifyHttpServices(activeForVerification)
+    }
     ServicesScreen(
         state = state,
         onBack = onBack,
         onSetDiscovery = viewModel::setEnabled,
         onOpenTunnel = onOpenTunnel,
         onAddTunnel = onAddTunnel,
+        verifiedHttpServices = state.verifiedHttpServices,
+        onOpenBrowser = { launchServiceUrl(context, it) },
         modifier = modifier,
     )
 }
@@ -97,6 +105,8 @@ fun ServicesScreen(
     onSetDiscovery: (Boolean) -> Unit,
     onOpenTunnel: (Int) -> Unit,
     onAddTunnel: (Int?) -> Unit,
+    verifiedHttpServices: Map<Int, String> = emptyMap(),
+    onOpenBrowser: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     // Services is the explicit discovery surface, so it must include ports
@@ -115,15 +125,8 @@ fun ServicesScreen(
         ScreenHeader(
             title = "Services & tunnels",
             subtitle = state.hostName.ifBlank { state.hostSubtitle },
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(SERVICES_BACK_TAG),
-                )
-            },
+            onBack = onBack,
+            backTestTag = SERVICES_BACK_TAG,
             trailing = {
                 Text(
                     text = state.connection.quietLabel(state.enabled),
@@ -181,6 +184,8 @@ fun ServicesScreen(
                             active = true,
                             manual = tunnel.remotePort in state.manualRemotePorts,
                             manualName = state.manualTunnelNames[tunnel.remotePort],
+                            verifiedUrl = verifiedHttpServices[tunnel.remotePort],
+                            onOpenBrowser = onOpenBrowser,
                             onClick = { onOpenTunnel(tunnel.remotePort) },
                         )
                     }
@@ -193,6 +198,8 @@ fun ServicesScreen(
                             active = false,
                             manual = tunnel.remotePort in state.manualRemotePorts,
                             manualName = state.manualTunnelNames[tunnel.remotePort],
+                            verifiedUrl = verifiedHttpServices[tunnel.remotePort],
+                            onOpenBrowser = onOpenBrowser,
                             onClick = if (tunnel.remotePort in state.manualRemotePorts) {
                                 { onOpenTunnel(tunnel.remotePort) }
                             } else {
@@ -248,6 +255,8 @@ private fun ServiceRow(
     active: Boolean,
     manual: Boolean,
     manualName: String?,
+    verifiedUrl: String?,
+    onOpenBrowser: (String) -> Unit,
     onClick: () -> Unit,
 ) {
     val title = manualName?.trim().takeUnless { it.isNullOrEmpty() }
@@ -268,11 +277,21 @@ private fun ServiceRow(
             )
         },
         trailing = {
-            Text(
-                text = if (active || manual) "Details" else "Add",
-                color = PocketShellColors.TextSecondary,
-                style = PocketShellType.metadata,
-            )
+            if (active && verifiedUrl != null) {
+                PocketShellButton(
+                    text = "Open",
+                    onClick = { onOpenBrowser(verifiedUrl) },
+                    variant = ButtonVariant.Text,
+                    compact = true,
+                    modifier = Modifier.testTag(serviceOpenTag(tunnel.remotePort)),
+                )
+            } else {
+                Text(
+                    text = if (active || manual) "Details" else "Add",
+                    color = PocketShellColors.TextSecondary,
+                    style = PocketShellType.metadata,
+                )
+            }
         },
         modifier = Modifier.testTag(servicesRowTag(tunnel.remotePort)),
         onClick = onClick,

--- a/app2/src/main/java/com/pocketshell/next/ports/TunnelDetailScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/ports/TunnelDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -37,6 +38,7 @@ import kotlinx.coroutines.withContext
 const val TUNNEL_DETAIL_TAG = "tunnel_detail"
 const val TUNNEL_COPY_ADDRESS_TAG = "tunnel_copy_address"
 const val TUNNEL_STOP_TAG = "tunnel_stop"
+const val TUNNEL_OPEN_BROWSER_TAG = "tunnel_open_browser"
 
 @Composable
 fun TunnelDetailRoute(
@@ -55,13 +57,18 @@ fun TunnelDetailRoute(
     val clipboard = LocalClipboardManager.current
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
+    LaunchedEffect(tunnel?.remotePort, tunnel?.localPort, tunnel?.status) {
+        viewModel.verifyHttpServices(listOfNotNull(tunnel))
+    }
     TunnelDetailScreen(
         hostName = state.hostName,
         tunnel = tunnel,
         manual = remotePort in state.manualRemotePorts,
         manualName = manualName,
+        verifiedUrl = state.verifiedHttpServices[remotePort],
         onBack = onBack,
         onCopyAddress = { localPort -> clipboard.setText(AnnotatedString("127.0.0.1:$localPort")) },
+        onOpenBrowser = { launchServiceUrl(context, it) },
         onStop = {
             if (remotePort in state.manualRemotePorts) {
                 coroutineScope.launch {
@@ -86,6 +93,8 @@ fun TunnelDetailScreen(
     onBack: () -> Unit,
     onCopyAddress: (Int) -> Unit,
     onStop: () -> Unit,
+    verifiedUrl: String? = null,
+    onOpenBrowser: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -99,14 +108,7 @@ fun TunnelDetailScreen(
                 ?: tunnel?.process?.ifBlank { "Port ${tunnel.remotePort}" }
                 ?: "Tunnel",
             subtitle = hostName,
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                )
-            },
+            onBack = onBack,
         )
         if (tunnel == null) {
             EmptyState(
@@ -139,6 +141,16 @@ fun TunnelDetailScreen(
                     .fillMaxWidth()
                     .testTag(TUNNEL_COPY_ADDRESS_TAG),
             )
+            if (verifiedUrl != null) {
+                PocketShellButton(
+                    text = "Open in browser",
+                    onClick = { onOpenBrowser(verifiedUrl) },
+                    variant = ButtonVariant.Secondary,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(TUNNEL_OPEN_BROWSER_TAG),
+                )
+            }
             PocketShellButton(
                 text = if (manual) "Remove tunnel" else "Stop tunnel",
                 onClick = onStop,

--- a/app2/src/main/java/com/pocketshell/next/settings/AppSettings.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/AppSettings.kt
@@ -3,7 +3,7 @@ package com.pocketshell.next.settings
 /**
  * Every user-tunable preference app2 has (rewrite task P-6).
  *
- * ## Six fields, not sixteen
+ * ## Seven fields, not sixteen
  *
  * The old client's `AppSettings` carried sixteen. Most of them configured
  * machinery the rewrite deleted, so porting them would have shipped a settings
@@ -19,7 +19,7 @@ package com.pocketshell.next.settings
  * | `terminalKeyboardMode` | app2's terminal pins char-based input (see `TerminalHostView`'s client) — a smart-text mode no longer exists to select. |
  * | `conversationFontSizeSp`, `showSystemNotes`, `defaultAgentSessionView` | The conversation view (U-10) is cut by the scope amendment. |
  * | `hostDetailViewMode` | The tree/flat toggle: app2 has one session-tree presentation (U-3). |
- * | `defaultHostId` | The open-on-launch destination. app2 always starts on the host list; "startup" is not in P-6's KEEP list. |
+ * | `defaultHostId` | The last host workspace list to resume on launch. Null keeps the Hosts landing screen. |
  * | `voiceTranscriptionProvider` | Whisper-vs-Android picker. Composer mic is Android `SpeechRecognizer` only (#2529). |
  *
  * `agentSubmitEnterDelayMs` was on that drop list (P-6: "agent surfaces are
@@ -34,6 +34,8 @@ package com.pocketshell.next.settings
  * one with no repository, no `Context` and no disk.
  */
 data class AppSettings(
+    /** Last host the user opened; null means launch on the Hosts list. */
+    val defaultHostId: Long? = null,
     /**
      * Terminal glyph size in RAW DEVICE PIXELS.
      *

--- a/app2/src/main/java/com/pocketshell/next/settings/SettingsRepository.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/SettingsRepository.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
  *
  * ## SharedPreferences, like the rest of app2's small stores
  *
- * Five scalars with one write per user tap. Room would need a schema bump for
+ * A small set of scalars with one write per user tap. Room would need a schema bump for
  * state that is never queried relationally; DataStore would add a version
  * catalog entry for nothing. `ShowAllPortsStore` made the same call for the
  * same reason.
@@ -80,6 +80,15 @@ class SettingsRepository @Inject constructor(
     /** The current settings, hot. Never a default that is corrected later. */
     val settings: StateFlow<AppSettings>
         get() = _settings.asStateFlow()
+
+    /** Remembers the host whose workspace list should be resumed next launch. */
+    fun setDefaultHostId(hostId: Long?) {
+        if (_settings.value.defaultHostId == hostId) return
+        write {
+            if (hostId == null) remove(KEY_DEFAULT_HOST_ID) else putLong(KEY_DEFAULT_HOST_ID, hostId)
+        }
+        _settings.value = _settings.value.copy(defaultHostId = hostId)
+    }
 
     /** Terminal glyph size in raw device pixels, snapped to the slider grid. */
     fun setTerminalTextSizePx(sizePx: Int) {
@@ -183,6 +192,7 @@ class SettingsRepository @Inject constructor(
      * setting the UI cannot represent — a slider pinned off its own track.
      */
     private fun readSnapshot(prefs: SharedPreferences): AppSettings = AppSettings(
+        defaultHostId = prefs.safeLongOrNull(KEY_DEFAULT_HOST_ID),
         terminalTextSizePx = snapTerminalTextSize(
             prefs.safeInt(KEY_TERMINAL_TEXT_SIZE_PX, AppSettings.DEFAULT_TERMINAL_TEXT_SIZE_PX),
         ),
@@ -312,6 +322,10 @@ class SettingsRepository @Inject constructor(
     private fun SharedPreferences.safeLong(key: String, default: Long): Long =
         runCatching { getLong(key, default) }.getOrElse { drop(key); default }
 
+    private fun SharedPreferences.safeLongOrNull(key: String): Long? =
+        if (!contains(key)) null else runCatching { getLong(key, 0L) }
+            .getOrElse { drop(key); null }
+
     private fun SharedPreferences.safeFloat(key: String, default: Float): Float =
         runCatching { getFloat(key, default) }.getOrElse { drop(key); default }
 
@@ -338,5 +352,6 @@ class SettingsRepository @Inject constructor(
         const val KEY_USAGE_WARN_THRESHOLD = "usage_warn_threshold_percent"
         const val KEY_BACKGROUND_GRACE_MILLIS = "background_grace_millis"
         const val KEY_AGENT_SUBMIT_ENTER_DELAY_MS = "agent_submit_enter_delay_ms"
+        const val KEY_DEFAULT_HOST_ID = "default_host_id"
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/settings/SettingsScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/SettingsScreen.kt
@@ -200,15 +200,8 @@ internal fun SettingsHeader(
     ScreenHeader(
         title = title,
         modifier = modifier,
-        leading = {
-            PocketShellButton(
-                text = "Back",
-                onClick = onBack,
-                variant = ButtonVariant.Text,
-                compact = true,
-                modifier = Modifier.testTag(SETTINGS_BACK_TAG),
-            )
-        },
+        onBack = onBack,
+        backTestTag = SETTINGS_BACK_TAG,
     )
 }
 

--- a/app2/src/main/java/com/pocketshell/next/settings/SettingsViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/SettingsViewModel.kt
@@ -64,6 +64,8 @@ class SettingsViewModel @Inject constructor(
 
     fun setAgentSubmitEnterDelayMs(delayMs: Int) = repository.setAgentSubmitEnterDelayMs(delayMs)
 
+    fun setDefaultHostId(hostId: Long?) = repository.setDefaultHostId(hostId)
+
     fun resetAdvancedDefaults() = repository.resetAdvancedDefaults()
 
     private companion object {

--- a/app2/src/main/java/com/pocketshell/next/settings/WorkspaceRootsScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/WorkspaceRootsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,6 +24,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.pocketshell.uikit.components.ButtonVariant
+import com.pocketshell.uikit.components.Banner
+import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.EmptyState
 import com.pocketshell.uikit.components.Kebab
 import com.pocketshell.uikit.components.KebabItem
@@ -32,6 +35,7 @@ import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellSpacing
+import com.pocketshell.next.workspaces.canonicalRemotePath
 
 /** Stable test tags. */
 const val WORKSPACE_ROOTS_LIST_TAG: String = "workspace-roots-list"
@@ -39,6 +43,7 @@ const val WORKSPACE_ROOTS_BACK_TAG: String = "workspace-roots-back"
 const val WORKSPACE_ROOTS_LABEL_FIELD_TAG: String = "workspace-roots-label-field"
 const val WORKSPACE_ROOTS_PATH_FIELD_TAG: String = "workspace-roots-path-field"
 const val WORKSPACE_ROOTS_ADD_TAG: String = "workspace-roots-add"
+const val WORKSPACE_ROOTS_CREATE_TAG: String = "workspace-roots-create"
 const val WORKSPACE_ROOTS_EMPTY_TAG: String = "workspace-roots-empty"
 
 fun workspaceRootRowTag(rootId: Long): String = "workspace-root-$rootId"
@@ -64,6 +69,7 @@ fun WorkspaceRootsRoute(
         state = state,
         onBack = onBack,
         onAddRoot = viewModel::addRoot,
+        onCreateRoot = viewModel::createRoot,
         onDeleteRoot = viewModel::deleteRoot,
         modifier = modifier,
     )
@@ -84,11 +90,18 @@ fun WorkspaceRootsScreen(
     state: WorkspaceRootsUiState,
     onBack: () -> Unit,
     onAddRoot: (label: String, path: String) -> Unit,
+    onCreateRoot: (label: String, path: String) -> Unit = { _, _ -> },
     onDeleteRoot: (WorkspaceRootRow) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var label by remember { mutableStateOf("") }
     var path by remember { mutableStateOf("") }
+    LaunchedEffect(state.successNonce) {
+        if (state.successNonce > 0) {
+            label = ""
+            path = ""
+        }
+    }
 
     Column(
         modifier = modifier
@@ -97,15 +110,8 @@ fun WorkspaceRootsScreen(
     ) {
         ScreenHeader(
             title = if (state.hostName.isBlank()) "Workspace roots" else "Roots · ${state.hostName}",
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(WORKSPACE_ROOTS_BACK_TAG),
-                )
-            },
+            onBack = onBack,
+            backTestTag = WORKSPACE_ROOTS_BACK_TAG,
         )
 
         Column(
@@ -134,15 +140,31 @@ fun WorkspaceRootsScreen(
                     .fillMaxWidth()
                     .testTag(WORKSPACE_ROOTS_LABEL_FIELD_TAG),
             )
+            state.failure?.let { failure ->
+                Banner(
+                    text = failure,
+                    role = BannerRole.Error,
+                    modifier = Modifier.testTag("workspace-roots-error"),
+                )
+            }
+            if (state.canCreate && state.createPath == canonicalRemotePath(path.trim().trimEnd('/'))) {
+                PocketShellButton(
+                    text = "Create folder on host",
+                    onClick = { onCreateRoot(label, path) },
+                    variant = ButtonVariant.Secondary,
+                    enabled = !state.adding,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(WORKSPACE_ROOTS_CREATE_TAG),
+                )
+            }
             PocketShellButton(
-                text = "Add root",
+                text = if (state.adding) "Checking…" else "Add root",
                 onClick = {
                     onAddRoot(label, path)
-                    label = ""
-                    path = ""
                 },
                 variant = ButtonVariant.Primary,
-                enabled = path.isNotBlank(),
+                enabled = path.isNotBlank() && !state.adding,
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag(WORKSPACE_ROOTS_ADD_TAG),

--- a/app2/src/main/java/com/pocketshell/next/settings/WorkspaceRootsViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/settings/WorkspaceRootsViewModel.kt
@@ -6,8 +6,11 @@ import androidx.lifecycle.viewModelScope
 import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.dao.ProjectRootDao
 import com.pocketshell.core.storage.entity.ProjectRootEntity
+import com.pocketshell.core.transport.ConnectResult
+import com.pocketshell.next.connect.ConnectionsRegistry
 import com.pocketshell.next.di.IoDispatcher
 import com.pocketshell.next.nav.Destination
+import com.pocketshell.next.workspaces.canonicalRemotePath
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -17,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /** One saved shortcut on the screen: what [SettingsScreen] calls a Workspace root. */
@@ -28,6 +32,12 @@ data class WorkspaceRootsUiState(
     val roots: List<WorkspaceRootRow> = emptyList(),
     /** True once the host name AND the first roots emission have both landed. */
     val loaded: Boolean = false,
+    val adding: Boolean = false,
+    val failure: String? = null,
+    /** The checked path can be created explicitly when it does not exist. */
+    val canCreate: Boolean = false,
+    val createPath: String? = null,
+    val successNonce: Int = 0,
 )
 
 /**
@@ -44,7 +54,8 @@ data class WorkspaceRootsUiState(
 @HiltViewModel
 class WorkspaceRootsViewModel @Inject constructor(
     private val projectRootDao: ProjectRootDao,
-    hostDao: HostDao,
+    private val hostDao: HostDao,
+    private val registry: ConnectionsRegistry,
     savedStateHandle: SavedStateHandle,
     @IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -55,15 +66,22 @@ class WorkspaceRootsViewModel @Inject constructor(
         }
 
     private val hostName: MutableStateFlow<String?> = MutableStateFlow(null)
+    private val addState = MutableStateFlow(RootAddState())
 
     val state: StateFlow<WorkspaceRootsUiState> = combine(
         hostName,
         projectRootDao.getByHostId(hostId),
-    ) { name, roots ->
+        addState,
+    ) { name, roots, action ->
         WorkspaceRootsUiState(
             hostName = name.orEmpty(),
             roots = roots.map { WorkspaceRootRow(id = it.id, label = it.label, path = it.path) },
             loaded = name != null,
+            adding = action.adding,
+            failure = action.failure,
+            canCreate = action.canCreate,
+            createPath = action.createPath,
+            successNonce = action.successNonce,
         )
     }
         .flowOn(dispatcher)
@@ -88,22 +106,149 @@ class WorkspaceRootsViewModel @Inject constructor(
      * already enforces.
      */
     fun addRoot(label: String, path: String) {
-        val trimmedPath = path.trim().trimEnd('/').ifBlank { return }
-        val trimmedLabel = label.trim().ifBlank {
-            trimmedPath.substringAfterLast('/').ifBlank { trimmedPath }
+        val trimmedPath = path.trim().trimEnd('/').ifBlank {
+            addState.update { it.copy(failure = "Enter a remote folder path.", canCreate = false, createPath = null) }
+            return
         }
+        val canonicalPath = canonicalRemotePath(trimmedPath)
+        if (canonicalPath == null || canonicalPath == ".") {
+            addState.update {
+                it.copy(
+                    failure = "Enter a valid absolute path or a path under ~.",
+                    canCreate = false,
+                    createPath = null,
+                )
+            }
+            return
+        }
+        if (addState.value.adding) return
+        val trimmedLabel = label.trim().ifBlank {
+            canonicalPath.substringAfterLast('/').ifBlank { canonicalPath }
+        }
+        addState.value = RootAddState(adding = true)
         viewModelScope.launch {
-            projectRootDao.insert(
-                ProjectRootEntity(hostId = hostId, label = trimmedLabel, path = trimmedPath),
-            )
+            val host = hostDao.getById(hostId)
+            if (host == null) {
+                finishAdd("This host is no longer saved on this device.")
+                return@launch
+            }
+            when (val outcome = registry.getOrConnect(hostId)) {
+                is ConnectResult.NeedsTrust -> {
+                    finishAdd("Confirm this host's key from the host list before adding a root.")
+                    return@launch
+                }
+                is ConnectResult.Failed -> {
+                    finishAdd(outcome.message)
+                    return@launch
+                }
+                is ConnectResult.Connected -> {
+                    val entry = runCatching { outcome.connection.sftp().stat(canonicalPath) }
+                        .getOrElse { error ->
+                            finishAdd("Could not inspect this root: ${error.message ?: "connection error"}")
+                            return@launch
+                        }
+                    when {
+                        entry == null -> {
+                            finishAdd(
+                                "That folder does not exist. You can create it on the host.",
+                                canCreate = true,
+                                createPath = canonicalPath,
+                            )
+                            return@launch
+                        }
+                        !entry.isDirectory -> {
+                            finishAdd("That path is a file, not a project root.")
+                            return@launch
+                        }
+                    }
+                }
+            }
+            saveRoot(trimmedLabel, canonicalPath)
         }
     }
 
-    fun deleteRoot(root: WorkspaceRootRow) {
-        viewModelScope.launch { projectRootDao.deleteById(root.id) }
+    /** Creates the exact missing directory after the user explicitly chooses it. */
+    fun createRoot(label: String, path: String) {
+        val canonicalPath = canonicalRemotePath(path.trim().trimEnd('/'))
+        if (canonicalPath == null || canonicalPath == ".") {
+            addState.update { it.copy(failure = "Enter a valid absolute path or a path under ~.") }
+            return
+        }
+        if (addState.value.createPath != canonicalPath || addState.value.adding) return
+        val trimmedLabel = label.trim().ifBlank {
+            canonicalPath.substringAfterLast('/').ifBlank { canonicalPath }
+        }
+        addState.value = RootAddState(adding = true)
+        viewModelScope.launch {
+            val host = hostDao.getById(hostId)
+            if (host == null) {
+                finishAdd("This host is no longer saved on this device.")
+                return@launch
+            }
+            val connection = when (val outcome = registry.getOrConnect(hostId)) {
+                is ConnectResult.Connected -> outcome.connection
+                is ConnectResult.NeedsTrust -> {
+                    finishAdd("Confirm this host's key from the host list before creating a root.")
+                    return@launch
+                }
+                is ConnectResult.Failed -> {
+                    finishAdd(outcome.message)
+                    return@launch
+                }
+            }
+            val existing = runCatching { connection.sftp().stat(canonicalPath) }.getOrElse { error ->
+                finishAdd("Could not inspect this root: ${error.message ?: "connection error"}")
+                return@launch
+            }
+            when {
+                existing?.isDirectory == true -> saveRoot(trimmedLabel, canonicalPath)
+                existing != null -> finishAdd("That path is a file, not a project root.")
+                else -> try {
+                    connection.sftp().mkdir(canonicalPath)
+                    saveRoot(trimmedLabel, canonicalPath)
+                } catch (error: Throwable) {
+                    finishAdd("Could not create the root: ${error.message ?: "permission denied"}")
+                }
+            }
+        }
+    }
+
+    fun deleteRoot(root: WorkspaceRootRow) = viewModelScope.launch(dispatcher) {
+        projectRootDao.deleteById(root.id)
     }
 
     private companion object {
         const val STOP_TIMEOUT_MILLIS = 5_000L
     }
+
+    private fun finishAdd(message: String) {
+        finishAdd(message, canCreate = false, createPath = null)
+    }
+
+    private fun finishAdd(message: String, canCreate: Boolean, createPath: String?) {
+        addState.update {
+            it.copy(adding = false, failure = message, canCreate = canCreate, createPath = createPath)
+        }
+    }
+
+    private suspend fun saveRoot(label: String, path: String) {
+        projectRootDao.insert(ProjectRootEntity(hostId = hostId, label = label, path = path))
+        addState.update {
+            it.copy(
+                adding = false,
+                failure = null,
+                canCreate = false,
+                createPath = null,
+                successNonce = it.successNonce + 1,
+            )
+        }
+    }
+
+    private data class RootAddState(
+        val adding: Boolean = false,
+        val failure: String? = null,
+        val canCreate: Boolean = false,
+        val createPath: String? = null,
+        val successNonce: Int = 0,
+    )
 }

--- a/app2/src/main/java/com/pocketshell/next/terminal/SessionScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/SessionScreen.kt
@@ -6,10 +6,15 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -40,22 +45,24 @@ import com.pocketshell.next.tree.STOP_SESSION_MESSAGE_TAG
 import com.pocketshell.next.tree.STOP_SESSION_TITLE
 import com.pocketshell.next.tree.STOP_SESSION_TITLE_TAG
 import com.pocketshell.next.tree.stopSessionMessage
-import com.pocketshell.next.usage.UsageGlancePill
 import com.pocketshell.next.usage.UsageGlancePillState
 import com.pocketshell.next.usage.UsageGlanceViewModel
+import com.pocketshell.next.workspaces.readableSessionName
 import com.pocketshell.uikit.components.Banner
 import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.ConfirmDialog
 import com.pocketshell.uikit.components.EmptyState
-import com.pocketshell.uikit.components.Kebab
-import com.pocketshell.uikit.components.KebabItem
+import com.pocketshell.uikit.components.KebabTrigger
+import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
+import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.components.SessionLauncherBar
 import com.pocketshell.uikit.model.KeyBinding
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellSpacing
+import com.pocketshell.uikit.theme.PocketShellType
 import com.termux.terminal.TerminalSession
 
 /** Stable test tags for the session screen's own chrome. */
@@ -133,6 +140,7 @@ fun SessionRoute(
         object : SessionSink {
             override val isLive: Boolean get() = viewModel.uiState.value is SessionUiState.Live
             override fun sendBytes(bytes: ByteArray) = viewModel.sendBytes(bytes)
+            override val sendFailures = viewModel.sendFailures
         }
     }
     LaunchedEffect(hostId, sessionName, sink) {
@@ -233,6 +241,7 @@ fun SessionScreen(
     onUseHistoryEntry: (SentMessage) -> Unit,
     onPermissionDenied: () -> Unit = {},
     sessionSwitcherState: SessionSwitcherUiState = SessionSwitcherUiState(),
+    sessionLabel: String = readableSessionName(sessionName),
     modifier: Modifier = Modifier,
     cellMetrics: TerminalCellMetrics = rememberTerminalCellMetrics(),
     initiallyShowComposer: Boolean = false,
@@ -258,44 +267,17 @@ fun SessionScreen(
             .testTag(SESSION_SCREEN_TAG),
     ) {
         ScreenHeader(
-            title = sessionName,
-            subtitle = statusLine(state),
+            title = if (sessionEnded) "Session ended" else sessionLabel,
+            subtitle = if (sessionEnded) sessionLabel else statusLine(state),
+            titleMaxLines = 2,
+            subtitleMaxLines = 2,
             titleTestTag = SESSION_TITLE_TAG,
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(SESSION_BACK_TAG),
-                )
-            },
+            onBack = onBack,
+            backTestTag = SESSION_BACK_TAG,
             trailing = {
-                if (usagePillState != null) {
-                    UsageGlancePill(state = usagePillState, onClick = onOpenUsage)
-                } else {
-                    PocketShellButton(
-                        text = "Usage",
-                        onClick = onOpenUsage,
-                        variant = ButtonVariant.Text,
-                        compact = true,
-                        modifier = Modifier.testTag(SESSION_USAGE_TAG),
-                    )
-                }
-                Kebab(
-                    items = listOf(
-                        KebabItem(
-                            label = "Terminal actions",
-                            onClick = { terminalActionsOpen = true },
-                            testTag = SESSION_ACTIONS_ITEM_TAG,
-                        ),
-                        KebabItem(
-                            label = STOP_SESSION_ITEM_LABEL,
-                            onClick = { pendingStop = true },
-                            testTag = STOP_SESSION_ITEM_TAG,
-                        ),
-                    ),
-                    contentDescription = "Session actions",
+                KebabTrigger(
+                    onClick = { terminalActionsOpen = true },
+                    contentDescription = "Terminal actions",
                     triggerTestTag = SESSION_HEADER_KEBAB_TAG,
                 )
             },
@@ -329,7 +311,7 @@ fun SessionScreen(
             when (state) {
                 SessionUiState.Connecting -> EmptyState(
                     title = "Attaching…",
-                    description = "Opening a terminal on \"$sessionName\".",
+                    description = "Opening a terminal on \"$sessionLabel\".",
                     modifier = Modifier
                         .fillMaxSize()
                         .testTag(SESSION_CONNECTING_TAG),
@@ -381,54 +363,43 @@ fun SessionScreen(
                     )
                 }
 
-                is SessionUiState.Failed -> Column(modifier = Modifier.fillMaxSize()) {
-                    Banner(
-                        text = state.message,
-                        role = BannerRole.Error,
-                        maxLines = 4,
-                        trailingContent = {
-                            PocketShellButton(
-                                text = "Retry",
-                                onClick = onRetry,
-                                variant = ButtonVariant.Text,
-                                compact = true,
-                                modifier = Modifier.testTag(SESSION_RETRY_TAG),
-                            )
-                        },
-                        modifier = Modifier
-                            .padding(horizontal = PocketShellSpacing.md)
-                            .padding(bottom = PocketShellSpacing.sm)
-                            .testTag(SESSION_ERROR_BANNER_TAG),
+                is SessionUiState.Failed -> if (sessionEnded) {
+                    SessionEndedBody(
+                        sessionName = sessionName,
+                        sessionLabel = sessionLabel,
+                        exitCode = endedExitCode(state.message),
+                        state = sessionSwitcherState,
+                        onOpenSession = onOpenSession,
+                        onOpenNewSession = onOpenNewSession,
+                        onBack = onBack,
+                        modifier = Modifier.testTag(SESSION_ENDED_TAG),
                     )
-                    EmptyState(
-                        title = if (sessionEnded) "Session ended" else "Not attached",
-                        description = if (sessionEnded) {
-                            "The remote process has exited. Go back to the workspace to choose " +
-                                "another session."
-                        } else {
-                            "Tap Retry, or go back to the session list to pick another session."
-                        },
-                        action = if (sessionEnded) {
-                            {
+                } else {
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        Banner(
+                            text = state.message,
+                            role = BannerRole.Error,
+                            maxLines = 4,
+                            trailingContent = {
                                 PocketShellButton(
-                                    text = "Back to workspace",
-                                    onClick = onBack,
-                                    variant = ButtonVariant.Secondary,
+                                    text = "Retry",
+                                    onClick = onRetry,
+                                    variant = ButtonVariant.Text,
+                                    compact = true,
+                                    modifier = Modifier.testTag(SESSION_RETRY_TAG),
                                 )
-                            }
-                        } else {
-                            null
-                        },
-                        modifier = Modifier
-                            .weight(1f)
-                            .then(
-                                if (sessionEnded) {
-                                    Modifier.testTag(SESSION_ENDED_TAG)
-                                } else {
-                                    Modifier
-                                },
-                            ),
-                    )
+                            },
+                            modifier = Modifier
+                                .padding(horizontal = PocketShellSpacing.md)
+                                .padding(bottom = PocketShellSpacing.sm)
+                                .testTag(SESSION_ERROR_BANNER_TAG),
+                        )
+                        EmptyState(
+                            title = "Not attached",
+                            description = "Tap Retry, or go back to the session list to pick another session.",
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
                 }
             }
         }
@@ -453,7 +424,7 @@ fun SessionScreen(
 
     if (composerOpen && !sessionEnded) {
         val sendAndMaybeDismiss: () -> Unit = {
-            if (onSend()) composerOpen = false
+            if (!sessionEnded && onSend()) composerOpen = false
         }
         val dismiss = {
             onCancelRecording()
@@ -462,6 +433,7 @@ fun SessionScreen(
         if (embedComposerInWindow) {
             PromptComposerSheet(
                 state = composerState,
+                targetLabel = sessionLabel,
                 onDismiss = dismiss,
                 onDraftChange = onDraftChange,
                 onSend = sendAndMaybeDismiss,
@@ -469,16 +441,24 @@ fun SessionScreen(
                 onAttach = onAttach,
                 onMicTap = onMicTap,
                 onCancelRecording = onCancelRecording,
-                onToggleHistory = onToggleHistory,
+                onToggleHistory = {
+                    composerOpen = false
+                    onToggleHistory()
+                },
                 onTogglePreview = onTogglePreview,
                 onRemoveAttachment = onRemoveAttachment,
                 onDismissNotice = onDismissNotice,
                 onDiscard = onDiscardDraft,
                 onPermissionDenied = onPermissionDenied,
+                onOpenHotkeys = {
+                    composerOpen = false
+                    hotkeysOpen = true
+                },
             )
         } else {
             PromptComposerContent(
                 state = composerState,
+                targetLabel = sessionLabel,
                 onClose = dismiss,
                 onDraftChange = onDraftChange,
                 onSend = sendAndMaybeDismiss,
@@ -486,11 +466,18 @@ fun SessionScreen(
                 onAttach = onAttach,
                 onMicTap = onMicTap,
                 onCancelRecording = onCancelRecording,
-                onToggleHistory = onToggleHistory,
+                onToggleHistory = {
+                    composerOpen = false
+                    onToggleHistory()
+                },
                 onTogglePreview = onTogglePreview,
                 onRemoveAttachment = onRemoveAttachment,
                 onDismissNotice = onDismissNotice,
                 onDiscard = onDiscardDraft,
+                onOpenHotkeys = {
+                    composerOpen = false
+                    hotkeysOpen = true
+                },
             )
         }
     }
@@ -514,6 +501,10 @@ fun SessionScreen(
             onBrowseFiles = {
                 terminalActionsOpen = false
                 onOpenFiles()
+            },
+            onOpenUsage = {
+                terminalActionsOpen = false
+                onOpenUsage()
             },
             onCopySelection = {
                 copyTerminalSelection?.invoke()
@@ -550,7 +541,10 @@ fun SessionScreen(
     if (composerState.historyOpen) {
         MessageHistorySheet(
             messages = composerState.history,
-            onPick = onUseHistoryEntry,
+            onPick = { message ->
+                onUseHistoryEntry(message)
+                composerOpen = true
+            },
             onDismiss = onToggleHistory,
         )
     }
@@ -558,7 +552,11 @@ fun SessionScreen(
     if (pendingStop) {
         ConfirmDialog(
             title = STOP_SESSION_TITLE,
-            message = stopSessionMessage(sessionName),
+            message = stopSessionMessage(
+                name = sessionLabel,
+                workspace = sessionSwitcherState.sessions.firstOrNull { it.name == sessionName }?.workspace,
+                host = "this host",
+            ),
             confirmLabel = STOP_SESSION_CONFIRM_LABEL,
             destructive = true,
             onConfirm = {
@@ -573,6 +571,103 @@ fun SessionScreen(
         )
     }
 }
+
+@Composable
+private fun SessionEndedBody(
+    sessionName: String,
+    sessionLabel: String = readableSessionName(sessionName),
+    exitCode: Int?,
+    state: SessionSwitcherUiState,
+    onOpenSession: (SessionRow) -> Unit,
+    onOpenNewSession: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val otherSessions = state.sessions.filter { it.name != sessionName }
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = PocketShellSpacing.lg, vertical = PocketShellSpacing.md),
+    ) {
+        Text(
+            text = "Terminal in $sessionLabel has ended.",
+            color = PocketShellColors.Text,
+            style = PocketShellType.body,
+        )
+        exitCode?.let { code ->
+            Text(
+                text = "Exit code: $code",
+                color = PocketShellColors.TextSecondary,
+                style = PocketShellType.metadata,
+                modifier = Modifier.padding(top = PocketShellSpacing.xs),
+            )
+        }
+        Text(
+            text = "The workspace is still here. Open another session or start a new one.",
+            color = PocketShellColors.TextSecondary,
+            style = PocketShellType.body,
+            modifier = Modifier.padding(top = PocketShellSpacing.xs),
+        )
+        SectionHeader(
+            label = "Other sessions",
+            count = otherSessions.size.takeIf { it > 0 },
+            modifier = Modifier.padding(top = PocketShellSpacing.lg),
+        )
+        when {
+            state.loading -> Text(
+                text = "Reading sessions…",
+                color = PocketShellColors.TextSecondary,
+                style = PocketShellType.body,
+                modifier = Modifier.padding(vertical = PocketShellSpacing.md),
+            )
+            state.failure != null && otherSessions.isEmpty() -> Text(
+                text = "Sessions unavailable: ${state.failure}",
+                color = PocketShellColors.TextSecondary,
+                style = PocketShellType.body,
+                modifier = Modifier.padding(vertical = PocketShellSpacing.md),
+            )
+            otherSessions.isEmpty() -> Text(
+                text = "No other sessions are running.",
+                color = PocketShellColors.TextSecondary,
+                style = PocketShellType.body,
+                modifier = Modifier.padding(vertical = PocketShellSpacing.md),
+            )
+            else -> LazyColumn(modifier = Modifier.weight(1f)) {
+                items(otherSessions, key = { "${it.workspace}:${it.name}" }) { session ->
+                    ListRow(
+                        title = session.name,
+                        subtitle = endedSessionSubtitle(session),
+                        onClick = { onOpenSession(session) },
+                    )
+                }
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = PocketShellSpacing.md),
+            horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+        ) {
+            PocketShellButton(
+                text = "New session",
+                onClick = onOpenNewSession,
+                variant = ButtonVariant.Primary,
+                modifier = Modifier.weight(1f),
+            )
+            PocketShellButton(
+                text = "Back to workspace",
+                onClick = onBack,
+                variant = ButtonVariant.Text,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+private fun endedSessionSubtitle(session: SessionRow): String = listOfNotNull(
+    session.agent?.replaceFirstChar { it.uppercase() },
+    session.profile,
+).ifEmpty { listOf("Terminal · Running") }.joinToString(" · ")
 
 @Composable
 private fun Terminal(
@@ -611,3 +706,6 @@ private fun statusLine(state: SessionUiState): String = when (state) {
 
 private fun String.looksLikeEndedSession(): Boolean =
     contains(" ended.") || contains(" ended (exit ") || contains(" ended:")
+
+private fun endedExitCode(message: String): Int? =
+    Regex("ended \\(exit (-?\\d+)\\)").find(message)?.groupValues?.getOrNull(1)?.toIntOrNull()

--- a/app2/src/main/java/com/pocketshell/next/terminal/SessionSwitcher.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/SessionSwitcher.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -26,11 +27,14 @@ import com.pocketshell.next.nav.Destination
 import com.pocketshell.next.tree.STOP_SESSION_ITEM_LABEL
 import com.pocketshell.next.tree.STOP_SESSION_ITEM_TAG
 import com.pocketshell.next.workspaces.canonicalRemotePath
+import com.pocketshell.next.workspaces.sessionDisplayNames
 import com.pocketshell.uikit.components.EmptyState
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellShapes
 import com.pocketshell.uikit.theme.PocketShellSpacing
+import androidx.compose.ui.unit.dp
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Job
@@ -113,60 +117,71 @@ fun SessionSwitcherSheet(
     onOpenSession: (SessionRow) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val displayNames = sessionDisplayNames(state.sessions)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         containerColor = PocketShellColors.Surface,
         contentColor = PocketShellColors.Text,
+        shape = PocketShellShapes.large,
     ) {
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
+                .heightIn(max = 560.dp)
                 .padding(horizontal = PocketShellSpacing.lg)
                 .padding(bottom = PocketShellSpacing.lg)
                 .testTag(SESSION_SWITCHER_SHEET_TAG),
         ) {
-            SheetHeader(
-                title = "Sessions",
-                subtitle = "Switch terminals in this workspace.",
-                onClose = onDismiss,
-            )
-            ListRow(
-                title = "New session",
-                subtitle = "Start another terminal here.",
-                onClick = onNewSession,
-                modifier = Modifier.testTag(SESSION_SWITCHER_NEW_TAG),
-            )
+            item {
+                SheetHeader(
+                    title = "Sessions",
+                    subtitle = "Switch terminals in this workspace.",
+                    onClose = onDismiss,
+                )
+            }
+            item {
+                ListRow(
+                    title = "New session",
+                    subtitle = "Start another terminal here.",
+                    onClick = onNewSession,
+                    modifier = Modifier.testTag(SESSION_SWITCHER_NEW_TAG),
+                )
+            }
             when {
-                state.loading -> EmptyState(
-                    title = "Loading sessions…",
-                    modifier = Modifier
-                        .padding(vertical = PocketShellSpacing.lg)
-                        .testTag(SESSION_SWITCHER_LOADING_TAG),
-                )
-                state.failure != null && state.sessions.isEmpty() -> EmptyState(
-                    title = "Sessions unavailable",
-                    description = state.failure,
-                    modifier = Modifier.testTag(SESSION_SWITCHER_ERROR_TAG),
-                )
-                state.sessions.isEmpty() -> EmptyState(
-                    title = "No other sessions",
-                    description = "Start another session from this workspace.",
-                    modifier = Modifier.testTag(SESSION_SWITCHER_EMPTY_TAG),
-                )
-                else -> LazyColumn {
-                    items(state.sessions, key = { "${it.workspace}:${it.name}" }) { session ->
-                        ListRow(
-                            title = session.name,
-                            subtitle = if (session.name == currentSessionName) {
-                                "Current session"
-                            } else {
-                                sessionSwitcherSubtitle(session)
-                            },
-                            onClick = { onOpenSession(session) },
-                            modifier = Modifier.testTag(sessionSwitcherRowTag(session.name)),
-                        )
-                    }
+                state.loading -> item {
+                    EmptyState(
+                        title = "Loading sessions…",
+                        modifier = Modifier
+                            .padding(vertical = PocketShellSpacing.lg)
+                            .testTag(SESSION_SWITCHER_LOADING_TAG),
+                    )
+                }
+                state.failure != null && state.sessions.isEmpty() -> item {
+                    EmptyState(
+                        title = "Sessions unavailable",
+                        description = state.failure,
+                        modifier = Modifier.testTag(SESSION_SWITCHER_ERROR_TAG),
+                    )
+                }
+                state.sessions.isEmpty() -> item {
+                    EmptyState(
+                        title = "No other sessions",
+                        description = "Start another session from this workspace.",
+                        modifier = Modifier.testTag(SESSION_SWITCHER_EMPTY_TAG),
+                    )
+                }
+                else -> items(state.sessions, key = { "${it.workspace}:${it.name}" }) { session ->
+                    ListRow(
+                        title = displayNames[session.name] ?: "Terminal",
+                        subtitle = if (session.name == currentSessionName) {
+                            "Current session"
+                        } else {
+                            sessionSwitcherSubtitle(session)
+                        },
+                        onClick = { onOpenSession(session) },
+                        modifier = Modifier.testTag(sessionSwitcherRowTag(session.name)),
+                    )
                 }
             }
         }
@@ -183,6 +198,7 @@ private fun sessionSwitcherSubtitle(session: SessionRow): String = listOfNotNull
 fun TerminalActionsSheet(
     onSessions: () -> Unit,
     onBrowseFiles: () -> Unit,
+    onOpenUsage: () -> Unit,
     onCopySelection: () -> Unit,
     onDetach: () -> Unit,
     onEndSession: () -> Unit,
@@ -193,6 +209,7 @@ fun TerminalActionsSheet(
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         containerColor = PocketShellColors.Surface,
         contentColor = PocketShellColors.Text,
+        shape = PocketShellShapes.large,
     ) {
         Column(
             modifier = Modifier
@@ -202,11 +219,18 @@ fun TerminalActionsSheet(
                 .testTag(TERMINAL_ACTIONS_SHEET_TAG),
         ) {
             SheetHeader(title = "Terminal", onClose = onDismiss)
-            TerminalActionRow("Sessions in workspace", onSessions, TERMINAL_ACTIONS_SESSIONS_TAG)
-            TerminalActionRow("Browse workspace files", onBrowseFiles, TERMINAL_ACTIONS_FILES_TAG)
-            TerminalActionRow("Copy selection", onCopySelection, TERMINAL_ACTIONS_COPY_TAG)
-            TerminalActionRow("Detach and keep running", onDetach, TERMINAL_ACTIONS_DETACH_TAG)
-            TerminalActionRow(STOP_SESSION_ITEM_LABEL, onEndSession, STOP_SESSION_ITEM_TAG)
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 480.dp),
+            ) {
+                item { TerminalActionRow("Sessions in workspace", onSessions, TERMINAL_ACTIONS_SESSIONS_TAG) }
+                item { TerminalActionRow("Browse workspace files", onBrowseFiles, TERMINAL_ACTIONS_FILES_TAG) }
+                item { TerminalActionRow("Usage", onOpenUsage, TERMINAL_ACTIONS_USAGE_TAG) }
+                item { TerminalActionRow("Copy selection", onCopySelection, TERMINAL_ACTIONS_COPY_TAG) }
+                item { TerminalActionRow("Detach and keep running", onDetach, TERMINAL_ACTIONS_DETACH_TAG) }
+                item { TerminalActionRow(STOP_SESSION_ITEM_LABEL, onEndSession, STOP_SESSION_ITEM_TAG) }
+            }
         }
     }
 }
@@ -219,5 +243,6 @@ private fun TerminalActionRow(title: String, onClick: () -> Unit, testTag: Strin
 const val TERMINAL_ACTIONS_SHEET_TAG: String = "terminal-actions-sheet"
 const val TERMINAL_ACTIONS_SESSIONS_TAG: String = "terminal-actions-sessions"
 const val TERMINAL_ACTIONS_FILES_TAG: String = "terminal-actions-files"
+const val TERMINAL_ACTIONS_USAGE_TAG: String = "terminal-actions-usage"
 const val TERMINAL_ACTIONS_COPY_TAG: String = "terminal-actions-copy"
 const val TERMINAL_ACTIONS_DETACH_TAG: String = "terminal-actions-detach"

--- a/app2/src/main/java/com/pocketshell/next/terminal/SessionViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/SessionViewModel.kt
@@ -25,8 +25,10 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -163,6 +165,9 @@ class SessionViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<SessionUiState>(SessionUiState.Connecting)
 
     val uiState: StateFlow<SessionUiState> = _uiState.asStateFlow()
+
+    private val _sendFailures = MutableSharedFlow<Unit>(extraBufferCapacity = 4)
+    val sendFailures = _sendFailures.asSharedFlow()
 
     /**
      * One-shot: the host accepted the kill, so the screen should pop back to
@@ -302,7 +307,13 @@ class SessionViewModel @Inject constructor(
      */
     fun sendBytes(bytes: ByteArray) {
         if (bytes.isEmpty()) return
-        val target = channel ?: return
+        val target = channel ?: run {
+            // A caller may observe Live just before the channel is retired by
+            // the reconnect watcher. Report that race to the composer instead
+            // of silently dropping the write after it cleared its draft.
+            _sendFailures.tryEmit(Unit)
+            return
+        }
         viewModelScope.launch {
             try {
                 target.write(bytes)
@@ -314,6 +325,7 @@ class SessionViewModel @Inject constructor(
                 // it its own failure message would mean a drop noticed by typing
                 // ended the screen while a drop noticed by the output pump
                 // reconnected.
+                _sendFailures.tryEmit(Unit)
                 val status = withTimeoutOrNull(EXIT_STATUS_GRACE_MS) { target.exit.await() }
                 settleEnd(target, status, finalClose = status == null && isFinalClose())
             }
@@ -781,9 +793,10 @@ class SessionViewModel @Inject constructor(
     private fun endedMessage(exitCode: Int?): String {
         val name = sessionLabel
         val subject = if (name == null) "The session" else "Session \"$name\""
-        return when {
-            exitCode == null || exitCode == 0 -> "$subject ended."
-            else -> "$subject ended (exit $exitCode)."
+        return if (exitCode == null) {
+            "$subject ended."
+        } else {
+            "$subject ended (exit $exitCode)."
         }
     }
 

--- a/app2/src/main/java/com/pocketshell/next/terminal/TerminalHotkeysSheet.kt
+++ b/app2/src/main/java/com/pocketshell/next/terminal/TerminalHotkeysSheet.kt
@@ -26,6 +26,7 @@ import com.pocketshell.uikit.components.TerminalHotkeysPage
 import com.pocketshell.uikit.model.KeyBinding
 import com.pocketshell.uikit.model.KeyKind
 import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellShapes
 
 /**
  * The dedicated terminal-hotkeys panel in its own [ModalBottomSheet] (#2521,
@@ -56,6 +57,7 @@ fun TerminalHotkeysSheet(
         sheetState = sheetState,
         containerColor = PocketShellColors.Surface,
         contentColor = PocketShellColors.Text,
+        shape = PocketShellShapes.large,
         modifier = modifier,
         contentWindowInsets = {
             WindowInsets.safeDrawing.only(

--- a/app2/src/main/java/com/pocketshell/next/tree/CreateSessionSheet.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/CreateSessionSheet.kt
@@ -32,10 +32,12 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.pocketshell.core.hostapi.EngineInfo
 import com.pocketshell.core.hostapi.ProfileInfo
+import com.pocketshell.next.workspaces.SessionKindMark
 import com.pocketshell.uikit.components.Banner
 import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
 import com.pocketshell.uikit.components.PocketShellButton
+import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.SectionHeader
 import com.pocketshell.uikit.components.SegmentedToggle
 import com.pocketshell.uikit.components.SheetHeader
@@ -61,6 +63,7 @@ const val CREATE_SESSION_TYPE_AGENT_TAG: String = "create-session-type-agent"
 const val CREATE_SESSION_ENGINE_TAG_PREFIX: String = "create-session-engine-"
 const val CREATE_SESSION_PROFILE_TAG: String = "create-session-profile"
 const val CREATE_SESSION_NO_ENGINES_TAG: String = "create-session-no-engines"
+const val CREATE_SESSION_UNAVAILABLE_TAG: String = "create-session-unavailable"
 
 fun createSessionEngineTag(engineId: String): String = "$CREATE_SESSION_ENGINE_TAG_PREFIX$engineId"
 
@@ -146,6 +149,17 @@ fun defaultSessionName(folder: String): String {
     return segment
 }
 
+/** Returns the derived name plus a stable numeric suffix when it is occupied. */
+fun collisionSafeSessionName(folder: String, existingNames: Collection<String>): String {
+    val base = defaultSessionName(folder)
+    if (base.isBlank()) return base
+    val occupied = existingNames.map { it.trim().lowercase() }.toSet()
+    if (base.lowercase() !in occupied) return base
+    var suffix = 2
+    while ("$base $suffix".lowercase() in occupied) suffix += 1
+    return "$base $suffix"
+}
+
 /**
  * The sheet's editable form, hoisted out of the composition.
  *
@@ -164,12 +178,17 @@ fun defaultSessionName(folder: String): String {
  * is still a plain shell session; Agent is an explicit pick.
  */
 @Stable
-class CreateSessionFormState(initialFolder: String = "") {
+class CreateSessionFormState(
+    initialFolder: String = "",
+    private val existingSessionNames: Collection<String> = emptyList(),
+) {
 
     var folder: String by mutableStateOf(initialFolder)
         private set
 
-    var name: String by mutableStateOf(defaultSessionName(initialFolder))
+    var name: String by mutableStateOf(
+        collisionSafeSessionName(initialFolder, existingSessionNames),
+    )
         private set
 
     /** True once the user typed in the name field, which freezes the tracking. */
@@ -187,7 +206,7 @@ class CreateSessionFormState(initialFolder: String = "") {
 
     fun onFolderChange(value: String) {
         folder = value
-        if (!nameEdited) name = defaultSessionName(value)
+        if (!nameEdited) name = collisionSafeSessionName(value, existingSessionNames)
     }
 
     fun onNameChange(value: String) {
@@ -267,6 +286,8 @@ fun CreateSessionSheet(
     onSubmit: (CreateSessionRequest) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
+    existingSessionNames: Collection<String> = emptyList(),
+    onRefreshEngines: () -> Unit = {},
     // `skipPartiallyExpanded` is load-bearing, not a style choice: a modal sheet
     // otherwise opens at its PARTIAL detent (about half the screen) and anything
     // below that line is off-screen. With the keyboard up — which is the normal
@@ -288,6 +309,8 @@ fun CreateSessionSheet(
             defaultFolder = defaultFolder,
             onSubmit = onSubmit,
             onCancel = onCancel,
+            existingSessionNames = existingSessionNames,
+            onRefreshEngines = onRefreshEngines,
         )
     }
 }
@@ -305,9 +328,11 @@ fun CreateSessionSheetContent(
     onSubmit: (CreateSessionRequest) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
-    form: CreateSessionFormState = remember(defaultFolder) {
-        CreateSessionFormState(defaultFolder)
+    existingSessionNames: Collection<String> = emptyList(),
+    form: CreateSessionFormState = remember(defaultFolder, existingSessionNames) {
+        CreateSessionFormState(defaultFolder, existingSessionNames)
     },
+    onRefreshEngines: () -> Unit = {},
 ) {
     val fieldColors = OutlinedTextFieldDefaults.colors(
         focusedTextColor = PocketShellColors.Text,
@@ -319,6 +344,7 @@ fun CreateSessionSheetContent(
         cursorColor = PocketShellColors.Accent,
     )
     val available = availableEnginesForCreate(state.engines)
+    var unavailableEngine by remember { mutableStateOf<EngineInfo?>(null) }
     val selectedEngine = if (form.kind == CreateSessionKind.Agent) {
         available.firstOrNull { it.id == form.engineId } ?: available.firstOrNull()
     } else {
@@ -329,6 +355,7 @@ fun CreateSessionSheetContent(
         .indexOfFirst { it.name == form.profileName }
         .let { index -> if (index >= 0) index else engineProfiles.indexOfFirst { it.isDefault } }
         .coerceAtLeast(0)
+    var optionsOpen by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier
@@ -348,9 +375,23 @@ fun CreateSessionSheetContent(
             verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
         ) {
             SheetHeader(
-                title = CREATE_SESSION_TITLE,
-                subtitle = CREATE_SESSION_HINT,
+                title = unavailableEngine?.let { "${it.label} unavailable" }
+                    ?: if (optionsOpen) "Session options" else CREATE_SESSION_TITLE,
+                subtitle = if (unavailableEngine != null) {
+                    "Choose another program to continue."
+                } else if (optionsOpen) {
+                    "Name, folder and profile for this session."
+                } else {
+                    form.folder.ifBlank { "Host default folder" }
+                },
                 titleTestTag = CREATE_SESSION_TITLE_TAG,
+                onClose = {
+                    when {
+                        unavailableEngine != null -> unavailableEngine = null
+                        optionsOpen -> optionsOpen = false
+                        else -> onCancel()
+                    }
+                },
             )
 
             // A failed create keeps the sheet open with the user's own text still
@@ -365,83 +406,169 @@ fun CreateSessionSheetContent(
                 )
             }
 
-            OutlinedTextField(
-                value = form.folder,
-                onValueChange = form::onFolderChange,
-                singleLine = true,
-                enabled = !state.submitting,
-                label = { Text(CREATE_SESSION_FOLDER_LABEL) },
-                placeholder = { Text("/home/you/git/project") },
-                colors = fieldColors,
-                textStyle = PocketShellType.bodyMono,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag(CREATE_SESSION_FOLDER_TAG),
-            )
-
-            OutlinedTextField(
-                value = form.name,
-                onValueChange = form::onNameChange,
-                singleLine = true,
-                enabled = !state.submitting,
-                label = { Text(CREATE_SESSION_NAME_LABEL) },
-                colors = fieldColors,
-                textStyle = PocketShellType.bodyMono,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag(CREATE_SESSION_NAME_TAG),
-            )
-
-            Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
-                SectionHeader(label = CREATE_SESSION_TYPE_LABEL)
-                SegmentedToggle(
-                    labels = CREATE_SESSION_TYPE_LABELS,
-                    selectedIndex = if (form.kind == CreateSessionKind.Shell) 0 else 1,
-                    onSelected = { index ->
-                        form.onKindChange(
-                            if (index == 0) CreateSessionKind.Shell else CreateSessionKind.Agent,
-                        )
+            if (unavailableEngine != null) {
+                val engine = unavailableEngine!!
+                Text(
+                    text = "PocketShell could not find a usable ${engine.label} installation on the host.",
+                    color = PocketShellColors.TextSecondary,
+                    style = PocketShellType.body,
+                )
+                PocketShellButton(
+                    text = "Choose another program",
+                    onClick = {
+                        unavailableEngine = null
+                        form.onKindChange(CreateSessionKind.Shell)
                     },
+                    variant = ButtonVariant.Primary,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                PocketShellButton(
+                    text = if (state.enginesLoading) "Checking…" else "Re-check",
+                    onClick = {
+                        unavailableEngine = null
+                        onRefreshEngines()
+                    },
+                    variant = ButtonVariant.Secondary,
+                    enabled = !state.enginesLoading,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                var technicalDetailsOpen by remember(engine.id) { mutableStateOf(false) }
+                ListRow(
+                    title = "Technical details",
+                    subtitle = if (technicalDetailsOpen) "Hide details" else "Show host capability details",
+                    onClick = { technicalDetailsOpen = !technicalDetailsOpen },
+                )
+                if (technicalDetailsOpen) {
+                    Text(
+                        text = "Executable unavailable\nHost engine: ${engine.id}\n" +
+                            (engine.unavailableReason ?: "The host did not report an installation."),
+                        color = PocketShellColors.TextSecondary,
+                        style = PocketShellType.bodyMono,
+                    )
+                }
+            } else if (optionsOpen) {
+                OutlinedTextField(
+                    value = form.folder,
+                    onValueChange = form::onFolderChange,
+                    singleLine = true,
+                    enabled = !state.submitting,
+                    label = { Text(CREATE_SESSION_FOLDER_LABEL) },
+                    placeholder = { Text("/home/you/git/project") },
+                    colors = fieldColors,
+                    textStyle = PocketShellType.bodyMono,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(min = PICKER_SEGMENT_HEIGHT),
-                    fillSegments = true,
-                    segmentTag = { index ->
-                        if (index == 0) CREATE_SESSION_TYPE_SHELL_TAG else CREATE_SESSION_TYPE_AGENT_TAG
-                    },
+                        .testTag(CREATE_SESSION_FOLDER_TAG),
                 )
-            }
 
-            if (form.kind == CreateSessionKind.Agent) {
-                AgentEnginePicker(
-                    available = available,
-                    selectedEngineId = selectedEngine?.id,
-                    loading = state.enginesLoading && available.isEmpty(),
-                    failure = state.enginesFailure,
+                OutlinedTextField(
+                    value = form.name,
+                    onValueChange = form::onNameChange,
+                    singleLine = true,
                     enabled = !state.submitting,
-                    onSelect = form::onEngineChange,
+                    label = { Text(CREATE_SESSION_NAME_LABEL) },
+                    colors = fieldColors,
+                    textStyle = PocketShellType.bodyMono,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(CREATE_SESSION_NAME_TAG),
                 )
+
                 if (engineProfiles.size > 1) {
                     Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
                         SectionHeader(label = CREATE_SESSION_PROFILE_LABEL)
                         SegmentedToggle(
                             labels = engineProfiles.map { it.name },
                             selectedIndex = selectedProfileIndex,
-                            onSelected = { index ->
-                                form.onProfileChange(engineProfiles[index].name)
-                            },
+                            onSelected = { index -> form.onProfileChange(engineProfiles[index].name) },
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .heightIn(min = PICKER_SEGMENT_HEIGHT)
                                 .testTag(CREATE_SESSION_PROFILE_TAG),
                             fillSegments = true,
-                            segmentTag = { index ->
-                                createSessionProfileTag(engineProfiles[index].name)
-                            },
+                            segmentTag = { index -> createSessionProfileTag(engineProfiles[index].name) },
                         )
                     }
+                }
+
+                Text(
+                    text = "These options only affect the session you are about to start.",
+                    color = PocketShellColors.TextMuted,
+                    style = PocketShellType.metadata,
+                )
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
+                    SectionHeader(label = "Program")
+                    ListRow(
+                        title = "Terminal",
+                        subtitle = "A plain terminal in this workspace",
+                        leading = { SessionKindMark(agent = "shell") },
+                        onClick = { if (!state.submitting) form.onKindChange(CreateSessionKind.Shell) },
+                        modifier = Modifier.testTag(CREATE_SESSION_TYPE_SHELL_TAG),
+                    )
+                    ListRow(
+                        title = "Agent",
+                        subtitle = if (available.isEmpty()) "No agent is ready on this host" else "Choose an available agent",
+                        onClick = { if (!state.submitting) form.onKindChange(CreateSessionKind.Agent) },
+                        modifier = Modifier.testTag(CREATE_SESSION_TYPE_AGENT_TAG),
+                    )
+                    if (form.kind == CreateSessionKind.Agent) {
+                        if (state.enginesLoading && available.isEmpty()) {
+                            Text(
+                                text = CREATE_SESSION_LOADING_ENGINES,
+                                color = PocketShellColors.TextMuted,
+                                style = PocketShellType.labelMono,
+                            )
+                        }
+                        available.forEach { engine ->
+                            ListRow(
+                                title = engine.label,
+                                subtitle = if (engine.id == selectedEngine?.id) "Selected agent" else "Ready on host",
+                                leading = { SessionKindMark(agent = engine.id) },
+                                onClick = { if (!state.submitting) form.onEngineChange(engine.id) },
+                                modifier = Modifier.testTag(createSessionEngineTag(engine.id)),
+                            )
+                        }
+                        state.engines.filter { engine ->
+                            engine.id != "shell" && engine !in available
+                        }.forEach { engine ->
+                            ListRow(
+                                title = engine.label,
+                                subtitle = "Not available${engine.unavailableReason?.let { reason -> " · $reason" }.orEmpty()}",
+                                leading = { SessionKindMark(agent = engine.id) },
+                                onClick = {
+                                    if (!state.submitting) {
+                                        form.onKindChange(CreateSessionKind.Agent)
+                                        unavailableEngine = engine
+                                    }
+                                },
+                                modifier = Modifier.testTag(createSessionEngineTag(engine.id)),
+                            )
+                        }
+                        if (!state.enginesLoading && state.engines.isEmpty()) {
+                            Text(
+                                text = state.enginesFailure ?: CREATE_SESSION_NO_ENGINES,
+                                color = PocketShellColors.TextMuted,
+                                style = PocketShellType.labelMono,
+                                modifier = Modifier.testTag(CREATE_SESSION_NO_ENGINES_TAG),
+                            )
+                        }
+                        unavailableEngine?.let { engine ->
+                            Banner(
+                                text = "${engine.label} is not available${engine.unavailableReason?.let { reason -> ": $reason" }.orEmpty()}",
+                                role = BannerRole.Warning,
+                                maxLines = 4,
+                                modifier = Modifier.testTag(CREATE_SESSION_UNAVAILABLE_TAG),
+                            )
+                        }
+                    }
+                    ListRow(
+                        title = "More options",
+                        subtitle = "Name, folder and profile",
+                        onClick = { optionsOpen = true },
+                    )
                 }
             }
 
@@ -458,8 +585,12 @@ fun CreateSessionSheetContent(
             ),
         ) {
             PocketShellButton(
-                text = CREATE_SESSION_CANCEL_LABEL,
-                onClick = onCancel,
+                text = if (unavailableEngine != null) "Close" else CREATE_SESSION_CANCEL_LABEL,
+                onClick = if (unavailableEngine != null) {
+                    { unavailableEngine = null }
+                } else {
+                    onCancel
+                },
                 variant = ButtonVariant.Text,
                 enabled = !state.submitting,
                 modifier = Modifier.testTag(CREATE_SESSION_CANCEL_TAG),
@@ -468,7 +599,7 @@ fun CreateSessionSheetContent(
                 text = if (state.submitting) "Creating…" else CREATE_SESSION_SUBMIT_LABEL,
                 onClick = { onSubmit(form.toRequest(state.engines, state.profiles)) },
                 variant = ButtonVariant.Primary,
-                enabled = form.canSubmitWith(available) && !state.submitting,
+                enabled = unavailableEngine == null && form.canSubmitWith(available) && !state.submitting,
                 modifier = Modifier.testTag(CREATE_SESSION_SUBMIT_TAG),
             )
         }
@@ -478,11 +609,13 @@ fun CreateSessionSheetContent(
 @Composable
 private fun AgentEnginePicker(
     available: List<EngineInfo>,
+    unavailable: List<EngineInfo>,
     selectedEngineId: String?,
     loading: Boolean,
     failure: String?,
     enabled: Boolean,
     onSelect: (String) -> Unit,
+    onUnavailable: (EngineInfo) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs)) {
         when {
@@ -519,6 +652,14 @@ private fun AgentEnginePicker(
                     style = PocketShellType.labelMono,
                 )
             }
+        }
+        unavailable.forEach { engine ->
+            ListRow(
+                title = engine.label,
+                subtitle = "Not available${engine.unavailableReason?.let { reason -> " · $reason" }.orEmpty()}",
+                onClick = { if (enabled) onUnavailable(engine) },
+                modifier = Modifier.testTag(createSessionEngineTag(engine.id)),
+            )
         }
     }
 }

--- a/app2/src/main/java/com/pocketshell/next/tree/SessionTreeScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/SessionTreeScreen.kt
@@ -3,6 +3,7 @@ package com.pocketshell.next.tree
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -10,24 +11,29 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.zIndex
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import com.pocketshell.core.hostapi.SessionRow
-import com.pocketshell.next.usage.UsageGlancePill
 import com.pocketshell.next.usage.UsageGlancePillState
 import com.pocketshell.next.usage.UsageGlanceViewModel
+import com.pocketshell.next.workspaces.SessionKindMark
+import com.pocketshell.next.workspaces.sessionKindLabel
+import com.pocketshell.next.workspaces.sessionDisplayNames
 import com.pocketshell.uikit.components.Banner
 import com.pocketshell.uikit.components.BannerRole
 import com.pocketshell.uikit.components.ButtonVariant
@@ -35,13 +41,13 @@ import com.pocketshell.uikit.components.ConfirmDialog
 import com.pocketshell.uikit.components.EmptyState
 import com.pocketshell.uikit.components.Kebab
 import com.pocketshell.uikit.components.KebabItem
+import com.pocketshell.uikit.components.KebabTrigger
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
 import com.pocketshell.uikit.components.SectionHeader
-import com.pocketshell.uikit.components.StatusDot
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.icons.PocketShellIcons
-import com.pocketshell.uikit.model.ConnectionStatus
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellShapes
@@ -76,6 +82,7 @@ const val SESSION_TREE_BACK_TAG: String = "session-tree-back"
 
 /** The header action that opens this host's usage panel (issue #2532). */
 const val SESSION_TREE_USAGE_TAG: String = "session-tree-usage"
+const val SESSION_TREE_ACTIONS_TAG: String = "session-tree-actions"
 
 fun sessionRowTag(name: String): String = "session-row-$name"
 
@@ -83,18 +90,24 @@ fun sessionRowMenuTag(name: String): String = "session-row-menu-$name"
 
 fun rootHeaderTag(key: String): String = "root-header-$key"
 
-/** Overflow item and confirmation copy for Stop session (issue #2535). */
-const val STOP_SESSION_ITEM_LABEL: String = "Stop session"
-const val STOP_SESSION_TITLE: String = "Stop session?"
-const val STOP_SESSION_CONFIRM_LABEL: String = "Stop"
+/** Overflow item and confirmation copy for ending a session (issue #2535). */
+const val STOP_SESSION_ITEM_LABEL: String = "End session"
+const val STOP_SESSION_TITLE: String = "End session?"
+const val STOP_SESSION_CONFIRM_LABEL: String = "End"
 const val STOP_SESSION_ITEM_TAG: String = "session-stop-item"
 const val STOP_SESSION_CONFIRM_TAG: String = "session-stop-confirm"
 const val STOP_SESSION_CANCEL_TAG: String = "session-stop-cancel"
 const val STOP_SESSION_TITLE_TAG: String = "session-stop-title"
 const val STOP_SESSION_MESSAGE_TAG: String = "session-stop-message"
 
-fun stopSessionMessage(name: String): String =
-    "Stop \"$name\"? This kills the session on the host. Anything running in it stops, and there is no undo."
+fun stopSessionMessage(name: String, workspace: String? = null, host: String? = null): String {
+    val context = listOfNotNull(
+        workspace?.trim()?.takeIf { it.isNotEmpty() }?.let { "workspace \"$it\"" },
+        host?.trim()?.takeIf { it.isNotEmpty() },
+    ).joinToString(" on ")
+    val location = context.takeIf { it.isNotEmpty() }?.let { " in $it" }.orEmpty()
+    return "End \"$name\"$location? This ends the session and anything running in it. There is no undo."
+}
 
 fun folderHeaderTag(key: String): String = "folder-header-$key"
 
@@ -141,6 +154,7 @@ fun SessionTreeRoute(
         onOpenSession = onOpenSession,
         onCreateSession = viewModel::openCreateSheet,
         onSubmitCreate = viewModel::createSession,
+        onRefreshEngines = viewModel::refreshEngines,
         onDismissCreate = viewModel::dismissCreateSheet,
         onRequestStop = viewModel::requestStopSession,
         onConfirmStop = viewModel::confirmStopSession,
@@ -212,12 +226,14 @@ fun SessionTreeScreen(
     modifier: Modifier = Modifier,
     onCreateSession: () -> Unit = {},
     onSubmitCreate: (CreateSessionRequest) -> Unit = {},
+    onRefreshEngines: () -> Unit = {},
     onDismissCreate: () -> Unit = {},
     onRequestStop: (String) -> Unit = {},
     onConfirmStop: () -> Unit = {},
     onCancelStop: () -> Unit = {},
     nowSec: Long = System.currentTimeMillis() / 1000,
 ) {
+    var hostToolsOpen by remember { mutableStateOf(false) }
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -235,6 +251,7 @@ fun SessionTreeScreen(
             onOpenUsage = onOpenUsage,
             usagePillState = usagePillState,
             nowSec = nowSec,
+            onOpenHostTools = { hostToolsOpen = true },
         )
 
         // Bottom-end FAB over the list, the one create affordance on this
@@ -258,19 +275,50 @@ fun SessionTreeScreen(
         }
     }
 
+    if (hostToolsOpen) {
+        SessionTreeHostToolsSheet(
+            onOpenFiles = {
+                hostToolsOpen = false
+                onOpenFiles()
+            },
+            onOpenPorts = {
+                hostToolsOpen = false
+                onOpenPorts()
+            },
+            onOpenUsage = {
+                hostToolsOpen = false
+                onOpenUsage()
+            },
+            onDismiss = { hostToolsOpen = false },
+        )
+    }
+
     if (state.create.visible) {
         CreateSessionSheet(
             state = state.create,
             defaultFolder = state.suggestedFolder,
+            existingSessionNames = state.roots
+                .flatMap { root -> root.folders.flatMap { folder -> folder.rows } }
+                .map { it.name },
             onSubmit = onSubmitCreate,
             onCancel = onDismissCreate,
+            onRefreshEngines = onRefreshEngines,
         )
     }
 
     state.pendingStop?.let { name ->
+        val pendingSession = state.roots
+            .asSequence()
+            .flatMap { it.folders.asSequence() }
+            .flatMap { it.rows.asSequence() }
+            .firstOrNull { it.name == name }
         ConfirmDialog(
             title = STOP_SESSION_TITLE,
-            message = stopSessionMessage(name),
+            message = stopSessionMessage(
+                name = com.pocketshell.next.workspaces.readableSessionName(name),
+                workspace = pendingSession?.workspace,
+                host = "host #${state.hostId}",
+            ),
             confirmLabel = STOP_SESSION_CONFIRM_LABEL,
             destructive = true,
             onConfirm = onConfirmStop,
@@ -297,7 +345,13 @@ private fun SessionTreeBody(
     onOpenUsage: () -> Unit,
     usagePillState: UsageGlancePillState?,
     nowSec: Long,
+    onOpenHostTools: () -> Unit,
 ) {
+    val displayNames = remember(state.roots) {
+        sessionDisplayNames(
+            state.roots.flatMap { root -> root.folders.flatMap { folder -> folder.rows } },
+        )
+    }
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -306,44 +360,14 @@ private fun SessionTreeBody(
         ScreenHeader(
             title = "Sessions",
             subtitle = headerSubtitle(state),
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(SESSION_TREE_BACK_TAG),
-                )
-            },
-            // Tasks P-3a / P-4 / issue #2532: Files, Ports and Usage are
-            // host-scoped, so they live in this header rather than behind a
-            // menu. The glance pill rides next to Usage when a reading exists;
-            // the Usage text button stays so the panel is always reachable.
+            onBack = onBack,
+            backTestTag = SESSION_TREE_BACK_TAG,
             trailing = {
-                PocketShellButton(
-                    text = "Files",
-                    onClick = onOpenFiles,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(SESSION_TREE_FILES_TAG),
+                KebabTrigger(
+                    onClick = onOpenHostTools,
+                    contentDescription = "Host tools",
+                    triggerTestTag = SESSION_TREE_ACTIONS_TAG,
                 )
-                PocketShellButton(
-                    text = "Ports",
-                    onClick = onOpenPorts,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(SESSION_TREE_PORTS_TAG),
-                )
-                PocketShellButton(
-                    text = "Usage",
-                    onClick = onOpenUsage,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(SESSION_TREE_USAGE_TAG),
-                )
-                usagePillState?.let { pillState ->
-                    UsageGlancePill(state = pillState, onClick = onOpenUsage)
-                }
             },
         )
 
@@ -454,7 +478,7 @@ private fun SessionTreeBody(
                                 val row = folder.rows[index]
                                 SessionTreeRow(
                                     row = row,
-                                    nowSec = nowSec,
+                                    displayName = displayNames[row.name] ?: row.name,
                                     indentLevels = if (folder.untracked) 1 else 2,
                                     onClick = { onOpenSession(row.name) },
                                     onRequestStop = { onRequestStop(row.name) },
@@ -469,29 +493,21 @@ private fun SessionTreeBody(
 }
 
 /**
- * One session row: attach dot, session name, optional relative activity.
- *
- * No engine/agent chrome — U-9 stays cut. The leading dot is always drawn
- * (green when attached, muted when not) rather than drawn-only-when-attached,
- * so every row's title starts at the same x and a column of rows scans as a
- * column.
+ * One session row. Host connectivity and process attachment are not agent
+ * state, so the row uses a muted program mark rather than a green status dot.
  */
 @Composable
 private fun SessionTreeRow(
     row: SessionRow,
-    nowSec: Long,
+    displayName: String = row.name,
     indentLevels: Int,
     onClick: () -> Unit,
     onRequestStop: () -> Unit,
 ) {
     ListRow(
-        title = row.name,
-        subtitle = relativeActivityLabel(row.activityEpoch, nowSec),
-        leading = {
-            StatusDot(
-                status = if (row.attached) ConnectionStatus.Connected else ConnectionStatus.Idle,
-            )
-        },
+        title = displayName,
+        subtitle = sessionKindLabel(row),
+        leading = { SessionKindMark(agent = row.agent) },
         trailing = {
             Kebab(
                 items = listOf(
@@ -508,14 +524,7 @@ private fun SessionTreeRow(
         onClick = onClick,
         modifier = Modifier
             .padding(start = PocketShellDensity.treeIndent * indentLevels)
-            .testTag(sessionRowTag(row.name))
-            .then(
-                if (row.attached) {
-                    Modifier.semantics { contentDescription = ATTACHED_DESCRIPTION }
-                } else {
-                    Modifier
-                },
-            ),
+            .testTag(sessionRowTag(row.name)),
     )
 }
 
@@ -531,5 +540,68 @@ private fun plural(count: Int, noun: String): String = if (count == 1) noun else
 /** The host-side error text, deduplicated for a compact banner. */
 private fun partialErrors(state: SessionTreeUiState): String =
     state.errors.map { it.message }.distinct().joinToString("; ")
+
+/** Host-scoped utilities live in one sheet so they do not compete with rows. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SessionTreeHostToolsSheet(
+    onOpenFiles: () -> Unit,
+    onOpenPorts: () -> Unit,
+    onOpenUsage: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = PocketShellColors.Surface,
+        modifier = Modifier.testTag(SESSION_TREE_ACTIONS_TAG),
+    ) {
+        SessionTreeHostToolsContent(
+            onOpenFiles = onOpenFiles,
+            onOpenPorts = onOpenPorts,
+            onOpenUsage = onOpenUsage,
+            onDismiss = onDismiss,
+        )
+    }
+}
+
+/** The sheet body, kept separate so the action semantics can be verified without modal animation. */
+@Composable
+internal fun SessionTreeHostToolsContent(
+    onOpenFiles: () -> Unit,
+    onOpenPorts: () -> Unit,
+    onOpenUsage: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = PocketShellSpacing.lg),
+    ) {
+        SheetHeader(
+            title = "Host tools",
+            subtitle = "Utilities for this host",
+            onClose = onDismiss,
+        )
+        ListRow(
+            title = "Files",
+            subtitle = "Browse the remote filesystem",
+            onClick = onOpenFiles,
+            modifier = Modifier.testTag(SESSION_TREE_FILES_TAG),
+        )
+        ListRow(
+            title = "Services & tunnels",
+            subtitle = "Forward a remote service",
+            onClick = onOpenPorts,
+            modifier = Modifier.testTag(SESSION_TREE_PORTS_TAG),
+        )
+        ListRow(
+            title = "Usage",
+            subtitle = "Provider capacity on this host",
+            onClick = onOpenUsage,
+            modifier = Modifier.testTag(SESSION_TREE_USAGE_TAG),
+        )
+    }
+}
 
 internal const val ATTACHED_DESCRIPTION: String = "Attached"

--- a/app2/src/main/java/com/pocketshell/next/tree/SessionTreeViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/SessionTreeViewModel.kt
@@ -331,6 +331,14 @@ class SessionTreeViewModel @Inject constructor(
         }
     }
 
+    /** Re-check host engine capability from the unavailable-agent sheet. */
+    fun refreshEngines() {
+        if (!_state.value.create.visible || _state.value.create.submitting) return
+        updateCreate { it.copy(enginesLoading = true, enginesFailure = null) }
+        pickerInFlight?.cancel()
+        pickerInFlight = viewModelScope.launch { loadPickerOptions() }
+    }
+
     /**
      * `pocketshell sessions create --json` for [request], then refresh the
      * listing and ask the screen to open it.
@@ -571,6 +579,20 @@ class SessionTreeViewModel @Inject constructor(
                 }
             }
             val target = RemotePath.join(parent, name)
+            val existing = runCatching { connection.sftp().stat(target) }.getOrElse { error ->
+                failCreateFolder(userMessage(error, "Could not inspect the new folder: "))
+                return@launch
+            }
+            if (existing != null) {
+                failCreateFolder(
+                    if (existing.isDirectory) {
+                        "A folder already exists there. Choose it from the folder browser."
+                    } else {
+                        "A file already exists there; choose a different folder name."
+                    },
+                )
+                return@launch
+            }
             runCatching { connection.sftp().mkdir(target) }.fold(
                 onSuccess = {
                     _state.update { it.copy(workspaceAction = WorkspaceActionState()) }

--- a/app2/src/main/java/com/pocketshell/next/tree/TreeGrouping.kt
+++ b/app2/src/main/java/com/pocketshell/next/tree/TreeGrouping.kt
@@ -7,7 +7,7 @@ import com.pocketshell.core.hostapi.SessionRow
  * root — blank/null workspace, `$HOME` itself, or a path outside `$HOME`.
  */
 const val OTHER_ROOT_KEY: String = "::other::"
-const val OTHER_ROOT_LABEL: String = "other"
+const val OTHER_ROOT_LABEL: String = "Other"
 
 /** @see OTHER_ROOT_LABEL */
 const val OTHER_WORKSPACE_LABEL: String = OTHER_ROOT_LABEL

--- a/app2/src/main/java/com/pocketshell/next/usage/UsageScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/usage/UsageScreen.kt
@@ -174,15 +174,8 @@ private fun UsageHeader(
     ScreenHeader(
         title = "Usage",
         subtitle = hostName ?: "Connected hosts",
-        leading = {
-            PocketShellButton(
-                text = "Back",
-                onClick = onBack,
-                variant = ButtonVariant.Text,
-                compact = true,
-                modifier = Modifier.testTag(USAGE_BACK_TAG),
-            )
-        },
+        onBack = onBack,
+        backTestTag = USAGE_BACK_TAG,
         trailing = {
             Kebab(
                 triggerTestTag = USAGE_OVERFLOW_TAG,

--- a/app2/src/main/java/com/pocketshell/next/workspaces/HostWorkspacesScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/workspaces/HostWorkspacesScreen.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -15,14 +17,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -112,6 +117,10 @@ fun HostWorkspacesRoute(
 ) {
     val state by viewModel.state.collectAsState()
     LifecycleEventEffect(Lifecycle.Event.ON_START) { viewModel.refresh() }
+    LaunchedEffect(state.openWorkspacePath) {
+        val path = viewModel.consumeOpenWorkspace() ?: return@LaunchedEffect
+        onOpenWorkspace(path)
+    }
     HostWorkspacesScreen(
         state = state,
         onRefresh = viewModel::refresh,
@@ -192,15 +201,8 @@ fun HostWorkspacesScreen(
         ScreenHeader(
             title = state.hostLabel.ifBlank { "Workspaces" },
             subtitle = hostWorkspacesSubtitle(state),
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(HOST_WORKSPACES_BACK_TAG),
-                )
-            },
+            onBack = onBack,
+            backTestTag = HOST_WORKSPACES_BACK_TAG,
             trailing = {
                 KebabTrigger(
                     onClick = { hostToolsVisible = true },
@@ -280,6 +282,19 @@ fun HostWorkspacesScreen(
                     modifier = Modifier.testTag(HOST_WORKSPACES_EMPTY_TAG),
                 )
 
+                state.statusUnavailable && state.roots.isEmpty() -> EmptyState(
+                    title = "Status unavailable",
+                    description = state.failure ?: "Could not refresh this host.",
+                    action = {
+                        PocketShellButton(
+                            text = "Retry",
+                            onClick = onRefresh,
+                            modifier = Modifier.testTag(HOST_WORKSPACES_RETRY_TAG),
+                        )
+                    },
+                    modifier = Modifier.testTag(HOST_WORKSPACES_EMPTY_TAG),
+                )
+
                 state.isEmptyAndHealthy -> EmptyState(
                     title = "No workspaces",
                     description = "Durable workspaces on this host will appear here.",
@@ -301,6 +316,7 @@ fun HostWorkspacesScreen(
                     filteredRoots(state).forEach { root ->
                         itemContent(
                             root = root,
+                            sessionsUnavailable = state.statusUnavailable || state.errors.isNotEmpty(),
                             onOpenWorkspace = onOpenWorkspace,
                             onOpenSession = onOpenSession,
                             onOpenAddWorkspace = onOpenAddWorkspace,
@@ -404,6 +420,10 @@ fun HostWorkspacesScreen(
     if (state.addWorkspaceBrowserVisible) {
         WorkspaceFolderBrowserSheet(
             state = state,
+            existingWorkspacePaths = state.roots
+                .flatMap { root -> root.workspaces }
+                .map { workspace -> workspace.path }
+                .toSet(),
             onBrowse = onBrowseWorkspaceFolder,
             onChoose = onChooseWorkspaceFolder,
             onDismiss = onDismissWorkspaceBrowser,
@@ -493,6 +513,7 @@ fun HostWorkspacesScreen(
 
 private fun androidx.compose.foundation.lazy.LazyListScope.itemContent(
     root: WorkspaceRootProjection,
+    sessionsUnavailable: Boolean,
     onOpenWorkspace: (String) -> Unit,
     onOpenSession: (SessionRow) -> Unit,
     onOpenAddWorkspace: (String) -> Unit,
@@ -530,6 +551,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.itemContent(
     }
 
     if (root.rootSessions.isNotEmpty()) {
+        val displayNames = sessionDisplayNames(root.rootSessions)
         item(key = "root-sessions:${root.key}") {
             SectionHeader(
                 label = HOST_WORKSPACES_IN_ROOT_LABEL,
@@ -542,6 +564,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.itemContent(
         ) { session ->
             WorkspaceSessionRow(
                 session = session,
+                displayName = displayNames[session.name] ?: session.name,
                 onClick = { onOpenSession(session) },
             )
         }
@@ -562,7 +585,12 @@ private fun androidx.compose.foundation.lazy.LazyListScope.itemContent(
         ) { workspace ->
             WorkspaceRow(
                 title = workspace.label,
-                subtitle = workspaceSessionSummary(workspace.sessions),
+                subtitleContent = {
+                    SessionKindSummary(
+                        sessions = workspace.sessions,
+                        unavailable = sessionsUnavailable,
+                    )
+                },
                 onClick = { onOpenWorkspace(workspace.path) },
                 testTag = workspaceRowTag(workspace.path),
             )
@@ -571,13 +599,19 @@ private fun androidx.compose.foundation.lazy.LazyListScope.itemContent(
 }
 
 @Composable
-private fun WorkspaceSessionRow(session: SessionRow, onClick: () -> Unit) {
+private fun WorkspaceSessionRow(
+    session: SessionRow,
+    displayName: String = session.name,
+    onClick: () -> Unit,
+) {
     ListRow(
-        title = session.name,
+        title = displayName,
         subtitle = sessionKindLabel(session),
-        titleStyle = PocketShellType.title,
+        leading = { SessionKindMark(agent = session.agent) },
+        titleStyle = PocketShellType.body,
         subtitleStyle = PocketShellType.metadata,
-        titleWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+        titleWeight = androidx.compose.ui.text.font.FontWeight.Medium,
+        titleMaxLines = 2,
         onClick = onClick,
         modifier = Modifier.testTag(workspaceSessionRowTag(session.name)),
     )
@@ -628,6 +662,8 @@ private fun RootActionsSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = com.pocketshell.uikit.theme.PocketShellShapes.large,
+        containerColor = PocketShellColors.Surface,
     ) {
         RootActionsSheetContent(
             root = root,
@@ -637,6 +673,7 @@ private fun RootActionsSheet(
             onCopyPath = onCopyPath,
             onBrowse = onBrowse,
             onRemove = onRemove,
+            onDismiss = onDismiss,
         )
     }
 }
@@ -654,20 +691,20 @@ internal fun RootActionsSheetContent(
     onCopyPath: () -> Unit,
     onBrowse: () -> Unit,
     onRemove: () -> Unit,
+    onDismiss: (() -> Unit)? = null,
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .heightIn(max = 560.dp)
+            .verticalScroll(rememberScrollState())
             .padding(bottom = PocketShellSpacing.lg),
     ) {
-        Text(
-            text = root.displayPath,
-            color = PocketShellColors.Text,
-            style = PocketShellType.title,
-            modifier = Modifier.padding(
-                horizontal = PocketShellSpacing.lg,
-                vertical = PocketShellSpacing.sm,
-            ),
+        SheetHeader(
+            title = root.displayPath,
+            subtitle = "Root actions",
+            onClose = onDismiss,
+            modifier = Modifier.padding(horizontal = PocketShellSpacing.lg),
         )
         RootActionRow(
             title = "Add workspace",
@@ -741,6 +778,8 @@ private fun HostToolsSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = com.pocketshell.uikit.theme.PocketShellShapes.large,
+        containerColor = PocketShellColors.Surface,
         modifier = Modifier.testTag(HOST_WORKSPACES_HOST_TOOLS_TAG),
     ) {
         Column(
@@ -748,14 +787,11 @@ private fun HostToolsSheet(
                 .fillMaxWidth()
                 .padding(bottom = PocketShellSpacing.lg),
         ) {
-            Text(
-                text = "Host tools",
-                color = PocketShellColors.Text,
-                style = PocketShellType.title,
-                modifier = Modifier.padding(
-                    horizontal = PocketShellSpacing.lg,
-                    vertical = PocketShellSpacing.sm,
-                ),
+            SheetHeader(
+                title = "Host tools",
+                subtitle = "Utilities for this host",
+                onClose = onDismiss,
+                modifier = Modifier.padding(horizontal = PocketShellSpacing.lg),
             )
             HostToolRow("Browse host files", onOpenFiles, SESSION_TREE_FILES_TAG)
             HostToolRow("Services & tunnels", onOpenPorts, SESSION_TREE_PORTS_TAG)
@@ -792,6 +828,8 @@ private fun HostConnectionDetailsSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = com.pocketshell.uikit.theme.PocketShellShapes.large,
+        containerColor = PocketShellColors.Surface,
     ) {
         Column(
             modifier = Modifier
@@ -821,30 +859,32 @@ private fun HostConnectionDetailsSheet(
 @Composable
 private fun WorkspaceFolderBrowserSheet(
     state: HostWorkspacesUiState,
+    existingWorkspacePaths: Set<String>,
     onBrowse: (String) -> Unit,
     onChoose: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val currentPath = state.addWorkspaceBrowsePath
     val rootPath = canonicalRemotePath(state.addWorkspaceRootPath)
+    val canonicalCurrentPath = canonicalRemotePath(currentPath)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        shape = com.pocketshell.uikit.theme.PocketShellShapes.large,
+        containerColor = PocketShellColors.Surface,
         modifier = Modifier.testTag(HOST_WORKSPACES_FOLDER_BROWSER_TAG),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(androidx.compose.foundation.rememberScrollState())
                 .padding(bottom = PocketShellSpacing.lg),
         ) {
-            Text(
-                text = "Choose folder",
-                color = PocketShellColors.Text,
-                style = PocketShellType.title,
-                modifier = Modifier.padding(
-                    horizontal = PocketShellSpacing.lg,
-                    vertical = PocketShellSpacing.sm,
-                ),
+            SheetHeader(
+                title = "Choose folder",
+                subtitle = "Browse a workspace folder",
+                onClose = onDismiss,
+                modifier = Modifier.padding(horizontal = PocketShellSpacing.lg),
             )
             Text(
                 text = currentPath,
@@ -853,7 +893,11 @@ private fun WorkspaceFolderBrowserSheet(
                 modifier = Modifier.padding(horizontal = PocketShellSpacing.lg),
             )
             PocketShellButton(
-                text = "Use this folder",
+                text = if (canonicalCurrentPath != null && canonicalCurrentPath in existingWorkspacePaths) {
+                    "Open this workspace"
+                } else {
+                    "Use this folder"
+                },
                 onClick = { onChoose(currentPath) },
                 variant = ButtonVariant.Primary,
                 modifier = Modifier
@@ -897,9 +941,14 @@ private fun WorkspaceFolderBrowserSheet(
                     )
                 } else {
                     state.addWorkspaceFolders.forEach { folder ->
+                        val alreadyAdded = canonicalRemotePath(folder.path) in existingWorkspacePaths
                         ListRow(
                             title = folder.name,
-                            subtitle = folder.path,
+                            subtitle = if (alreadyAdded) {
+                                "Already added · ${folder.path}"
+                            } else {
+                                folder.path
+                            },
                             onClick = { onBrowse(folder.path) },
                         )
                     }

--- a/app2/src/main/java/com/pocketshell/next/workspaces/HostWorkspacesViewModel.kt
+++ b/app2/src/main/java/com/pocketshell/next/workspaces/HostWorkspacesViewModel.kt
@@ -35,6 +35,8 @@ data class HostWorkspacesUiState(
     val roots: List<WorkspaceRootProjection> = emptyList(),
     val errors: List<SessionListError> = emptyList(),
     val failure: String? = null,
+    /** True when the rows are the last known projection and the refresh failed. */
+    val statusUnavailable: Boolean = false,
     /** Client-side filter over the bounded durable workspace listing. */
     val searchQuery: String = "",
     val addWorkspaceVisible: Boolean = false,
@@ -47,6 +49,8 @@ data class HostWorkspacesUiState(
     val addWorkspaceFolders: List<WorkspaceFolderEntry> = emptyList(),
     val addWorkspaceBrowseLoading: Boolean = false,
     val addWorkspaceBrowseFailure: String? = null,
+    /** Set after a successful add so the selected folder opens immediately. */
+    val openWorkspacePath: String? = null,
     val createFolderVisible: Boolean = false,
     val createFolderParentPath: String = "",
     val createFolderName: String = "",
@@ -56,7 +60,8 @@ data class HostWorkspacesUiState(
     val workspaceCount: Int get() = roots.sumOf { it.workspaces.size }
     val sessionCount: Int get() = roots.sumOf { it.sessionCount }
     val isEmptyAndHealthy: Boolean
-        get() = loaded && roots.isEmpty() && errors.isEmpty() && failure == null
+        get() = loaded && roots.isEmpty() && errors.isEmpty() &&
+            failure == null && !statusUnavailable
 }
 
 /** One directory child offered by the root-scoped workspace picker. */
@@ -109,6 +114,12 @@ class HostWorkspacesViewModel @Inject constructor(
 
     fun setSearchQuery(query: String) {
         _state.update { it.copy(searchQuery = query) }
+    }
+
+    fun consumeOpenWorkspace(): String? {
+        val path = _state.value.openWorkspacePath ?: return null
+        _state.update { it.copy(openWorkspacePath = null) }
+        return path
     }
 
     /** Moves a saved root and persists the placement for future refreshes. */
@@ -321,6 +332,20 @@ class HostWorkspacesViewModel @Inject constructor(
                     return@launch
                 }
             }
+            val entry = runCatching { connection.sftp().stat(canonicalPath) }.getOrElse { error ->
+                finishAdd(userMessage(error, "Could not inspect the workspace folder: "))
+                return@launch
+            }
+            when {
+                entry == null -> {
+                    finishAdd("That folder does not exist on the host.")
+                    return@launch
+                }
+                !entry.isDirectory -> {
+                    finishAdd("That path is a file, not a workspace folder.")
+                    return@launch
+                }
+            }
             clients.create(connection).addWorkspace(host.treeIdentity, canonicalPath).fold(
                 onSuccess = {
                     _state.update {
@@ -330,6 +355,7 @@ class HostWorkspacesViewModel @Inject constructor(
                             addWorkspaceRootPath = "",
                             addWorkspacePath = "",
                             addWorkspaceFailure = null,
+                            openWorkspacePath = canonicalPath,
                         )
                     }
                     refresh()
@@ -372,6 +398,20 @@ class HostWorkspacesViewModel @Inject constructor(
                 return@launch
             }
             val path = childPath(parent, name)
+            val existing = runCatching { connection.sftp().stat(path) }.getOrElse { error ->
+                finishFolder(userMessage(error, "Could not inspect the new folder: "))
+                return@launch
+            }
+            if (existing != null) {
+                finishFolder(
+                    if (existing.isDirectory) {
+                        "A folder already exists there. Add the existing folder instead."
+                    } else {
+                        "A file already exists there; choose a different folder name."
+                    },
+                )
+                return@launch
+            }
             runCatching { connection.sftp().mkdir(path) }.fold(
                 onFailure = { error ->
                     finishFolder(userMessage(error, "Could not create the folder: "))
@@ -499,13 +539,19 @@ class HostWorkspacesViewModel @Inject constructor(
                 ),
                 errors = sessions.errors,
                 failure = null,
+                statusUnavailable = false,
             )
         }
     }
 
     private fun fail(message: String) {
         _state.update { current ->
-            current.copy(loading = false, refreshing = false, failure = message)
+            current.copy(
+                loading = false,
+                refreshing = false,
+                failure = message,
+                statusUnavailable = current.loaded,
+            )
         }
     }
 

--- a/app2/src/main/java/com/pocketshell/next/workspaces/ReorderWorkspacesScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/workspaces/ReorderWorkspacesScreen.kt
@@ -78,15 +78,8 @@ fun ReorderWorkspacesScreen(
         ScreenHeader(
             title = "Reorder workspaces",
             subtitle = state.hostLabel,
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(REORDER_WORKSPACES_BACK_TAG),
-                )
-            },
+            onBack = onBack,
+            backTestTag = REORDER_WORKSPACES_BACK_TAG,
         )
 
         when {

--- a/app2/src/main/java/com/pocketshell/next/workspaces/SessionKindMark.kt
+++ b/app2/src/main/java/com/pocketshell/next/workspaces/SessionKindMark.kt
@@ -1,0 +1,34 @@
+package com.pocketshell.next.workspaces
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.pocketshell.uikit.icons.PocketShellIcons
+import com.pocketshell.uikit.theme.PocketShellColors
+
+/** Quiet, monochrome session mark used as metadata beside a readable name. */
+@Composable
+fun SessionKindMark(
+    agent: String?,
+    modifier: Modifier = Modifier,
+    showShell: Boolean = false,
+) {
+    val key = agent?.trim()?.lowercase()
+    val icon = when (key) {
+        "claude" -> PocketShellIcons.Hexagon
+        "codex" -> PocketShellIcons.Code
+        "opencode", "open_code", "open-code" -> PocketShellIcons.Terminal
+        "grok" -> PocketShellIcons.Zap
+        "shell", null, "", "unknown" -> if (showShell) PocketShellIcons.Terminal else null
+        else -> null
+    } ?: return
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = PocketShellColors.TextMuted,
+        modifier = modifier.size(18.dp),
+    )
+}

--- a/app2/src/main/java/com/pocketshell/next/workspaces/SessionKindSummary.kt
+++ b/app2/src/main/java/com/pocketshell/next/workspaces/SessionKindSummary.kt
@@ -1,0 +1,87 @@
+package com.pocketshell.next.workspaces
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.pocketshell.core.hostapi.SessionRow
+import com.pocketshell.uikit.theme.PocketShellColors
+import com.pocketshell.uikit.theme.PocketShellSpacing
+import com.pocketshell.uikit.theme.PocketShellType
+
+private data class KindGroup(
+    val label: String,
+    val agent: String?,
+    val count: Int,
+)
+
+/** Compact wrapped summary used under workspace rows in the host projection. */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun SessionKindSummary(
+    sessions: List<SessionRow>,
+    unavailable: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    if (unavailable) {
+        Text(
+            text = "Status unavailable",
+            color = PocketShellColors.TextMuted,
+            style = PocketShellType.metadata,
+            modifier = modifier,
+        )
+        return
+    }
+    if (sessions.isEmpty()) {
+        Text(
+            text = "No sessions",
+            color = PocketShellColors.TextMuted,
+            style = PocketShellType.metadata,
+            modifier = modifier,
+        )
+        return
+    }
+
+    val groups = buildList<KindGroup> {
+        sessions.forEach { session ->
+            val label = sessionKindLabel(session)
+            val index = indexOfFirst { it.label == label }
+            if (index == -1) {
+                add(KindGroup(label = label, agent = session.agent, count = 1))
+            } else {
+                val current = this[index]
+                this[index] = current.copy(count = current.count + 1)
+            }
+        }
+    }
+    FlowRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
+        verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.xs),
+    ) {
+        groups.take(3).forEach { group ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                SessionKindMark(agent = group.agent)
+                Text(
+                    text = if (group.count == 1) group.label else "${group.label} ×${group.count}",
+                    color = PocketShellColors.TextMuted,
+                    style = PocketShellType.metadata,
+                    modifier = Modifier.padding(start = PocketShellSpacing.xs),
+                )
+            }
+        }
+        if (groups.size > 3) {
+            Text(
+                text = "+${groups.size - 3} more kinds",
+                color = PocketShellColors.TextMuted,
+                style = PocketShellType.metadata,
+            )
+        }
+    }
+}

--- a/app2/src/main/java/com/pocketshell/next/workspaces/WorkspaceProjection.kt
+++ b/app2/src/main/java/com/pocketshell/next/workspaces/WorkspaceProjection.kt
@@ -43,6 +43,8 @@ data class WorkspaceProjection(
     val sessions: List<SessionRow>,
     /** True only when the host's durable membership list contains this path. */
     val durable: Boolean,
+    /** Durable membership order; inferred session workspaces sort after it. */
+    val membershipOrder: Int = Int.MAX_VALUE,
 )
 
 /**
@@ -84,6 +86,30 @@ fun sessionKindLabel(session: SessionRow): String = when (
         .filter(String::isNotBlank)
         .joinToString(" ") { word -> word.replaceFirstChar { it.uppercase() } }
         .ifBlank { "Terminal" }
+}
+
+/**
+ * Chooses a readable row label without changing the host identity used for
+ * navigation. Generated shell tags become "Terminal"; meaningful tags keep
+ * their short leaf so two sessions remain distinguishable.
+ */
+fun sessionDisplayNames(sessions: List<SessionRow>): Map<String, String> {
+    val occurrences = mutableMapOf<String, Int>()
+    return sessions.associate { session ->
+        val base = readableSessionName(session.name)
+        val occurrence = (occurrences[base] ?: 0) + 1
+        occurrences[base] = occurrence
+        session.name to if (occurrence == 1) base else "$base $occurrence"
+    }
+}
+
+/** Converts a host session identifier into the short name shown in the UI. */
+fun readableSessionName(name: String): String {
+    val leaf = name.substringAfterLast(':').trim()
+    return when (leaf.lowercase()) {
+        "", "shell", "terminal", "default" -> "Terminal"
+        else -> leaf
+    }
 }
 
 /** The label used for sessions that do not belong to a known root. */
@@ -133,32 +159,19 @@ fun projectWorkspaceRoots(
     configured.forEach { rootSpecs.putIfAbsent(it.key, it) }
 
     val canonicalMemberships = linkedMapOf<String, WorkspaceMembership>()
-    for (membership in memberships) {
+    val membershipOrders = mutableMapOf<String, Int>()
+    for ((membershipIndex, membership) in memberships.withIndex()) {
         val path = canonicalRemotePath(membership.path, resolvedHome) ?: continue
-        canonicalMemberships.putIfAbsent(
-            path,
-            membership.copy(
-                path = path,
-                displayPath = membership.displayPath.trim().ifEmpty { path },
-            ),
-        )
-    }
-
-    if (configured.isEmpty()) {
-        (canonicalMemberships.keys + sessions.mapNotNull { canonicalRemotePath(it.workspace, resolvedHome) })
-            .forEach { path ->
-                inferredRootForPath(path, resolvedHome)?.let { rootPath ->
-                    rootSpecs.putIfAbsent(
-                        rootPath,
-                        RootSpec(
-                            path = rootPath,
-                            label = pathLabel(rootPath, resolvedHome),
-                            order = Long.MAX_VALUE,
-                            configured = false,
-                        ),
-                    )
-                }
-            }
+        if (canonicalMemberships.putIfAbsent(
+                path,
+                membership.copy(
+                    path = path,
+                    displayPath = membership.displayPath.trim().ifEmpty { path },
+                ),
+            ) == null
+        ) {
+            membershipOrders[path] = membershipIndex
+        }
     }
 
     val rootBuckets = linkedMapOf<String, RootBucket>()
@@ -175,12 +188,18 @@ fun projectWorkspaceRoots(
                     configured = false,
                 )
             }
+        // A configured root is already a navigable host location. If the host
+        // registry also reports that exact path as a workspace, keep sessions
+        // in the root-level group rather than rendering a second child row
+        // with the same identity.
+        if (root.configured && path == root.path) continue
         val bucket = rootBuckets.getOrPut(root.key) { RootBucket(root) }
         val workspace = MutableWorkspace(
             path = path,
             displayPath = membership.displayPath,
             sessions = mutableListOf(),
             durable = true,
+            membershipOrder = membershipOrders[path] ?: Int.MAX_VALUE,
         )
         durableRows[path] = workspace
         bucket.workspaces[path] = workspace
@@ -227,6 +246,7 @@ fun projectWorkspaceRoots(
                         compareBy<MutableWorkspace> {
                             explicitOrder[it.path] ?: Int.MAX_VALUE
                         }
+                            .thenBy { it.membershipOrder }
                             .thenBy { workspaceCreated(it.sessions) }
                             .thenBy { it.path },
                     )
@@ -237,6 +257,7 @@ fun projectWorkspaceRoots(
                             displayPath = workspace.displayPath,
                             sessions = workspace.sessions.sortedWith(SESSION_ORDER),
                             durable = workspace.durable,
+                            membershipOrder = workspace.membershipOrder,
                         )
                     },
             )
@@ -309,6 +330,7 @@ private data class MutableWorkspace(
     val displayPath: String,
     val sessions: MutableList<SessionRow>,
     val durable: Boolean,
+    val membershipOrder: Int = Int.MAX_VALUE,
 )
 
 private const val OTHER_WORKSPACE_ROOT_KEY = "::quiet-other::"
@@ -347,24 +369,6 @@ private fun pathWithin(path: String, root: String?, home: String?): Boolean {
     val canonicalRoot = canonicalRemotePath(root, home) ?: return false
     val canonicalPath = canonicalRemotePath(path, home) ?: return false
     return canonicalPath == canonicalRoot || canonicalPath.startsWith("$canonicalRoot/")
-}
-
-private fun inferredRootForPath(path: String, home: String?): String? {
-    val canonicalHome = canonicalRemotePath(home)
-    if (canonicalHome != null) {
-        if (path == canonicalHome) return canonicalHome
-        if (path.startsWith("$canonicalHome/")) {
-            val relative = path.removePrefix("$canonicalHome/")
-            val first = relative.substringBefore('/').takeIf { it.isNotEmpty() } ?: return canonicalHome
-            return "$canonicalHome/$first"
-        }
-        return null
-    }
-    return if (path.startsWith('/')) {
-        path.split('/').filter { it.isNotEmpty() }.take(2).joinToString("/").let { "/$it" }
-    } else {
-        null
-    }
 }
 
 private fun inferRemoteHome(paths: List<String>): String? {

--- a/app2/src/main/java/com/pocketshell/next/workspaces/WorkspaceScreen.kt
+++ b/app2/src/main/java/com/pocketshell/next/workspaces/WorkspaceScreen.kt
@@ -4,11 +4,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,6 +26,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -49,9 +55,11 @@ import com.pocketshell.uikit.components.ConfirmDialog
 import com.pocketshell.uikit.components.EmptyState
 import com.pocketshell.uikit.components.Kebab
 import com.pocketshell.uikit.components.KebabItem
+import com.pocketshell.uikit.components.KebabTrigger
 import com.pocketshell.uikit.components.ListRow
 import com.pocketshell.uikit.components.PocketShellButton
 import com.pocketshell.uikit.components.ScreenHeader
+import com.pocketshell.uikit.components.SheetHeader
 import com.pocketshell.uikit.theme.PocketShellSpacing
 
 const val WORKSPACE_SCREEN_TAG: String = "workspace-screen"
@@ -107,6 +115,7 @@ fun WorkspaceRoute(
         onOpenReorder = onOpenReorder,
         onCreateSession = viewModel::openCreateSheet,
         onSubmitCreate = viewModel::createSession,
+        onRefreshEngines = viewModel::refreshEngines,
         onDismissCreate = viewModel::dismissCreateSheet,
         onRequestStop = viewModel::requestStopSession,
         onConfirmStop = viewModel::confirmStopSession,
@@ -135,6 +144,7 @@ fun WorkspaceScreen(
     modifier: Modifier = Modifier,
     onCreateSession: () -> Unit = {},
     onSubmitCreate: (CreateSessionRequest) -> Unit = {},
+    onRefreshEngines: () -> Unit = {},
     onDismissCreate: () -> Unit = {},
     onRequestStop: (String) -> Unit = {},
     onConfirmStop: () -> Unit = {},
@@ -146,7 +156,11 @@ fun WorkspaceScreen(
     onConfirmRemoveFromList: () -> Unit = {},
 ) {
     val clipboard = LocalClipboardManager.current
+    val displayNames = remember(state.workspaceSessions) {
+        sessionDisplayNames(state.workspaceSessions)
+    }
     var removeDialogVisible by remember { mutableStateOf(false) }
+    var workspaceActionsOpen by remember { mutableStateOf(false) }
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -155,53 +169,13 @@ fun WorkspaceScreen(
         ScreenHeader(
             title = workspaceLabel(state.workspacePath),
             subtitle = workspaceSubtitle(state),
-            titleMaxLines = Int.MAX_VALUE,
-            subtitleMaxLines = Int.MAX_VALUE,
-            leading = {
-                PocketShellButton(
-                    text = "Back",
-                    onClick = onBack,
-                    variant = ButtonVariant.Text,
-                    compact = true,
-                    modifier = Modifier.testTag(WORKSPACE_BACK_TAG),
-                )
-            },
+            titleMaxLines = 2,
+            subtitleMaxLines = 2,
+            onBack = onBack,
+            backTestTag = WORKSPACE_BACK_TAG,
             trailing = {
-                Kebab(
-                    items = listOf(
-                        KebabItem(
-                            label = WORKSPACE_NEW_SESSION_LABEL,
-                            onClick = onCreateSession,
-                            testTag = WORKSPACE_NEW_SESSION_TAG,
-                        ),
-                        KebabItem(label = "Files", onClick = onOpenFiles),
-                        KebabItem(label = "Ports", onClick = onOpenPorts),
-                        KebabItem(label = "Usage", onClick = onOpenUsage),
-                        KebabItem(
-                            label = "Copy folder path",
-                            onClick = {
-                                state.workspacePath?.let { path ->
-                                    clipboard.setText(AnnotatedString(path))
-                                }
-                            },
-                            testTag = WORKSPACE_COPY_PATH_TAG,
-                        ),
-                        KebabItem(
-                            label = "Reorder workspaces",
-                            onClick = onOpenReorder,
-                            testTag = WORKSPACE_REORDER_TAG,
-                        ),
-                        KebabItem(
-                            label = "Create folder",
-                            onClick = onOpenCreateFolder,
-                            testTag = WORKSPACE_CREATE_FOLDER_TAG,
-                        ),
-                        KebabItem(
-                            label = "Remove from list",
-                            onClick = { removeDialogVisible = true },
-                            testTag = WORKSPACE_REMOVE_FROM_LIST_TAG,
-                        ),
-                    ),
+                KebabTrigger(
+                    onClick = { workspaceActionsOpen = true },
                     contentDescription = "Workspace actions",
                     triggerTestTag = WORKSPACE_ACTIONS_TAG,
                 )
@@ -291,6 +265,7 @@ fun WorkspaceScreen(
                     ) { session ->
                         WorkspaceSessionRow(
                             session = session,
+                            displayName = displayNames[session.name] ?: session.name,
                             onClick = { onOpenSession(session.name) },
                             onRequestStop = { onRequestStop(session.name) },
                         )
@@ -318,8 +293,40 @@ fun WorkspaceScreen(
         CreateSessionSheet(
             state = state.create,
             defaultFolder = state.suggestedFolder,
+            existingSessionNames = state.workspaceSessions.map { it.name },
             onSubmit = onSubmitCreate,
             onCancel = onDismissCreate,
+            onRefreshEngines = onRefreshEngines,
+        )
+    }
+
+    if (workspaceActionsOpen) {
+        WorkspaceActionsSheet(
+            onNewSession = {
+                workspaceActionsOpen = false
+                onCreateSession()
+            },
+            onBrowseFiles = {
+                workspaceActionsOpen = false
+                onOpenFiles()
+            },
+            onCopyPath = {
+                workspaceActionsOpen = false
+                state.workspacePath?.let { path -> clipboard.setText(AnnotatedString(path)) }
+            },
+            onReorder = {
+                workspaceActionsOpen = false
+                onOpenReorder()
+            },
+            onCreateFolder = {
+                workspaceActionsOpen = false
+                onOpenCreateFolder()
+            },
+            onRemove = {
+                workspaceActionsOpen = false
+                removeDialogVisible = true
+            },
+            onDismiss = { workspaceActionsOpen = false },
         )
     }
 
@@ -375,7 +382,11 @@ fun WorkspaceScreen(
     state.pendingStop?.let { name ->
         ConfirmDialog(
             title = STOP_SESSION_TITLE,
-            message = stopSessionMessage(name),
+            message = stopSessionMessage(
+                name = readableSessionName(name),
+                workspace = state.workspacePath,
+                host = "host #${state.hostId}",
+            ),
             confirmLabel = STOP_SESSION_CONFIRM_LABEL,
             destructive = true,
             onConfirm = onConfirmStop,
@@ -388,18 +399,112 @@ fun WorkspaceScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WorkspaceActionsSheet(
+    onNewSession: () -> Unit,
+    onBrowseFiles: () -> Unit,
+    onCopyPath: () -> Unit,
+    onReorder: () -> Unit,
+    onCreateFolder: () -> Unit,
+    onRemove: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = com.pocketshell.uikit.theme.PocketShellColors.Surface,
+        shape = com.pocketshell.uikit.theme.PocketShellShapes.large,
+        modifier = Modifier.testTag(WORKSPACE_ACTIONS_TAG),
+    ) {
+        WorkspaceActionsContent(
+            onNewSession = onNewSession,
+            onBrowseFiles = onBrowseFiles,
+            onCopyPath = onCopyPath,
+            onReorder = onReorder,
+            onCreateFolder = onCreateFolder,
+            onRemove = onRemove,
+            onDismiss = onDismiss,
+        )
+    }
+}
+
+/** The workspace action body, separate from the modal container for deterministic UI tests. */
+@Composable
+internal fun WorkspaceActionsContent(
+    onNewSession: () -> Unit,
+    onBrowseFiles: () -> Unit,
+    onCopyPath: () -> Unit,
+    onReorder: () -> Unit,
+    onCreateFolder: () -> Unit,
+    onRemove: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = 560.dp)
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = PocketShellSpacing.lg),
+    ) {
+        SheetHeader(
+            title = "Workspace actions",
+            subtitle = "Manage this workspace",
+            onClose = onDismiss,
+        )
+        ListRow(
+            title = WORKSPACE_NEW_SESSION_LABEL,
+            subtitle = "Start another terminal here",
+            onClick = onNewSession,
+            modifier = Modifier.testTag(WORKSPACE_NEW_SESSION_TAG),
+        )
+        ListRow(
+            title = "Browse files",
+            subtitle = "Open this folder in Files",
+            onClick = onBrowseFiles,
+        )
+        ListRow(
+            title = "Copy folder path",
+            subtitle = "Copy the canonical remote path",
+            onClick = onCopyPath,
+            modifier = Modifier.testTag(WORKSPACE_COPY_PATH_TAG),
+        )
+        ListRow(
+            title = "Reorder workspaces",
+            subtitle = "Change the host list order",
+            onClick = onReorder,
+            modifier = Modifier.testTag(WORKSPACE_REORDER_TAG),
+        )
+        ListRow(
+            title = "Create folder",
+            subtitle = "Create a child folder here",
+            onClick = onCreateFolder,
+            modifier = Modifier.testTag(WORKSPACE_CREATE_FOLDER_TAG),
+        )
+        ListRow(
+            title = "Remove from list",
+            subtitle = "Keeps the folder and running sessions",
+            onClick = onRemove,
+            modifier = Modifier.testTag(WORKSPACE_REMOVE_FROM_LIST_TAG),
+        )
+    }
+}
+
 @Composable
 private fun WorkspaceSessionRow(
     session: SessionRow,
+    displayName: String = session.name,
     onClick: () -> Unit,
     onRequestStop: () -> Unit,
 ) {
     ListRow(
-        title = session.name,
+        title = displayName,
         subtitle = sessionKindLabel(session),
-        titleStyle = com.pocketshell.uikit.theme.PocketShellType.title,
+        leading = { SessionKindMark(agent = session.agent) },
+        titleStyle = com.pocketshell.uikit.theme.PocketShellType.body,
         subtitleStyle = com.pocketshell.uikit.theme.PocketShellType.metadata,
-        titleWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+        titleWeight = androidx.compose.ui.text.font.FontWeight.Medium,
+        titleMaxLines = 2,
         trailing = {
             Kebab(
                 items = listOf(

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerBarTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerBarTest.kt
@@ -140,7 +140,7 @@ class ComposerBarTest {
         composeRule.onNodeWithTag(COMPOSER_STAGING_TAG).assertIsDisplayed()
         composeRule.onNodeWithText("Uploading 2 of 3 · shot.png").assertIsDisplayed()
         composeRule.onNodeWithTag(COMPOSER_SEND_TAG).assertIsNotEnabled()
-        composeRule.onNodeWithTag(COMPOSER_ATTACH_TAG).assertIsNotEnabled()
+        composeRule.onNodeWithTag(COMPOSER_TOOLS_TRIGGER_TAG).assertIsNotEnabled()
     }
 
     @Test
@@ -160,6 +160,7 @@ class ComposerBarTest {
         composeRule.onNodeWithTag(COMPOSER_ATTACH_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(COMPOSER_HISTORY_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(COMPOSER_SLASH_TRIGGER_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_TOOLS_TRIGGER_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(COMPOSER_MIC_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(COMPOSER_SEND_TAG).assertIsDisplayed()
@@ -209,6 +210,7 @@ class ComposerBarTest {
         var toggled = 0
         setContent(ComposerUiState(), onToggleHistory = { toggled += 1 })
 
+        composeRule.onNodeWithTag(COMPOSER_TOOLS_TRIGGER_TAG).performClick()
         composeRule.onNodeWithTag(COMPOSER_HISTORY_TAG).performClick()
 
         assertEquals(1, toggled)
@@ -224,9 +226,10 @@ class ComposerBarTest {
     fun `idle controls sit on one row with grouped tools insert send and mic`() {
         setContent(ComposerUiState(draft = "hello", micAvailable = true))
 
-        composeRule.onNodeWithTag(COMPOSER_ATTACH_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(COMPOSER_HISTORY_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(COMPOSER_SLASH_TRIGGER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(COMPOSER_TOOLS_TRIGGER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(COMPOSER_ATTACH_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_HISTORY_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_SLASH_TRIGGER_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(COMPOSER_SEND_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(COMPOSER_MIC_TAG).assertIsDisplayed()
@@ -238,7 +241,7 @@ class ComposerBarTest {
         composeRule.onNodeWithTag(COMPOSER_DISCARD_TAG).assertDoesNotExist()
 
         assertSameRow(COMPOSER_INSERT_TAG, COMPOSER_SEND_TAG, COMPOSER_MIC_TAG)
-        assertSameRow(COMPOSER_ATTACH_TAG, COMPOSER_HISTORY_TAG, COMPOSER_SLASH_TRIGGER_TAG, COMPOSER_MIC_TAG)
+        assertSameRow(COMPOSER_TOOLS_TRIGGER_TAG, COMPOSER_INSERT_TAG, COMPOSER_SEND_TAG, COMPOSER_MIC_TAG)
     }
 
     /**
@@ -349,12 +352,12 @@ class ComposerBarTest {
         }
         val stop = controls.getValue(COMPOSER_STOP_RECORDING_TAG)
         assertEquals(
-            "the stop control is squashed — the recording row has run out of width",
-            44f,
+            "the stop control keeps the 48dp touch target",
+            48f,
             stop.width / density,
             0.5f,
         )
-        assertEquals(44f, stop.height / density, 0.5f)
+        assertEquals(48f, stop.height / density, 0.5f)
     }
 
     @Test
@@ -362,6 +365,7 @@ class ComposerBarTest {
         var draft = ""
         setContent(ComposerUiState(), onDraftChange = { draft = it })
 
+        composeRule.onNodeWithTag(COMPOSER_TOOLS_TRIGGER_TAG).performClick()
         composeRule.onNodeWithTag(COMPOSER_SLASH_TRIGGER_TAG).performClick()
 
         assertEquals("/", draft)

--- a/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/ComposerViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import com.pocketshell.next.settings.AppSettings
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -317,6 +318,52 @@ class ComposerViewModelTest {
 
         assertEquals("half-written thought", second.state.value.draft)
     }
+
+    @Test
+    fun `the first bound session surfaces an async send failure and rebinding keeps the new failure subscription`() =
+        runTest(dispatcher) {
+            hostId = stack.seedHost()
+            val firstSink = FailureRecordingSessionSink()
+            val secondSink = FailureRecordingSessionSink()
+            val viewModel = stack.viewModel()
+
+            viewModel.bind(hostId, SESSION, firstSink)
+            advanceUntilIdle()
+
+            viewModel.onDraftChange("first session message")
+            advanceUntilIdle()
+            viewModel.send()
+            advanceUntilIdle()
+
+            firstSink.fail()
+            advanceUntilIdle()
+
+            assertEquals("first session message", viewModel.state.value.draft)
+            assertEquals(ComposerNotice.DeliveryUncertain, viewModel.state.value.notice)
+
+            viewModel.bind(hostId, OTHER_SESSION, secondSink)
+            advanceUntilIdle()
+            assertEquals("", viewModel.state.value.draft)
+            assertNull(viewModel.state.value.notice)
+
+            viewModel.onDraftChange("second session message")
+            advanceUntilIdle()
+            viewModel.send()
+            advanceUntilIdle()
+
+            // A failure from the session being left must not be able to consume
+            // the pending delivery belonging to the new session.
+            firstSink.fail()
+            advanceUntilIdle()
+            assertEquals("", viewModel.state.value.draft)
+            assertNull(viewModel.state.value.notice)
+
+            secondSink.fail()
+            advanceUntilIdle()
+
+            assertEquals("second session message", viewModel.state.value.draft)
+            assertEquals(ComposerNotice.DeliveryUncertain, viewModel.state.value.notice)
+        }
 
     // ------------------------------------------------- rebinding across sessions
 
@@ -1120,6 +1167,18 @@ class ComposerViewModelTest {
     private val SESSION_KEY: String get() = "$hostId/$SESSION"
 
     private val SCOPE: String get() = "$hostId-$SESSION"
+
+    private class FailureRecordingSessionSink : SessionSink {
+        private val failures = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+        override val isLive: Boolean = true
+        override fun sendBytes(bytes: ByteArray) = Unit
+        override val sendFailures = failures
+
+        fun fail() {
+            check(failures.tryEmit(Unit)) { "the failure event was not accepted" }
+        }
+    }
 
     private companion object {
         const val SESSION = "devbox"

--- a/app2/src/test/java/com/pocketshell/next/composer/PromptComposerPermissionTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/composer/PromptComposerPermissionTest.kt
@@ -68,7 +68,7 @@ class PromptComposerPermissionTest {
     }
 
     @Test
-    fun `the title hides when the ime is up`() {
+    fun `the title stays visible when the ime is up`() {
         composeRule.setContent {
             PocketShellTheme {
                 PromptComposerContent(
@@ -90,7 +90,7 @@ class PromptComposerPermissionTest {
             }
         }
         composeRule.waitForIdle()
-        composeRule.onNodeWithTag(COMPOSER_TITLE_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(COMPOSER_TITLE_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(COMPOSER_DRAFT_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(COMPOSER_SEND_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(COMPOSER_INSERT_TAG).assertIsDisplayed()

--- a/app2/src/test/java/com/pocketshell/next/files/FileExplorerScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/files/FileExplorerScreenTest.kt
@@ -3,10 +3,12 @@ package com.pocketshell.next.files
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pocketshell.core.transport.SftpEntry
 import com.pocketshell.uikit.theme.PocketShellTheme
@@ -117,9 +119,26 @@ class FileExplorerScreenTest {
 
         composeRule.onNodeWithTag(FILE_EXPLORER_TRANSFER_TAG).assertIsDisplayed()
         composeRule.onNodeWithText("Uploading photo.png…").assertIsDisplayed()
-        composeRule.onNodeWithTag(FILE_EXPLORER_UPLOAD_TAG).assertIsNotEnabled()
         composeRule.onNodeWithTag(fileDownloadTag("a.txt")).assertIsNotEnabled()
-        // A running transfer has no dismiss — there is nothing to dismiss yet.
+    }
+
+    @Test
+    fun `file tools disable upload while a transfer is running`() {
+        composeRule.setContent {
+            PocketShellTheme {
+                FileToolsSheetContent(
+                    path = "/w",
+                    canUpload = false,
+                    onUpload = {},
+                    onCreateFolder = {},
+                    onNewTextFile = {},
+                    onOpenTransfers = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(FILE_EXPLORER_UPLOAD_TAG).assertHasNoClickAction()
         composeRule.onNodeWithText("Dismiss").assertDoesNotExist()
     }
 
@@ -149,15 +168,13 @@ class FileExplorerScreenTest {
 
     @Test
     fun `up is disabled at the root, where there is nowhere to go`() {
-        setContent(state(path = "/", loaded = true))
-
-        composeRule.onNodeWithTag(FILE_EXPLORER_UP_TAG).assertIsNotEnabled()
+        setToolsContent(path = "/", canGoUp = false)
+        composeRule.onNodeWithTag(FILE_EXPLORER_UP_TAG).assertHasNoClickAction()
     }
 
     @Test
     fun `up is enabled below the root`() {
-        setContent(state(path = "/home", loaded = true))
-
+        setToolsContent(path = "/home", canGoUp = true)
         composeRule.onNodeWithTag(FILE_EXPLORER_UP_TAG).assertIsEnabled()
     }
 
@@ -180,7 +197,7 @@ class FileExplorerScreenTest {
         composeRule.onNodeWithText("Upload files").performClick()
         composeRule.onNodeWithText("Create folder").performClick()
         composeRule.onNodeWithText("New text file").performClick()
-        composeRule.onNodeWithText("Transfers").performClick()
+        composeRule.onNodeWithText("Transfers").performScrollTo().performClick()
 
         assertEquals(listOf("upload", "folder", "new", "transfers"), actions)
     }
@@ -240,6 +257,23 @@ class FileExplorerScreenTest {
                 )
             }
         }
+    }
+
+    private fun setToolsContent(path: String, canGoUp: Boolean) {
+        composeRule.setContent {
+            PocketShellTheme {
+                FileToolsSheetContent(
+                    path = path,
+                    canGoUp = canGoUp,
+                    onUpload = {},
+                    onCreateFolder = {},
+                    onNewTextFile = {},
+                    onOpenTransfers = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
     }
 
     private fun state(

--- a/app2/src/test/java/com/pocketshell/next/files/ViewerScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/files/ViewerScreenTest.kt
@@ -110,21 +110,18 @@ class ViewerScreenTest {
     }
 
     @Test
-    fun `editing swaps the header actions for Save and Cancel`() {
+    fun `editing exposes Save in the header and leaves through the dirty sheet`() {
         var saved = 0
-        var cancelled = 0
         setContent(
             state(loaded = true, editing = true, draft = "x", content = ViewerContent.Text("x")),
             onSave = { saved += 1 },
-            onCancelEdit = { cancelled += 1 },
         )
 
         composeRule.onNodeWithTag(VIEWER_EDIT_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(VIEWER_SAVE_TAG).performClick()
-        composeRule.onNodeWithTag(VIEWER_CANCEL_TAG).performClick()
+        composeRule.onNodeWithTag(VIEWER_CANCEL_TAG).assertDoesNotExist()
 
         assertEquals(1, saved)
-        assertEquals(1, cancelled)
     }
 
     @Test
@@ -134,7 +131,7 @@ class ViewerScreenTest {
         )
 
         composeRule.onNodeWithTag(VIEWER_SAVE_TAG).assertIsNotEnabled()
-        composeRule.onNodeWithTag(VIEWER_CANCEL_TAG).assertIsNotEnabled()
+        composeRule.onNodeWithTag(VIEWER_CANCEL_TAG).assertDoesNotExist()
         composeRule.onNodeWithText("Saving…").assertIsDisplayed()
     }
 

--- a/app2/src/test/java/com/pocketshell/next/hosts/HostListNavigationTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/hosts/HostListNavigationTest.kt
@@ -132,20 +132,15 @@ class HostListNavigationTest {
     }
 
     @Test
-    fun `tapping Settings in the empty state navigates to Settings`() {
-        val nav = setContent()
+    fun `the empty state has one first-run action`() {
+        setContent()
 
         composeRule.waitUntil(timeoutMillis = 5_000) {
             composeRule.onAllNodesWithText("Your work, from here.").fetchSemanticsNodes().isNotEmpty()
         }
 
-        composeRule.onNodeWithTag(HOST_LIST_SETTINGS_TAG).performClick()
-        composeRule.waitUntil(timeoutMillis = 5_000) {
-            composeRule.onAllNodesWithText("Settings").fetchSemanticsNodes().isNotEmpty()
-        }
-
-        assertEquals(Destination.Settings.pattern, nav.currentBackStackEntry?.destination?.route)
-        composeRule.onNodeWithText("Settings").assertExists()
+        composeRule.onNodeWithText("Add host").assertExists()
+        composeRule.onNodeWithTag(HOST_LIST_SETTINGS_TAG).assertDoesNotExist()
     }
 
     /**

--- a/app2/src/test/java/com/pocketshell/next/hosts/QrChunkCodecTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/hosts/QrChunkCodecTest.kt
@@ -6,6 +6,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Base64
+import java.util.zip.CRC32
 
 /**
  * [QrChunkCodec] and [QrChunkAssembler] on the plain JVM — no Robolectric, no
@@ -18,6 +20,20 @@ import org.junit.Test
  * emitter's QRs from scanning, and nothing else in the build would notice.
  */
 class QrChunkCodecTest {
+
+    @Test
+    fun `a legacy 1500-byte v1 part remains decodable`() {
+        val chunk = "z".repeat(1500).toByteArray(Charsets.UTF_8)
+        val checksum = CRC32().apply { update(chunk) }.value.toString(16).padStart(8, '0')
+        val encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(chunk)
+        val envelope = QrChunkCodec.ENVELOPE_PREFIX +
+            "part=1/1&id=legacy15&checksum=$checksum&payload=$encoded"
+
+        val decoded = QrChunkCodec.decodePart(envelope).getOrThrow()
+
+        assertEquals(1500, decoded.chunk.size)
+        assertTrue(chunk.contentEquals(decoded.chunk))
+    }
 
     @Test
     fun `a small payload encodes as a single part and round-trips`() {

--- a/app2/src/test/java/com/pocketshell/next/hosts/SshKeyStoreTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/hosts/SshKeyStoreTest.kt
@@ -95,6 +95,19 @@ class SshKeyStoreTest {
     }
 
     @Test
+    fun `the unencrypted agents fixture reads its embedded public key`() = runTest {
+        val fixtureDir = File("../tests/docker")
+        val privateKey = File(fixtureDir, "test_key").readText()
+        val expectedPublicKey = File(fixtureDir, "test_key.pub").readText().trim()
+        val key = store.importKey("fixture-key", privateKey)
+
+        val actualPublicKey = requireNotNull(store.readPublicKey(key))
+        // The app deliberately emits its own stable comment; the authorized
+        // key payload is the contract shared with the fixture.
+        assertEquals(expectedPublicKey.substringBeforeLast(' '), actualPublicKey.substringBeforeLast(' '))
+    }
+
+    @Test
     fun `two generated keys are distinct rows with distinct files`() = runTest {
         val first = store.generateKey("k")
         val second = store.generateKey("k")

--- a/app2/src/test/java/com/pocketshell/next/hosts/SshKeysScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/hosts/SshKeysScreenTest.kt
@@ -4,9 +4,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.click
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -22,34 +20,23 @@ class SshKeysScreenTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun `detail copy action writes the complete public key to the clipboard`() {
+    fun `detail content copy action writes the complete public key to the clipboard`() {
         val publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIfixture pocketshell"
         val copiedValue = AtomicReference<String?>()
         composeRule.setContent {
-            SshKeysScreen(
-                state = SshKeysUiState(
-                    loaded = true,
-                    keys = listOf(SshKeyRow(7L, "work-key", "SHA256:fixture", publicKey = publicKey)),
-                ),
-                onBack = {},
-                onGenerate = {},
-                onImportPasted = { _, _ -> },
-                onPickFile = {},
-                onDelete = {},
-                onDismissMessage = {},
+            SshKeyDetailContent(
+                key = SshKeyRow(7L, "work-key", "SHA256:fixture", publicKey = publicKey),
+                onClose = {},
                 onCopyPublicKey = { copiedValue.set(it) },
+                onCopyFingerprint = {},
             )
         }
         composeRule.waitForIdle()
 
-        composeRule.onNodeWithTag(sshKeyRowTag(7L)).performClick()
-        composeRule.waitForIdle()
-        composeRule.mainClock.advanceTimeBy(1_000)
-        composeRule.waitForIdle()
         composeRule.onNodeWithTag(SSH_KEYS_COPY_PUBLIC_KEY_TAG)
             .performScrollTo()
             .assertIsDisplayed()
-            .performTouchInput { click() }
+            .performClick()
         composeRule.waitForIdle()
 
         assertEquals(publicKey, copiedValue.get())

--- a/app2/src/test/java/com/pocketshell/next/hosts/SshKeysViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/hosts/SshKeysViewModelTest.kt
@@ -103,6 +103,39 @@ class SshKeysViewModelTest {
     }
 
     @Test
+    fun `loading an unencrypted detail asynchronously exposes the complete public key`() = runTest {
+        viewModel.import("id_ed25519", UNENCRYPTED_PEM).join()
+        val row = viewModel.state.first { it.keys.isNotEmpty() }.keys.single()
+
+        viewModel.loadPublicKey(row.id).join()
+
+        val loaded = viewModel.state.value.keys.single()
+        assertFalse(loaded.publicKeyLoading)
+        assertEquals(SshKeyMaterial.publicKeyLine(UNENCRYPTED_PEM), loaded.publicKey)
+        assertNull(loaded.publicKeyError)
+    }
+
+    @Test
+    fun `loading a missing detail file leaves loading and reports a useful error`() = runTest {
+        val id = db.sshKeyDao().insert(
+            com.pocketshell.core.storage.entity.SshKeyEntity(
+                name = "missing",
+                privateKeyPath = File(temporaryFolder.root, "missing-key").absolutePath,
+            ),
+        )
+        val row = viewModel.state.first { it.keys.any { key -> key.id == id } }
+            .keys.single()
+
+        viewModel.loadPublicKey(row.id)
+
+        val failed = viewModel.state.first {
+            it.keys.single().publicKeyError != null && !it.keys.single().publicKeyLoading
+        }.keys.single()
+        assertEquals("The private key file is missing", failed.publicKeyError)
+        assertNull(failed.publicKey)
+    }
+
+    @Test
     fun `an encrypted key is added and defers passphrase entry until needed`() = runTest {
         viewModel.import("locked", ENCRYPTED_PEM).join()
 

--- a/app2/src/test/java/com/pocketshell/next/hosts/SshKeysViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/hosts/SshKeysViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.pocketshell.next.hosts
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.core.storage.AppDatabase
@@ -43,6 +46,7 @@ class SshKeysViewModelTest {
     private lateinit var db: AppDatabase
     private lateinit var keyStore: SshKeyStore
     private lateinit var viewModel: SshKeysViewModel
+    private val viewModelStore = ViewModelStore()
     private val unlocker = object : SshKeyUnlocker {
         override fun rememberPassphrase(keyId: Long, value: CharArray) = Unit
         override fun copyPassphrase(keyId: Long): CharArray? = null
@@ -61,11 +65,19 @@ class SshKeysViewModelTest {
             db.sshKeyDao(),
             UnconfinedTestDispatcher(),
         )
-        viewModel = SshKeysViewModel(db.sshKeyDao(), keyStore, unlocker)
+        val created = SshKeysViewModel(db.sshKeyDao(), keyStore, unlocker)
+        viewModel = ViewModelProvider(
+            viewModelStore,
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T = created as T
+            },
+        )[SshKeysViewModel::class.java]
     }
 
     @After
     fun tearDown() {
+        viewModelStore.clear()
         db.close()
         Dispatchers.resetMain()
     }

--- a/app2/src/test/java/com/pocketshell/next/ports/PortForwardScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/ports/PortForwardScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pocketshell.core.portfwd.AutoForwarderSupervisor.ConnectionState
@@ -88,6 +89,9 @@ class PortForwardScreenTest {
             onTogglePort = { toggled += it },
         )
 
+        composeRule
+            .onNodeWithTag(PORT_TABLE_TAG)
+            .performScrollToNode(hasText("9000"))
         composeRule.onNodeWithTag(portRowTag(9_000)).performClick()
 
         assertEquals(listOf(9_000), toggled)
@@ -231,8 +235,6 @@ class PortForwardScreenTest {
         setContent(state(enabled = false), onBack = { backs += 1 })
 
         composeRule.onNodeWithTag(PORT_FORWARD_BACK_TAG).assertIsDisplayed()
-        composeRule.onNodeWithText("Back").assertIsDisplayed()
-        composeRule.onNodeWithText("‹").assertDoesNotExist()
         composeRule.onNodeWithTag(PORT_FORWARD_BACK_TAG).performClick()
 
         assertEquals(1, backs)

--- a/app2/src/test/java/com/pocketshell/next/ports/ServicesScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/ports/ServicesScreenTest.kt
@@ -99,6 +99,29 @@ class ServicesScreenTest {
     }
 
     @Test
+    fun `only a verified active service exposes the browser action`() {
+        val opened = mutableListOf<String>()
+        setContent(
+            state(
+                enabled = true,
+                connection = ConnectionState.Connected,
+                rows = listOf(
+                    tunnel(5173, "vite", TunnelInfo.Status.FORWARDING, localPort = 35173),
+                    tunnel(8000, "python", TunnelInfo.Status.FORWARDING, localPort = 38000),
+                ),
+            ).copy(
+                verifiedHttpServices = mapOf(5173 to "http://127.0.0.1:35173"),
+            ),
+            onOpenBrowser = { opened += it },
+        )
+
+        composeRule.onNodeWithTag(serviceOpenTag(5173)).assertIsDisplayed().performClick()
+        composeRule.onNodeWithTag(serviceOpenTag(8000)).assertDoesNotExist()
+
+        assertEquals(listOf("http://127.0.0.1:35173"), opened)
+    }
+
+    @Test
     fun `lost connection shows an actionable error instead of an empty catalog`() {
         setContent(
             state(
@@ -116,6 +139,7 @@ class ServicesScreenTest {
         onSetDiscovery: (Boolean) -> Unit = {},
         onOpenTunnel: (Int) -> Unit = {},
         onAddTunnel: (Int?) -> Unit = {},
+        onOpenBrowser: (String) -> Unit = {},
     ) {
         composeRule.setContent {
             PocketShellTheme {
@@ -125,6 +149,8 @@ class ServicesScreenTest {
                     onSetDiscovery = onSetDiscovery,
                     onOpenTunnel = onOpenTunnel,
                     onAddTunnel = onAddTunnel,
+                    verifiedHttpServices = state.verifiedHttpServices,
+                    onOpenBrowser = onOpenBrowser,
                 )
             }
         }

--- a/app2/src/test/java/com/pocketshell/next/ports/TunnelDetailScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/ports/TunnelDetailScreenTest.kt
@@ -42,9 +42,28 @@ class TunnelDetailScreenTest {
         composeRule.onNodeWithText("Remove tunnel").assertDoesNotExist()
     }
 
+    @Test
+    fun `verified tunnel detail exposes browser handoff`() {
+        val opened = mutableListOf<String>()
+        setContent(
+            manual = false,
+            verifiedUrl = "https://127.0.0.1:35173",
+            onOpenBrowser = { opened += it },
+        )
+
+        composeRule.onNodeWithTag(TUNNEL_OPEN_BROWSER_TAG)
+            .performScrollTo()
+            .assertIsDisplayed()
+            .performClick()
+
+        assertEquals(listOf("https://127.0.0.1:35173"), opened)
+    }
+
     private fun setContent(
         manual: Boolean,
         onStop: () -> Unit = {},
+        verifiedUrl: String? = null,
+        onOpenBrowser: (String) -> Unit = {},
     ) {
         composeRule.setContent {
             PocketShellTheme {
@@ -60,6 +79,8 @@ class TunnelDetailScreenTest {
                     onBack = {},
                     onCopyAddress = {},
                     onStop = onStop,
+                    verifiedUrl = verifiedUrl,
+                    onOpenBrowser = onOpenBrowser,
                 )
             }
         }

--- a/app2/src/test/java/com/pocketshell/next/settings/SettingsNavigationTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/settings/SettingsNavigationTest.kt
@@ -63,6 +63,9 @@ class SettingsNavigationTest {
     fun setUp() {
         clearCrashReports()
         stack = TestConnectStack()
+        stack.factory.script = { connection ->
+            connection.sftpFixture().seedDirectory("/home/alexey/git/pocketshell")
+        }
         hostId = runBlocking {
             val keyId = stack.db.sshKeyDao().insert(SshKeyEntity(name = "k", privateKeyPath = "/tmp/k"))
             stack.db.hostDao().insert(
@@ -172,8 +175,6 @@ class SettingsNavigationTest {
         composeRule.waitForIdle()
 
         composeRule.onNodeWithTag(CRASH_REPORTS_BACK_TAG).assertExists()
-        composeRule.onNodeWithText("Back").assertExists()
-        composeRule.onNodeWithText("‹").assertDoesNotExist()
         composeRule.onNodeWithTag(CRASH_REPORTS_BACK_TAG).performClick()
         composeRule.waitForIdle()
 
@@ -250,6 +251,7 @@ class SettingsNavigationTest {
                         viewModel = WorkspaceRootsViewModel(
                             projectRootDao = stack.db.projectRootDao(),
                             hostDao = stack.db.hostDao(),
+                            registry = stack.registry,
                             savedStateHandle = SavedStateHandle(
                                 mapOf(Destination.ARG_HOST_ID to hostId),
                             ),

--- a/app2/src/test/java/com/pocketshell/next/settings/WorkspaceRootsScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/settings/WorkspaceRootsScreenTest.kt
@@ -37,7 +37,7 @@ class WorkspaceRootsScreenTest {
     }
 
     @Test
-    fun `typing a path and tapping add reports both fields and clears them`() {
+    fun `typing a path and tapping add reports both fields`() {
         var added: Pair<String, String>? = null
         setContent(onAddRoot = { label, path -> added = label to path })
 
@@ -46,8 +46,6 @@ class WorkspaceRootsScreenTest {
         composeRule.onNodeWithTag(WORKSPACE_ROOTS_ADD_TAG).performClick()
 
         assertEquals("Pocketshell" to "/home/alexey/git/pocketshell", added)
-        // The add control disables again once the fields it just cleared are empty.
-        composeRule.onNodeWithTag(WORKSPACE_ROOTS_ADD_TAG).assertIsNotEnabled()
     }
 
     @Test
@@ -72,8 +70,6 @@ class WorkspaceRootsScreenTest {
         setContent(onBack = { backCount++ })
 
         composeRule.onNodeWithTag(WORKSPACE_ROOTS_BACK_TAG).assertIsDisplayed()
-        composeRule.onNodeWithText("Back").assertIsDisplayed()
-        composeRule.onNodeWithText("‹").assertDoesNotExist()
         composeRule.onNodeWithTag(WORKSPACE_ROOTS_BACK_TAG).performClick()
 
         assertEquals(1, backCount)

--- a/app2/src/test/java/com/pocketshell/next/settings/WorkspaceRootsViewModelTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/settings/WorkspaceRootsViewModelTest.kt
@@ -6,6 +6,9 @@ import androidx.test.core.app.ApplicationProvider
 import com.pocketshell.core.storage.AppDatabase
 import com.pocketshell.core.storage.entity.HostEntity
 import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.next.connect.ConnectionsRegistry
+import com.pocketshell.next.connect.FakeHostConnectionFactory
+import com.pocketshell.next.connect.RoomTrustStore
 import com.pocketshell.next.nav.Destination
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -30,6 +33,7 @@ import org.robolectric.annotation.Config
 class WorkspaceRootsViewModelTest {
 
     private lateinit var db: AppDatabase
+    private lateinit var registry: ConnectionsRegistry
     private var hostId: Long = 0
 
     @Before
@@ -38,7 +42,27 @@ class WorkspaceRootsViewModelTest {
         db = Room.inMemoryDatabaseBuilder(
             ApplicationProvider.getApplicationContext(),
             AppDatabase::class.java,
-        ).allowMainThreadQueries().build()
+        )
+            .allowMainThreadQueries()
+            .setQueryExecutor { it.run() }
+            .setTransactionExecutor { it.run() }
+            .build()
+        val factory = FakeHostConnectionFactory()
+        factory.script = { connection ->
+            val sftp = connection.sftpFixture()
+            listOf(
+                "/home/alexey/git/pocketshell",
+                "/a",
+                "/b",
+                "/home/alexey/proj",
+            ).forEach(sftp::seedDirectory)
+        }
+        registry = ConnectionsRegistry(
+            factory = factory,
+            trustStore = RoomTrustStore(db.hostDao(), Dispatchers.Unconfined),
+            hostDao = db.hostDao(),
+            dispatcher = Dispatchers.Unconfined,
+        )
         runBlocking {
             val keyId = db.sshKeyDao().insert(SshKeyEntity(name = "k", privateKeyPath = "/tmp/k"))
             hostId = db.hostDao().insert(
@@ -56,6 +80,7 @@ class WorkspaceRootsViewModelTest {
     private fun viewModel(id: Long = hostId): WorkspaceRootsViewModel = WorkspaceRootsViewModel(
         projectRootDao = db.projectRootDao(),
         hostDao = db.hostDao(),
+        registry = registry,
         savedStateHandle = SavedStateHandle(mapOf(Destination.ARG_HOST_ID to id)),
         dispatcher = UnconfinedTestDispatcher(),
     )
@@ -124,10 +149,10 @@ class WorkspaceRootsViewModelTest {
         val roots = vm.state.first { it.roots.size == 2 }.roots
         val toDelete = roots.first { it.path == "/a" }
 
-        vm.deleteRoot(toDelete)
+        vm.deleteRoot(toDelete).join()
 
-        val remaining = vm.state.first { it.roots.size == 1 }.roots
-        assertEquals("/b", remaining.single().path)
+        val remaining = db.projectRootDao().getByHostId(hostId).first()
+        assertEquals(listOf("/b"), remaining.map { it.path })
     }
 
     @Test

--- a/app2/src/test/java/com/pocketshell/next/terminal/SessionScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/terminal/SessionScreenTest.kt
@@ -6,6 +6,9 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pocketshell.next.composer.COMPOSER_INSERT_TAG
 import com.pocketshell.next.composer.COMPOSER_SEND_TAG
@@ -16,15 +19,15 @@ import com.pocketshell.next.composer.ComposerNotice
 import com.pocketshell.next.composer.ComposerUiState
 import com.pocketshell.next.tree.STOP_SESSION_CANCEL_TAG
 import com.pocketshell.next.tree.STOP_SESSION_CONFIRM_TAG
-import com.pocketshell.next.tree.STOP_SESSION_ITEM_LABEL
+import com.pocketshell.next.tree.STOP_SESSION_ITEM_TAG
 import com.pocketshell.next.tree.STOP_SESSION_TITLE
 import com.pocketshell.next.tree.stopSessionMessage
-import com.pocketshell.next.usage.USAGE_GLANCE_PILL_TAG
 import com.pocketshell.next.usage.UsageGlancePillState
 import com.pocketshell.uikit.components.SESSION_COMPOSER_LAUNCHER_TAG
 import com.pocketshell.uikit.model.PillKind
 import com.pocketshell.uikit.components.SESSION_HOTKEYS_LAUNCHER_TAG
 import com.pocketshell.uikit.components.SESSION_LAUNCHER_BAR_TAG
+import com.pocketshell.next.terminal.TERMINAL_ACTIONS_USAGE_TAG
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -62,12 +65,13 @@ class SessionScreenTest {
     }
 
     @Test
-    fun `a failure shows the message it was given and never a terminal`() {
+    fun `an ended session shows the ended page and never a terminal`() {
         setContent(SessionUiState.Failed("Session \"$SESSION\" ended (exit 3)."))
 
-        composeRule.onNodeWithTag(SESSION_ERROR_BANNER_TAG).assertIsDisplayed()
-        composeRule.onNodeWithText("Session \"$SESSION\" ended (exit 3).").assertIsDisplayed()
-        // "attaching" and "not attached" must not look the same.
+        composeRule.onNodeWithTag(SESSION_ENDED_TAG).assertIsDisplayed()
+        composeRule.onNodeWithText("Session ended").assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_ERROR_BANNER_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(SESSION_LAUNCHER_BAR_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(SESSION_CONNECTING_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(SESSION_TERMINAL_TAG).assertDoesNotExist()
     }
@@ -78,8 +82,6 @@ class SessionScreenTest {
         setContent(SessionUiState.Connecting, onBack = { backs += 1 })
 
         composeRule.onNodeWithTag(SESSION_BACK_TAG).assertIsDisplayed()
-        composeRule.onNodeWithText("Back").assertIsDisplayed()
-        composeRule.onNodeWithText("‹").assertDoesNotExist()
         composeRule.onNodeWithTag(SESSION_BACK_TAG).performClick()
 
         assertEquals(1, backs)
@@ -91,20 +93,19 @@ class SessionScreenTest {
      * error belong on that screen, not as a missing button.
      */
     @Test
-    fun `usage is reachable when the glance pill has no reading`() {
+    fun `usage is reachable from terminal actions`() {
         var opened = 0
         setContent(SessionUiState.Connecting, onOpenUsage = { opened += 1 })
 
-        composeRule.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertDoesNotExist()
-        composeRule.onNodeWithTag(SESSION_USAGE_TAG).assertIsDisplayed()
-        composeRule.onNodeWithText("Usage").assertIsDisplayed()
-        composeRule.onNodeWithTag(SESSION_USAGE_TAG).performClick()
+        composeRule.onNodeWithTag(SESSION_USAGE_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(SESSION_HEADER_KEBAB_TAG).performClick()
+        composeRule.onNodeWithTag(TERMINAL_ACTIONS_USAGE_TAG).performClick()
 
         assertEquals(1, opened)
     }
 
     @Test
-    fun `the glance pill is the usage tap target when a reading exists`() {
+    fun `usage reading does not add a second header action`() {
         var opened = 0
         setContent(
             SessionUiState.Connecting,
@@ -120,8 +121,9 @@ class SessionScreenTest {
         )
 
         composeRule.onNodeWithTag(SESSION_USAGE_TAG).assertDoesNotExist()
-        composeRule.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(USAGE_GLANCE_PILL_TAG).performClick()
+        composeRule.onNodeWithTag(SESSION_HEADER_KEBAB_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_HEADER_KEBAB_TAG).performClick()
+        composeRule.onNodeWithTag(TERMINAL_ACTIONS_USAGE_TAG).performClick()
 
         assertEquals(1, opened)
     }
@@ -148,16 +150,15 @@ class SessionScreenTest {
             ),
         )
 
-        composeRule.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertIsDisplayed()
-        composeRule.onNodeWithText("Claude").assertIsDisplayed()
-        composeRule.onNodeWithText("38%").assertIsDisplayed()
-        // The tokens the cross-provider pill would have shown must be absent.
+        composeRule.onNodeWithTag(SESSION_USAGE_TAG).assertDoesNotExist()
+        // Usage readings stay in the usage page rather than crowding the terminal header.
+        composeRule.onNodeWithTag(SESSION_HEADER_KEBAB_TAG).assertIsDisplayed()
+        // The tokens the old cross-provider pill would have shown must be absent.
+        composeRule.onNodeWithText("Claude").assertDoesNotExist()
+        composeRule.onNodeWithText("38%").assertDoesNotExist()
         composeRule.onNodeWithText("Claude 7d").assertDoesNotExist()
         composeRule.onNodeWithText("7d").assertDoesNotExist()
         composeRule.onNodeWithText("5h").assertDoesNotExist()
-        composeRule
-            .onNodeWithContentDescription("Usage Claude 38%")
-            .assertIsDisplayed()
     }
 
     @Test
@@ -321,11 +322,12 @@ class SessionScreenTest {
     }
 
     @Test
-    fun `a failed session keeps the composer launcher so a draft can still be kept`() {
-        setContent(SessionUiState.Failed("no route to host"))
+    fun `an ended session has no composer launcher`() {
+        setContent(SessionUiState.Failed("Session \"$SESSION\" ended (exit 3)."))
 
-        composeRule.onNodeWithTag(SESSION_ERROR_BANNER_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_ENDED_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(SESSION_ERROR_BANNER_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(SESSION_COMPOSER_LAUNCHER_TAG).assertDoesNotExist()
         composeRule.onNodeWithTag(SESSION_HOTKEYS_LAUNCHER_TAG).assertDoesNotExist()
     }
 
@@ -344,7 +346,7 @@ class SessionScreenTest {
     }
 
     @Test
-    fun `header kebab Stop session confirms then reports the name`() {
+    fun `header kebab End session confirms with host context`() {
         var stopped = 0
         setContent(
             SessionUiState.Live(createRemoteTerminalSession()),
@@ -352,10 +354,11 @@ class SessionScreenTest {
         )
 
         composeRule.onNodeWithTag(SESSION_HEADER_KEBAB_TAG).performClick()
-        composeRule.onNodeWithText(STOP_SESSION_ITEM_LABEL).assertIsDisplayed()
-        composeRule.onNodeWithText(STOP_SESSION_ITEM_LABEL).performClick()
+        composeRule.onNodeWithTag(TERMINAL_ACTIONS_SHEET_TAG).performTouchInput { swipeUp() }
+        composeRule.onNodeWithTag(STOP_SESSION_ITEM_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(STOP_SESSION_ITEM_TAG).performClick()
         composeRule.onNodeWithText(STOP_SESSION_TITLE).assertIsDisplayed()
-        composeRule.onNodeWithText(stopSessionMessage(SESSION)).assertIsDisplayed()
+        composeRule.onNodeWithText(stopSessionMessage(SESSION, host = "this host")).assertIsDisplayed()
         composeRule.onNodeWithTag(STOP_SESSION_CONFIRM_TAG).performClick()
 
         assertEquals(1, stopped)
@@ -370,7 +373,8 @@ class SessionScreenTest {
         )
 
         composeRule.onNodeWithTag(SESSION_HEADER_KEBAB_TAG).performClick()
-        composeRule.onNodeWithText(STOP_SESSION_ITEM_LABEL).performClick()
+        composeRule.onNodeWithTag(TERMINAL_ACTIONS_SHEET_TAG).performTouchInput { swipeUp() }
+        composeRule.onNodeWithTag(STOP_SESSION_ITEM_TAG).performClick()
         composeRule.onNodeWithTag(STOP_SESSION_CANCEL_TAG).performClick()
 
         assertEquals(0, stopped)

--- a/app2/src/test/java/com/pocketshell/next/tree/CreateSessionSheetTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/CreateSessionSheetTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -52,11 +54,12 @@ class CreateSessionSheetTest {
 
         composeRule.onNodeWithTag(CREATE_SESSION_SHEET_TAG).assertIsDisplayed()
         composeRule.onNodeWithText(CREATE_SESSION_TITLE).assertIsDisplayed()
-        composeRule.onNodeWithText(CREATE_SESSION_HINT).assertIsDisplayed()
-        composeRule.onNodeWithTag(CREATE_SESSION_FOLDER_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(CREATE_SESSION_NAME_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_TYPE_SHELL_TAG).performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_TYPE_AGENT_TAG).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("More options").performScrollTo().performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(CREATE_SESSION_FOLDER_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(CREATE_SESSION_NAME_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_CANCEL_TAG).assertIsDisplayed()
 
@@ -160,6 +163,8 @@ class CreateSessionSheetTest {
         composeRule.onNodeWithTag(CREATE_SESSION_ERROR_TAG).assertIsDisplayed()
         composeRule.onNodeWithText(failure).assertIsDisplayed()
         // Still editable and still submittable — this is a retry, not a dead end.
+        composeRule.onNodeWithText("More options").performScrollTo().performClick()
+        composeRule.waitForIdle()
         composeRule.onNodeWithTag(CREATE_SESSION_FOLDER_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).assertIsEnabled()
     }
@@ -200,8 +205,9 @@ class CreateSessionSheetTest {
 
         composeRule.onNodeWithTag(createSessionEngineTag("claude")).performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithTag(createSessionEngineTag("codex")).performScrollTo().assertIsDisplayed()
-        composeRule.onNodeWithTag(createSessionEngineTag("opencode")).assertDoesNotExist()
-        composeRule.onNodeWithTag(createSessionEngineTag("disabled")).assertDoesNotExist()
+        composeRule.onNodeWithTag(createSessionEngineTag("opencode")).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithTag(createSessionEngineTag("disabled")).performScrollTo().assertIsDisplayed()
+        composeRule.onAllNodesWithText("Not available", substring = true).assertCountEquals(2)
         composeRule.onNodeWithText("Claude").assertIsDisplayed()
         composeRule.onNodeWithText("Codex").assertIsDisplayed()
     }
@@ -228,6 +234,8 @@ class CreateSessionSheetTest {
         )
 
         composeRule.onNodeWithTag(createSessionEngineTag("claude")).performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("More options").performScrollTo().performClick()
+        composeRule.waitForIdle()
         composeRule.onNodeWithTag(CREATE_SESSION_PROFILE_TAG).performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithTag(CREATE_SESSION_SUBMIT_TAG).assertIsEnabled().performClick()
 

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeNavigationTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeNavigationTest.kt
@@ -14,8 +14,8 @@ import com.pocketshell.next.connect.TestConnectStack
 import com.pocketshell.next.nav.Destination
 import com.pocketshell.next.ports.PortForwardUiState
 import com.pocketshell.next.ports.SERVICES_SCREEN_TAG
+import com.pocketshell.next.ports.SERVICES_BACK_TAG
 import com.pocketshell.next.ports.ServicesScreen
-import com.pocketshell.next.usage.USAGE_BACK_TAG
 import com.pocketshell.next.usage.USAGE_SCREEN_TAG
 import com.pocketshell.next.usage.UsageScreen
 import com.pocketshell.next.usage.UsageScreenState
@@ -60,11 +60,10 @@ class SessionTreeNavigationTest {
 
     @Test
     fun `tree Usage opens the usage panel`() {
-        val nav = setContentWithNav()
+        val nav = setContentWithNav(directHostTools = true)
         composeRule.runOnUiThread { nav.navigate(Destination.Tree.route(hostId = 7)) }
         composeRule.waitForIdle()
 
-        composeRule.onNodeWithTag(SESSION_TREE_USAGE_TAG).assertIsDisplayed()
         composeRule.onNodeWithTag(SESSION_TREE_USAGE_TAG).performClick()
         composeRule.waitForIdle()
 
@@ -81,14 +80,14 @@ class SessionTreeNavigationTest {
         composeRule.waitForIdle()
 
         composeRule.onNodeWithTag(SERVICES_SCREEN_TAG).assertIsDisplayed()
-        composeRule.onNodeWithText("Back").performClick()
+        composeRule.onNodeWithTag(SERVICES_BACK_TAG).performClick()
         composeRule.waitForIdle()
 
         assertEquals(Destination.Tree.pattern, nav.currentBackStackEntry?.destination?.route)
         composeRule.onNodeWithTag(SESSION_TREE_TAG).assertIsDisplayed()
     }
 
-    private fun setContentWithNav(): NavHostController {
+    private fun setContentWithNav(directHostTools: Boolean = false): NavHostController {
         lateinit var controller: NavHostController
         composeRule.setContent {
             controller = rememberNavController()
@@ -98,15 +97,24 @@ class SessionTreeNavigationTest {
                     hostsScreen = { Text("Hosts") },
                     connectViewModel = { stack.viewModel },
                     workspacesScreen = { _, _, _, _, _, onOpenPorts, onBack, onOpenUsage ->
-                        SessionTreeScreen(
-                            state = SessionTreeUiState(hostId = 7, loaded = true),
-                            onRefresh = {},
-                            onOpenSession = {},
-                            onOpenFiles = {},
-                            onOpenPorts = onOpenPorts,
-                            onBack = onBack,
-                            onOpenUsage = onOpenUsage,
-                        )
+                        if (directHostTools) {
+                            SessionTreeHostToolsContent(
+                                onOpenFiles = {},
+                                onOpenPorts = onOpenPorts,
+                                onOpenUsage = onOpenUsage,
+                                onDismiss = {},
+                            )
+                        } else {
+                            SessionTreeScreen(
+                                state = SessionTreeUiState(hostId = 7, loaded = true),
+                                onRefresh = {},
+                                onOpenSession = {},
+                                onOpenFiles = {},
+                                onOpenPorts = onOpenPorts,
+                                onBack = onBack,
+                                onOpenUsage = onOpenUsage,
+                            )
+                        }
                     },
                     servicesScreen = { onBack, _, _ ->
                         ServicesScreen(

--- a/app2/src/test/java/com/pocketshell/next/tree/SessionTreeScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/tree/SessionTreeScreenTest.kt
@@ -17,7 +17,6 @@ import com.pocketshell.core.hostapi.SessionListError
 import com.pocketshell.core.hostapi.SessionRow
 import com.pocketshell.next.usage.USAGE_GLANCE_PILL_TAG
 import com.pocketshell.next.usage.UsageGlancePillState
-import com.pocketshell.uikit.model.PillKind
 import com.pocketshell.uikit.theme.PocketShellTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -102,7 +101,7 @@ class SessionTreeScreenTest {
     }
 
     @Test
-    fun `a row shows relative activity and never engine, tag or implementation text`() {
+    fun `a row shows a readable name and kind instead of raw identifiers`() {
         setContent(
             state(
                 loaded = true,
@@ -112,15 +111,16 @@ class SessionTreeScreenTest {
                         "/home/a/git/aplexer",
                         activity = NOW - 7_200,
                                                 tag = "yolo",
-                        engine = "codex",
+                        agent = "codex",
                     ),
                 ),
             ),
         )
 
-        composeRule.onNodeWithText("2h ago").assertIsDisplayed()
-        composeRule.onNodeWithText("aplexer · yolo · 2h ago").assertDoesNotExist()
-        composeRule.onNodeWithContentDescription("codex").assertDoesNotExist()
+        composeRule.onNodeWithText("yolo").assertIsDisplayed()
+        composeRule.onNodeWithText("Codex").assertIsDisplayed()
+        composeRule.onNodeWithText("2h ago").assertDoesNotExist()
+        composeRule.onNodeWithText("aplexer-follow:yolo").assertDoesNotExist()
     }
 
     @Test
@@ -143,7 +143,7 @@ class SessionTreeScreenTest {
      * Attached is the green dot only.
      */
     @Test
-    fun `the tree has no agent badge or chip and an attached row keeps its green dot`() {
+    fun `the tree has no agent badge, chip or connection status dot`() {
         setContent(
             state(
                 loaded = true,
@@ -174,7 +174,7 @@ class SessionTreeScreenTest {
         composeRule.onNodeWithContentDescription("Working").assertDoesNotExist()
         composeRule.onNodeWithContentDescription("claude").assertDoesNotExist()
         composeRule.onNodeWithContentDescription("codex").assertDoesNotExist()
-        composeRule.onNodeWithContentDescription(ATTACHED_DESCRIPTION).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(ATTACHED_DESCRIPTION).assertDoesNotExist()
         composeRule.onNodeWithTag(sessionRowTag("waiting-agent")).assertIsDisplayed()
     }
 
@@ -235,17 +235,20 @@ class SessionTreeScreenTest {
      * test is RED until that action exists and fires `onOpenPorts`.
      */
     @Test
-    fun `tapping Ports in the header opens port forwarding`() {
+    fun `host tools exposes the ports action`() {
         var files = 0
         var ports = 0
-        setContent(
-            state(loaded = true, sessions = listOf(row("claude-main", "/w", activity = NOW))),
-            onOpenFiles = { files += 1 },
-            onOpenPorts = { ports += 1 },
-        )
-
-        composeRule.onNodeWithTag(SESSION_TREE_FILES_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(SESSION_TREE_PORTS_TAG).assertIsDisplayed()
+        composeRule.setContent {
+            PocketShellTheme {
+                SessionTreeHostToolsContent(
+                    onOpenFiles = { files += 1 },
+                    onOpenPorts = { ports += 1 },
+                    onOpenUsage = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
         composeRule.onNodeWithTag(SESSION_TREE_PORTS_TAG).performClick()
 
         assertEquals(1, ports)
@@ -266,8 +269,6 @@ class SessionTreeScreenTest {
         )
 
         composeRule.onNodeWithTag(SESSION_TREE_BACK_TAG).assertIsDisplayed()
-        composeRule.onNodeWithText("Back").assertIsDisplayed()
-        composeRule.onNodeWithText("‹").assertDoesNotExist()
         composeRule.onNodeWithTag(SESSION_TREE_BACK_TAG).performClick()
 
         assertEquals(1, backs)
@@ -279,38 +280,40 @@ class SessionTreeScreenTest {
      * caller; this test is RED until that action exists and fires `onOpenUsage`.
      */
     @Test
-    fun `tapping Usage in the header opens the usage panel`() {
+    fun `host tools exposes the usage action`() {
         var usage = 0
-        setContent(
-            state(loaded = true, sessions = listOf(row("claude-main", "/w", activity = NOW))),
-            onOpenUsage = { usage += 1 },
-        )
-
-        composeRule.onNodeWithTag(SESSION_TREE_USAGE_TAG).assertIsDisplayed()
+        composeRule.setContent {
+            PocketShellTheme {
+                SessionTreeHostToolsContent(
+                    onOpenFiles = {},
+                    onOpenPorts = {},
+                    onOpenUsage = { usage += 1 },
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
         composeRule.onNodeWithTag(SESSION_TREE_USAGE_TAG).performClick()
 
         assertEquals(1, usage)
     }
 
     @Test
-    fun `a glance pill sits beside Usage when a reading exists and also opens the panel`() {
+    fun `host tools keeps usage out of the tree header`() {
         var usage = 0
-        setContent(
-            state(loaded = true, sessions = listOf(row("claude-main", "/w", activity = NOW))),
-            onOpenUsage = { usage += 1 },
-            usagePillState = UsageGlancePillState(
-                percent = 72,
-                provider = "Codex",
-                window = "7d",
-                kind = PillKind.Warn,
-                stale = false,
-                fetchedClock = "13:40",
-            ),
-        )
-
-        composeRule.onNodeWithTag(SESSION_TREE_USAGE_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertIsDisplayed()
-        composeRule.onNodeWithTag(USAGE_GLANCE_PILL_TAG).performClick()
+        composeRule.setContent {
+            PocketShellTheme {
+                SessionTreeHostToolsContent(
+                    onOpenFiles = {},
+                    onOpenPorts = {},
+                    onOpenUsage = { usage += 1 },
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(USAGE_GLANCE_PILL_TAG).assertDoesNotExist()
+        composeRule.onNodeWithTag(SESSION_TREE_USAGE_TAG).performClick()
 
         assertEquals(1, usage)
     }
@@ -453,7 +456,9 @@ class SessionTreeScreenTest {
 
         composeRule.onNodeWithTag(STOP_SESSION_TITLE_TAG).assertIsDisplayed()
         composeRule.onNodeWithText(STOP_SESSION_TITLE).assertIsDisplayed()
-        composeRule.onNodeWithText(stopSessionMessage("api")).assertIsDisplayed()
+        composeRule.onNodeWithText(
+            stopSessionMessage("api", workspace = "/w", host = "host #7"),
+        ).assertIsDisplayed()
         composeRule.onNodeWithTag(STOP_SESSION_CONFIRM_TAG).performClick()
 
         assertEquals(1, confirmed)
@@ -534,6 +539,7 @@ class SessionTreeScreenTest {
         activity: Long?,
         tag: String? = null,
         engine: String? = null,
+        agent: String? = null,
         attached: Boolean = false,
         agentState: AgentState? = null,
         agentStateSource: AgentStateSource? = null,
@@ -545,7 +551,7 @@ class SessionTreeScreenTest {
         tag = tag,
         engine = engine,
         profile = null,
-        agent = null,
+        agent = agent,
         agentState = agentState,
         agentStateSource = agentStateSource,
         attached = attached,

--- a/app2/src/test/java/com/pocketshell/next/usage/UsageScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/usage/UsageScreenTest.kt
@@ -55,8 +55,6 @@ class UsageScreenTest {
         }
 
         composeRule.onNodeWithTag(USAGE_BACK_TAG).assertIsDisplayed()
-        composeRule.onNodeWithText("Back").assertIsDisplayed()
-        composeRule.onNodeWithText("‹").assertDoesNotExist()
         composeRule.onNodeWithTag(USAGE_BACK_TAG).performClick()
 
         assertEquals(1, backs)

--- a/app2/src/test/java/com/pocketshell/next/workspaces/QuietWorkspaceScreenTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/workspaces/QuietWorkspaceScreenTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pocketshell.core.hostapi.SessionRow
 import com.pocketshell.next.tree.SessionTreeUiState
@@ -374,17 +375,21 @@ class QuietWorkspaceScreenTest {
     @Test
     fun `workspace actions expose folder creation and removal`() {
         val openedCreate = mutableListOf<Boolean>()
-        setWorkspaceContent(
-            state = SessionTreeUiState(
-                hostId = 7,
-                workspacePath = "/home/alexey/git/empty",
-                loaded = true,
-            ),
-            onOpenCreateFolder = { openedCreate += true },
-        )
-
-        composeRule.onNodeWithTag(WORKSPACE_ACTIONS_TAG).performClick()
-        composeRule.onNodeWithTag(WORKSPACE_CREATE_FOLDER_TAG).performClick()
+        composeRule.setContent {
+            PocketShellTheme {
+                WorkspaceActionsContent(
+                    onNewSession = {},
+                    onBrowseFiles = {},
+                    onCopyPath = {},
+                    onReorder = {},
+                    onCreateFolder = { openedCreate += true },
+                    onRemove = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(WORKSPACE_CREATE_FOLDER_TAG).performScrollTo().performClick()
         assertEquals(listOf(true), openedCreate)
     }
 

--- a/app2/src/test/java/com/pocketshell/next/workspaces/WorkspaceProjectionTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/workspaces/WorkspaceProjectionTest.kt
@@ -36,6 +36,10 @@ class WorkspaceProjectionTest {
                 WorkspaceMembership("/home/alexey/git/app", "~/git/app"),
                 WorkspaceMembership("/home/alexey/work/app", "~/work/app"),
             ),
+            registeredRoots = listOf(
+                RegisteredWorkspaceRoot("/home/alexey/git", "Git"),
+                RegisteredWorkspaceRoot("/home/alexey/work", "Work"),
+            ),
         )
 
         assertEquals(listOf("~/git", "~/work"), result.map { it.displayPath })
@@ -67,6 +71,22 @@ class WorkspaceProjectionTest {
 
         val root = result.single()
         assertEquals("Git", root.label)
+        assertEquals(listOf("root-shell"), root.rootSessions.map { it.name })
+        assertEquals(listOf("app"), root.workspaces.map { it.label })
+    }
+
+    @Test
+    fun `a membership equal to a configured root does not create a duplicate child`() {
+        val result = projectWorkspaceRoots(
+            sessions = listOf(session("root-shell", "/home/alexey/git")),
+            memberships = listOf(
+                WorkspaceMembership("/home/alexey/git", "~/git"),
+                WorkspaceMembership("/home/alexey/git/app", "~/git/app"),
+            ),
+            registeredRoots = listOf(RegisteredWorkspaceRoot("/home/alexey/git", "Git")),
+        )
+
+        val root = result.single()
         assertEquals(listOf("root-shell"), root.rootSessions.map { it.name })
         assertEquals(listOf("app"), root.workspaces.map { it.label })
     }

--- a/scripts/check-component-drift.sh
+++ b/scripts/check-component-drift.sh
@@ -12,7 +12,7 @@
 # on the current clean tree and FAILS when a file gains a NEW one (or a
 # brand-new file ships with any).
 #
-# What counts as a raw call-site (in app/src/main + shared/ui-kit/src/main,
+# What counts as a raw call-site (in app2/src/main + shared/ui-kit/src/main,
 # *.kt only): a call to one of these Material widgets, i.e. the widget name
 # immediately followed by `(`:
 #   - AlertDialog(               -> use ConfirmDialog / FormDialog (ui-kit)
@@ -22,10 +22,9 @@
 # Import lines are excluded (an `import androidx...AlertDialog` is not a use).
 # The shared ui-kit wrapper components (ConfirmDialog.kt, FormDialog.kt,
 # LoadingIndicator.kt, PocketShellButton.kt, HostCard.kt) are the canonical
-# implementations — they are SUPPOSED to call the raw widget exactly once, so
-# their call-sites live in the baseline like any other accepted site. Lowering
-# a count (by migrating a screen) is encouraged and the script tells you to
-# re-baseline when a count drops.
+# implementations — their raw call-sites are accepted and live in the baseline
+# like any other accepted site. Lowering a count (by migrating a screen) is
+# encouraged and the script tells you to re-baseline when a count drops.
 #
 # Usage:
 #   scripts/check-component-drift.sh            # check against the committed baseline
@@ -36,7 +35,7 @@
 #   0  no NEW drift (counts <= baseline)            [also: --update succeeded]
 #   1  NEW drift found (a file exceeds its baseline, or a new file has raw uses)
 #
-# Cheap: pure grep over two source roots, runs in well under a second. Wired
+# Cheap: pure grep over the two live source roots, runs in well under a second. Wired
 # into the Unit job of .github/workflows/tests.yml (a fast static grep — it does
 # NOT need the emulator job).
 set -euo pipefail
@@ -45,7 +44,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-SCAN_DIRS=(app/src/main shared/ui-kit/src/main)
+SCAN_DIRS=(app2/src/main shared/ui-kit/src/main)
 BASELINE_FILE="scripts/component-drift-baseline.txt"
 
 # The raw Material call-sites we guard. `\b<name>[[:space:]]*\(` matches the
@@ -66,11 +65,11 @@ current_counts() {
     | sort
 }
 
-# Mutation-sensitive proof for the guard itself. The production FileViewer
-# source is copied into a temporary miniature tree, then each migrated form
-# dialog is changed back to a raw AlertDialog in isolation. The real guard must
-# reject both mutations; otherwise a green count check could be disconnected
-# from the source boundary it is meant to protect.
+# Mutation-sensitive proof for the guard itself. Real production sources from
+# both live roots are copied into a temporary miniature tree, then raw calls
+# are added in isolation. The real guard must reject each mutation; otherwise
+# a green count check could be disconnected from the source boundary it is
+# meant to protect.
 self_test() (
   set -euo pipefail
 
@@ -78,19 +77,24 @@ self_test() (
   sandbox="$(mktemp -d "${TMPDIR:-/tmp}/component-drift-selftest.XXXXXX")"
   trap 'rm -rf -- "$sandbox"' EXIT
 
-  # The fixture is a REAL baselined file, so the self-test cannot drift away
-  # from the thing it validates. It used to be the old app module's
-  # FileViewerScreen.kt (mutating its two FormDialog call-sites); the rewrite
-  # deleted that file and every other `app/` entry in the baseline, so the
-  # fixture moved to a surviving ui-kit wrapper. ConfirmDialog.kt is baselined at
-  # exactly 1 accepted raw AlertDialog( call — the wrapper's own — which is the
-  # shape the assertion below needs.
+  # These fixtures are REAL production files, so the self-test cannot drift
+  # away from the source it validates. The shared fixture keeps the existing
+  # three-widget mutation coverage. The app2 fixture proves the live app source
+  # root is scanned too; it has no raw calls and therefore relies on the guard's
+  # default zero baseline until a mutation adds one.
   local fixture_rel="shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ConfirmDialog.kt"
+  local app2_fixture_rel="app2/src/main/java/com/pocketshell/next/settings/SettingsScreen.kt"
   scan_source="$sandbox/$fixture_rel"
   clean_source="$sandbox/clean/ConfirmDialog.kt"
-  mkdir -p "$(dirname "$scan_source")" "$(dirname "$clean_source")" "$sandbox/scripts"
+  local app2_scan_source="$sandbox/$app2_fixture_rel"
+  local app2_clean_source="$sandbox/clean/SettingsScreen.kt"
+  mkdir -p "$(dirname "$scan_source")" "$(dirname "$clean_source")" \
+    "$(dirname "$app2_scan_source")" "$(dirname "$app2_clean_source")" \
+    "$sandbox/scripts"
   cp "$REPO_ROOT/$fixture_rel" "$clean_source"
   cp "$clean_source" "$scan_source"
+  cp "$REPO_ROOT/$app2_fixture_rel" "$app2_clean_source"
+  cp "$app2_clean_source" "$app2_scan_source"
   cp "$BASELINE_FILE" "$sandbox/scripts/component-drift-baseline.txt"
   cp "$SCRIPT_DIR/check-component-drift.sh" "$sandbox/scripts/check-component-drift.sh"
   chmod +x "$sandbox/scripts/check-component-drift.sh"
@@ -123,7 +127,7 @@ self_test() (
       exit 1
     fi
     grep -Fq \
-      "DRIFT  $fixture_rel: 2 raw component call-sites (baseline 1, +1 new)" \
+      "DRIFT  $fixture_rel: 1 raw component call-sites (baseline 0, +1 new)" \
       <<<"$output" \
       || { printf '%s\n' "$output" >&2; echo "FAIL: $label mutation failed for an unexpected reason" >&2; exit 1; }
     echo "PASS: $label raw-component mutation is rejected"
@@ -133,6 +137,28 @@ self_test() (
   mutate_and_require_red AlertDialog 'AlertDialog('
   mutate_and_require_red Spinner 'CircularProgressIndicator('
   mutate_and_require_red TextButton 'TextButton('
+
+  # The live app2 source root must reject a raw component added to an existing
+  # production file, even though that file has no baseline row today.
+  local app2_mutant="$sandbox/app2-AlertDialog/SettingsScreen.kt"
+  mkdir -p "$(dirname "$app2_mutant")"
+  cp "$app2_clean_source" "$app2_mutant"
+  printf '\n@Composable\nprivate fun SelfTestApp2Drift() {\n    AlertDialog(\n    )\n}\n' \
+    >> "$app2_mutant"
+  grep -Fq 'AlertDialog(' "$app2_mutant" \
+    || { echo "FAIL: app2 AlertDialog mutation did not apply" >&2; exit 1; }
+  cp "$app2_mutant" "$app2_scan_source"
+  if output="$(cd "$sandbox" && scripts/check-component-drift.sh 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    echo "FAIL: app2 raw-component mutation was accepted" >&2
+    exit 1
+  fi
+  grep -Fq \
+    "DRIFT  $app2_fixture_rel: 1 raw component call-sites (baseline 0, +1 new)" \
+    <<<"$output" \
+    || { printf '%s\n' "$output" >&2; echo "FAIL: app2 mutation failed for an unexpected reason" >&2; exit 1; }
+  echo "PASS: app2 raw-component mutation is rejected"
+  cp "$app2_clean_source" "$app2_scan_source"
 
   # And the other direction: a NEW file with a raw call is drift even though it
   # has no baseline row at all (this is how a freshly-added screen is caught).

--- a/scripts/check-product-tmux-absent.sh
+++ b/scripts/check-product-tmux-absent.sh
@@ -11,19 +11,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-scan_roots() {
-  local -a roots=("$@")
-  local root
-  for root in "${roots[@]}"; do
-    if [[ ! -d "$root" ]]; then
-      echo "check-product-tmux-absent: FAIL — missing scan root: $root" >&2
+scan_paths() {
+  local -a paths=("$@")
+  local path
+  for path in "${paths[@]}"; do
+    if [[ ! -e "$path" ]]; then
+      echo "check-product-tmux-absent: FAIL — missing scan path: $path" >&2
       return 1
     fi
   done
 
   local matches
   if command -v rg >/dev/null 2>&1; then
-    matches="$(rg -n -i 'tmux' "${roots[@]}" \
+    matches="$(rg -n -i 'tmux' "${paths[@]}" \
       --glob '!**/build/**' \
       --glob '!shared/core-terminal/src/main/java/com/termux/**' \
       --glob '!shared/core-storage/src/main/java/com/pocketshell/core/storage/AppDatabase.kt' \
@@ -33,7 +33,7 @@ scan_roots() {
     # Ubuntu runners have grep but may not have ripgrep. Keep this fallback's
     # exclusions aligned with the product surface above so the guard remains
     # blocking instead of silently skipping its scan.
-    matches="$(grep -RniE 'tmux' "${roots[@]}" \
+    matches="$(grep -RniE 'tmux' "${paths[@]}" \
       --exclude-dir=build \
       --exclude-dir=termux \
       --exclude=AppDatabase.kt \
@@ -62,13 +62,20 @@ self_test() {
 
   mkdir -p "$tmp/product"
   printf '%s\n' 'val backend = "tmux"' > "$tmp/product/Runtime.kt"
-  if scan_roots "$tmp/product"; then
+  if scan_paths "$tmp/product"; then
     echo "check-product-tmux-absent: self-test FAIL — planted product hit was missed" >&2
     return 1
   fi
 
+  printf '%s\n' '[project.scripts]' 'backend = "tmux"' > "$tmp/product/pyproject.toml"
+  if scan_paths "$tmp/product/pyproject.toml"; then
+    echo "check-product-tmux-absent: self-test FAIL — manifest-file scan missed planted product hit" >&2
+    return 1
+  fi
+
   printf '%s\n' 'val backend = "aplexer"' > "$tmp/product/Runtime.kt"
-  if ! scan_roots "$tmp/product"; then
+  printf '%s\n' '[project.scripts]' 'pocketshell = "pocketshell.cli:main"' > "$tmp/product/pyproject.toml"
+  if ! scan_paths "$tmp/product"; then
     echo "check-product-tmux-absent: self-test FAIL — clean product tree was rejected" >&2
     return 1
   fi
@@ -85,8 +92,10 @@ if [[ "${1:-}" != "" ]]; then
   exit 2
 fi
 
-scan_roots \
+scan_paths \
   tools/pocketshell/src \
+  tools/pocketshell/pyproject.toml \
   app2/src/main \
+  app2/build.gradle.kts \
   shared/*/src/main
 echo "check-product-tmux-absent: OK — product session paths are aplexer-only"

--- a/scripts/component-drift-baseline.txt
+++ b/scripts/component-drift-baseline.txt
@@ -7,8 +7,6 @@
 #   here like any other accepted site.
 # regenerate with: scripts/check-component-drift.sh --update
 # lower numbers are better — re-baseline after migrating a screen.
-shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ConfirmDialog.kt 1
-shared/ui-kit/src/main/java/com/pocketshell/uikit/components/FormDialog.kt 1
 shared/ui-kit/src/main/java/com/pocketshell/uikit/components/HostCard.kt 2
 shared/ui-kit/src/main/java/com/pocketshell/uikit/components/LoadingIndicator.kt 2
 shared/ui-kit/src/main/java/com/pocketshell/uikit/components/PocketShellButton.kt 2

--- a/shared/core-storage/src/main/java/com/pocketshell/core/storage/dao/SshKeyDao.kt
+++ b/shared/core-storage/src/main/java/com/pocketshell/core/storage/dao/SshKeyDao.kt
@@ -8,10 +8,19 @@ import androidx.room.Query
 import com.pocketshell.core.storage.entity.SshKeyEntity
 import kotlinx.coroutines.flow.Flow
 
+/** Host labels shown before an SSH key deletion can cascade to those hosts. */
+data class SshKeyHostReference(
+    val keyId: Long,
+    val hostName: String,
+)
+
 @Dao
 interface SshKeyDao {
     @Query("SELECT * FROM ssh_keys ORDER BY name")
     fun getAll(): Flow<List<SshKeyEntity>>
+
+    @Query("SELECT keyId, name AS hostName FROM hosts ORDER BY name")
+    fun getHostReferences(): Flow<List<SshKeyHostReference>>
 
     @Query("SELECT * FROM ssh_keys WHERE id = :id")
     suspend fun getById(id: Long): SshKeyEntity?

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ConfirmDialog.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ConfirmDialog.kt
@@ -1,61 +1,27 @@
 package com.pocketshell.uikit.components
 
-import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
-import com.pocketshell.uikit.theme.PocketShellTypography
+import com.pocketshell.uikit.theme.PocketShellSpacing
+import com.pocketshell.uikit.theme.PocketShellType
 
-/**
- * The canonical confirm / destructive-confirm dialog for PocketShell (#756).
- *
- * The UI-consistency audit (#756) found 31 raw Material `AlertDialog`s, with the
- * confirm/destructive flow (delete host, delete key, reset costs, reveal env)
- * re-implemented per screen — each repeating the same recipe by hand: a `Text`
- * title in [PocketShellColors.Text], a `Text` body in
- * [PocketShellColors.TextSecondary], a confirm [PocketShellButton]
- * ([ButtonVariant.Primary] or [ButtonVariant.Destructive]), a Cancel
- * [ButtonVariant.Text] button, and `containerColor = Surface`. [ConfirmDialog]
- * folds that recipe into one shared surface so every confirm dialog reads the
- * same.
- *
- * Destructive vs affirmative is a single [destructive] flag, not a colour the
- * caller picks: when true the confirm action paints with
- * [ButtonVariant.Destructive] (red TEXT — per `docs/design-system.md`:
- * "destructive confirmation uses red text only on the confirm action"), when
- * false it paints with [ButtonVariant.Primary] (filled accent). The dismiss
- * action is always the muted [ButtonVariant.Text] Cancel.
- *
- * Tokens (NO raw hex):
- * - Title is [PocketShellTypography] `titleMedium` (16sp) in
- *   [PocketShellColors.Text].
- * - Body ([message]) is `bodyMedium` (14sp) in [PocketShellColors.TextSecondary].
- * - Container is [PocketShellColors.Surface] with the
- *   [PocketShellShapes.large] sheet/dialog radius.
- *
- * Both buttons route through the shared [PocketShellButton], so confirm/cancel
- * colour, weight, shape, and disabled treatment can't drift per call site.
- *
- * @param title the dialog headline ("Delete this key?", "Reset cost history?").
- * @param message the explanatory body line.
- * @param confirmLabel the confirm button label ("Delete", "Reset", "Overwrite").
- * @param onConfirm invoked when the confirm button is tapped.
- * @param onDismiss invoked on Cancel, scrim tap, or system back.
- * @param modifier outer modifier forwarded to the [AlertDialog].
- * @param destructive when true, the confirm action paints destructive (red
- *   text); when false it paints the affirmative filled-accent primary.
- * @param dismissLabel the dismiss button label (defaults to "Cancel").
- * @param confirmTestTag optional `testTag` on the confirm button, so call sites
- *   that previously hand-rolled the dialog keep their existing instrumentation
- *   hooks after migrating onto [ConfirmDialog] (e.g. a "Stop"/"Clear" confirm).
- * @param dismissTestTag optional `testTag` on the dismiss (Cancel) button, same
- *   migration rationale as [confirmTestTag].
- * @param titleTestTag optional `testTag` on the title [Text].
- * @param messageTestTag optional `testTag` on the body [Text].
- */
+/** Shared Quiet confirmation sheet used by destructive and affirmative flows. */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConfirmDialog(
     title: String,
@@ -71,42 +37,62 @@ fun ConfirmDialog(
     titleTestTag: String? = null,
     messageTestTag: String? = null,
 ) {
-    AlertDialog(
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
-        title = {
-            Text(
-                text = title,
-                color = PocketShellColors.Text,
-                style = PocketShellTypography.titleMedium,
-                modifier = if (titleTestTag != null) Modifier.testTag(titleTestTag) else Modifier,
-            )
-        },
-        text = {
-            Text(
-                text = message,
-                color = PocketShellColors.TextSecondary,
-                style = PocketShellTypography.bodyMedium,
-                modifier = if (messageTestTag != null) Modifier.testTag(messageTestTag) else Modifier,
-            )
-        },
-        confirmButton = {
-            PocketShellButton(
-                text = confirmLabel,
-                onClick = onConfirm,
-                variant = if (destructive) ButtonVariant.Destructive else ButtonVariant.Primary,
-                modifier = if (confirmTestTag != null) Modifier.testTag(confirmTestTag) else Modifier,
-            )
-        },
-        dismissButton = {
-            PocketShellButton(
-                text = dismissLabel,
-                onClick = onDismiss,
-                variant = ButtonVariant.Text,
-                modifier = if (dismissTestTag != null) Modifier.testTag(dismissTestTag) else Modifier,
-            )
-        },
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
         containerColor = PocketShellColors.Surface,
         shape = PocketShellShapes.large,
-    )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = PocketShellSpacing.xl)
+                    .padding(bottom = PocketShellSpacing.lg),
+                verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.md),
+            ) {
+                SheetHeader(
+                    title = title,
+                    onClose = onDismiss,
+                    titleTestTag = titleTestTag,
+                )
+                Text(
+                    text = message,
+                    color = PocketShellColors.TextSecondary,
+                    style = PocketShellType.body,
+                    modifier = messageTestTag?.let { Modifier.testTag(it) } ?: Modifier,
+                )
+            }
+            HorizontalDivider(color = PocketShellColors.BorderSoft)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = PocketShellSpacing.xl, vertical = PocketShellSpacing.md),
+                verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+            ) {
+                PocketShellButton(
+                    text = confirmLabel,
+                    onClick = onConfirm,
+                    variant = if (destructive) ButtonVariant.Destructive else ButtonVariant.Primary,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .let { base -> if (confirmTestTag == null) base else base.testTag(confirmTestTag) },
+                )
+                PocketShellButton(
+                    text = dismissLabel,
+                    onClick = onDismiss,
+                    variant = ButtonVariant.Text,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .let { base -> if (dismissTestTag == null) base else base.testTag(dismissTestTag) },
+                )
+            }
+        }
+    }
 }

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/FormDialog.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/FormDialog.kt
@@ -3,72 +3,26 @@ package com.pocketshell.uikit.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
-import com.pocketshell.uikit.theme.PocketShellTypography
+import com.pocketshell.uikit.theme.PocketShellSpacing
 
-/**
- * The canonical input / form dialog for PocketShell (#861).
- *
- * The #756 design-consistency audit found ~7 input-bearing `AlertDialog`s
- * (add/edit/rename snippet, the command-macro editor, the recurring-job editor,
- * the forwarding passphrase prompt, the session-rename dialog) that each
- * re-implement the same scaffold by hand: a `Text` title in
- * [PocketShellColors.Text], a [Column] of the caller's
- * `OutlinedTextField`(s)/helper text/toggles, a confirm [PocketShellButton]
- * ([ButtonVariant.Primary]), a Cancel [ButtonVariant.Text] button, and
- * `containerColor = Surface` with the [PocketShellShapes.large] (20dp) dialog
- * radius. [ConfirmDialog] can't cover them because it has no content slot for
- * the form fields. [FormDialog] folds that recipe into one shared surface so
- * every input dialog reads the same.
- *
- * Unlike [ConfirmDialog] (a fixed title + body message), [FormDialog] takes a
- * **content slot** ([content]) where the caller composes its own
- * `OutlinedTextField`(s), helper captions, kind toggles, etc. The content is
- * laid out in a [Column] with the same dense [Arrangement.spacedBy] rhythm the
- * call sites used by hand, so the caller only supplies the fields.
- *
- * Tokens (NO raw hex):
- * - Title is [PocketShellTypography] `titleMedium` (16sp) in
- *   [PocketShellColors.Text] (matching [ConfirmDialog]).
- * - Container is [PocketShellColors.Surface] with the
- *   [PocketShellShapes.large] dialog radius (20dp per `docs/design-system.md`).
- *
- * The action row is the canonical dialog pairing (`Text` Cancel + `Primary`
- * confirm, right-aligned) from the design system, both routed through the
- * shared [PocketShellButton] so colour/weight/shape/disabled treatment can't
- * drift per call site. An optional [extraAction] slot sits to the LEFT of
- * Cancel for the one editor (recurring-job) that pairs a destructive "Remove"
- * with the standard Cancel/Save row.
- *
- * @param title the dialog headline ("Add snippet", "Rename session").
- * @param confirmLabel the confirm button label ("Save", "Open", "Rename").
- * @param onConfirm invoked when the confirm button is tapped.
- * @param onDismiss invoked on Cancel, scrim tap, or system back.
- * @param modifier outer modifier forwarded to the [AlertDialog].
- * @param confirmEnabled when false the confirm button is disabled (form not yet
- *   valid — e.g. a blank required field); defaults to `true`.
- * @param dismissLabel the dismiss button label (defaults to "Cancel").
- * @param confirmTestTag optional `testTag` on the confirm button, so call sites
- *   that previously hand-rolled the dialog keep their existing instrumentation
- *   hooks after migrating onto [FormDialog].
- * @param dismissTestTag optional `testTag` on the dismiss (Cancel) button, same
- *   migration rationale as [confirmTestTag].
- * @param extraAction optional leading action (e.g. a destructive "Remove")
- *   placed to the left of Cancel; `null` for the common case.
- * @param content the form-field slot, composed in a [ColumnScope] with a dense
- *   `spacedBy(10.dp)` vertical rhythm.
- */
+/** Shared Quiet form sheet with an independently scrolling body. */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FormDialog(
     title: String,
@@ -83,45 +37,58 @@ fun FormDialog(
     extraAction: (@Composable () -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    AlertDialog(
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
-        title = {
-            Text(
-                text = title,
-                color = PocketShellColors.Text,
-                style = PocketShellTypography.titleMedium,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = PocketShellColors.Surface,
+        shape = PocketShellShapes.large,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .imePadding(),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = PocketShellSpacing.xl)
+                    .padding(bottom = PocketShellSpacing.lg),
+                verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+                content = {
+                    SheetHeader(title = title, onClose = onDismiss)
+                    content()
+                },
             )
-        },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(10.dp), content = content)
-        },
-        confirmButton = {
-            PocketShellButton(
-                text = confirmLabel,
-                onClick = onConfirm,
-                variant = ButtonVariant.Primary,
-                enabled = confirmEnabled,
-                modifier = if (confirmTestTag != null) Modifier.testTag(confirmTestTag) else Modifier,
-            )
-        },
-        dismissButton = {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                if (extraAction != null) {
-                    extraAction()
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
+            HorizontalDivider(color = PocketShellColors.BorderSoft)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = PocketShellSpacing.xl, vertical = PocketShellSpacing.md),
+                verticalArrangement = Arrangement.spacedBy(PocketShellSpacing.sm),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                extraAction?.invoke()
+                PocketShellButton(
+                    text = confirmLabel,
+                    onClick = onConfirm,
+                    variant = ButtonVariant.Primary,
+                    enabled = confirmEnabled,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .let { base -> if (confirmTestTag == null) base else base.testTag(confirmTestTag) },
+                )
                 PocketShellButton(
                     text = dismissLabel,
                     onClick = onDismiss,
                     variant = ButtonVariant.Text,
-                    modifier = if (dismissTestTag != null) Modifier.testTag(dismissTestTag) else Modifier,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .let { base -> if (dismissTestTag == null) base else base.testTag(dismissTestTag) },
                 )
             }
-        },
-        containerColor = PocketShellColors.Surface,
-        titleContentColor = PocketShellColors.Text,
-        textContentColor = PocketShellColors.TextSecondary,
-        shape = PocketShellShapes.large,
-    )
+        }
+    }
 }

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/Kebab.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/Kebab.kt
@@ -68,12 +68,10 @@ data class KebabItem(
  * inline action buttons). Generalises the merged-#455 host-card kebab so every
  * screen's row overflow renders identically.
  *
- * - The trigger is a 40dp circular [PocketShellColors.SurfaceElev] container
+ * - The trigger is a 48dp circular [PocketShellColors.SurfaceElev] container
  *   with a 1dp [PocketShellColors.BorderSoft] hairline border (design-system §8
  *   "always-visible affordance"), holding the Quiet registry's `more` vector.
- *   40dp container already clears the 48dp touch floor once `minimumInteractive`
- *   semantics expand around it; the explicit 40dp visible chrome matches the
- *   mockup.
+ *   so the visible control itself satisfies the 48dp touch floor.
  * - The menu opens on [PocketShellColors.SurfaceElev] (the
  *   `surfaceContainerHigh`-equivalent raw token in our single dark scheme) with
  *   each row at [PocketShellType.bodyDense]`(13)` + an optional leading icon.
@@ -87,10 +85,7 @@ data class KebabItem(
  * screen that already has stable instrumentation for its overflow button can
  * adopt this component without breaking existing tests.
  *
- * [triggerSize] defaults to the compact 40dp visual used by most rows. Screens
- * that need the trigger itself to be the full touch target (for example dense
- * session rows with long names) can raise it to their a11y floor without adding
- * a second clickable wrapper around the menu.
+ * [triggerSize] defaults to the 48dp Quiet touch target.
  */
 @Composable
 fun Kebab(
@@ -98,7 +93,7 @@ fun Kebab(
     modifier: Modifier = Modifier,
     contentDescription: String = "More actions",
     triggerTestTag: String = KEBAB_BUTTON_TAG,
-    triggerSize: Dp = 40.dp,
+    triggerSize: Dp = 48.dp,
     expanded: Boolean? = null,
     onExpandedChange: ((Boolean) -> Unit)? = null,
 ) {
@@ -170,7 +165,7 @@ fun KebabTrigger(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     triggerTestTag: String = KEBAB_BUTTON_TAG,
-    triggerSize: Dp = 40.dp,
+    triggerSize: Dp = 48.dp,
 ) {
     Box(
         modifier = modifier

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ListRow.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ListRow.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.clickable
 import androidx.compose.material3.Text
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,7 +27,7 @@ import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
 
 /**
- * The core compact list row — the one source of truth for every dense row in
+ * The core list row — the one source of truth for flat rows in
  * the app (host list, sessions, settings, conversation list, port-forward
  * panel, …). Encodes the issue #489 row pattern and the design language locked
  * on #479:
@@ -43,27 +44,20 @@ import com.pocketshell.uikit.theme.PocketShellType
  *
  * - **[leading]** (optional) — status dot ([StatusDot]) / avatar / icon. Pass
  *   `null` for a flush-left title (e.g. settings rows).
- * - **title** — the primary scan target, [PocketShellType.bodyDense]`(13)`
- *   Medium on the bright text token.
+ * - **title** — the primary scan target, [PocketShellType.body] (18sp) on the
+ *   bright text token.
  * - **[subtitle]** (optional) — paths / IDs / `user@host`, rendered
- *   [PocketShellType.bodyMono]`(13)` on the muted token. The default is a
+ *   [PocketShellType.metadata] (16sp) on the muted token. The default is a
  *   single ellipsised line; callers such as [WorkspaceRow] may opt into a
  *   second line when the label itself is part of navigation.
  * - **[trailing]** (optional) — badge ([Badge]) / count / kebab ([Kebab]). One
  *   overflow affordance per row (design language: avoid multiple inline action
  *   buttons).
  *
- * ### Density vs. touch floor (#461 Δ6)
+ * ### Density and touch floor
  *
- * The row **paints compact**: [PocketShellDensity.rowMinHeight]`(44)` floor,
- * [PocketShellDensity.rowPadV]`(8)` / [PocketShellDensity.rowPadH]`(12)` padding
- * — so more rows fit per screen. When [onClick] is set the whole row becomes the
- * tap target and its minimum height is raised to the
- * [PocketShellDensity.tapTargetMin]`(48)` a11y floor via
- * `Modifier.defaultMinSize`. **The floor is baked in here** so consuming screens
- * cannot regress the hit area below 48dp by accident — that is the whole point
- * of extracting this row into ui-kit. (The 44dp paint floor still applies for
- * the non-clickable / decorative case.)
+ * Rows use the Quiet 72dp minimum and 20dp screen gutter. The whole row is the
+ * tap target when [onClick] is supplied, and wrapped content is allowed to grow.
  *
  * Colours stay on the always-dark raw tokens (#477 single dark scheme) so the
  * row never flips with the system light setting.
@@ -81,28 +75,33 @@ fun ListRow(
     titleStyle: TextStyle = PocketShellType.body,
     subtitleStyle: TextStyle = PocketShellType.metadata,
     titleWeight: FontWeight? = null,
+    subtitleContent: (@Composable () -> Unit)? = null,
 ) {
     // Every standard row is a 72dp minimum hit target. WorkspaceRow raises
     // this to the separate 88dp workspace navigation target.
     val minHeight = PocketShellDensity.rowMinHeight
 
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .defaultMinSize(minHeight = minHeight)
-            .then(
-                if (onClick != null) {
-                    Modifier.clickable(role = Role.Button, onClick = onClick)
-                } else {
-                    Modifier
-                },
-            )
-            .padding(
-                horizontal = PocketShellDensity.rowPadH,
-                vertical = PocketShellDensity.rowPadV,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
+    Column(
+        modifier = if (onClick == null) modifier.fillMaxWidth() else Modifier.fillMaxWidth(),
     ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .defaultMinSize(minHeight = minHeight)
+                .then(
+                    if (onClick != null) {
+                        Modifier.clickable(role = Role.Button, onClick = onClick)
+                    } else {
+                        Modifier
+                    },
+                )
+                .then(if (onClick != null) modifier else Modifier)
+                .padding(
+                    horizontal = PocketShellDensity.rowPadH,
+                    vertical = PocketShellDensity.rowPadV,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
         if (leading != null) {
             // A fixed-width leading box keeps every row's title left edge
             // aligned regardless of whether the leading slot is an 8dp dot or a
@@ -122,15 +121,19 @@ fun ListRow(
                 maxLines = titleMaxLines,
                 overflow = TextOverflow.Ellipsis,
             )
-            if (subtitle != null) {
+            if (subtitle != null || subtitleContent != null) {
                 Spacer(modifier = Modifier.size(2.dp))
-                Text(
-                    text = subtitle,
-                    color = PocketShellColors.TextMuted,
-                    style = subtitleStyle,
-                    maxLines = subtitleMaxLines,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                if (subtitleContent != null) {
+                    subtitleContent()
+                } else {
+                    Text(
+                        text = requireNotNull(subtitle),
+                        color = PocketShellColors.TextMuted,
+                        style = subtitleStyle,
+                        maxLines = subtitleMaxLines,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
         }
 
@@ -143,5 +146,10 @@ fun ListRow(
                 trailing()
             }
         }
+        }
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = PocketShellDensity.rowPadH),
+            color = PocketShellColors.BorderSoft,
+        )
     }
 }

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/PocketShellButton.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/PocketShellButton.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -13,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.defaultMinSize
 import com.pocketshell.uikit.theme.LocalPocketShellSemantic
 import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellShapes
@@ -110,7 +110,7 @@ fun PocketShellButton(
     ) {
         Text(
             text = text,
-            style = if (compact) PocketShellType.button else LocalTextStyle.current,
+            style = if (compact) PocketShellType.bodyDense else PocketShellType.button,
             fontWeight = if (variant == ButtonVariant.Primary) FontWeight.SemiBold else FontWeight.Medium,
         )
     }
@@ -137,11 +137,14 @@ fun PocketShellButton(
     // action sits flush in a banner/dialog row; the standard variants keep
     // Material's default content padding untouched.
     val contentPadding = if (compact) CompactContentPadding else null
+    // Compact changes only the label padding. Every visible button keeps the
+    // Quiet 56dp button minimum even when it appears inside a banner.
+    val sizedModifier = modifier.defaultMinSize(minHeight = 56.dp)
     when (variant) {
         ButtonVariant.Primary -> {
             Button(
                 onClick = onClick,
-                modifier = modifier,
+                modifier = sizedModifier,
                 enabled = enabled,
                 shape = ButtonShape,
                 contentPadding = contentPadding ?: ButtonDefaults.ContentPadding,
@@ -162,7 +165,7 @@ fun PocketShellButton(
             // other variants applies; the accent border is the only differentiator.
             Button(
                 onClick = onClick,
-                modifier = modifier,
+                modifier = sizedModifier,
                 enabled = enabled,
                 shape = ButtonShape,
                 contentPadding = contentPadding ?: ButtonDefaults.ContentPadding,
@@ -184,7 +187,7 @@ fun PocketShellButton(
         ButtonVariant.Text -> {
             TextButton(
                 onClick = onClick,
-                modifier = modifier,
+                modifier = sizedModifier,
                 enabled = enabled,
                 shape = ButtonShape,
                 contentPadding = contentPadding ?: ButtonDefaults.TextButtonContentPadding,
@@ -201,7 +204,7 @@ fun PocketShellButton(
             // "destructive confirmation uses red text only on the confirm action").
             TextButton(
                 onClick = onClick,
-                modifier = modifier,
+                modifier = sizedModifier,
                 enabled = enabled,
                 shape = ButtonShape,
                 contentPadding = contentPadding ?: ButtonDefaults.TextButtonContentPadding,

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ScreenHeader.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/ScreenHeader.kt
@@ -8,12 +8,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -21,6 +22,7 @@ import com.pocketshell.uikit.theme.PocketShellColors
 import com.pocketshell.uikit.theme.PocketShellDensity
 import com.pocketshell.uikit.theme.PocketShellSpacing
 import com.pocketshell.uikit.theme.PocketShellType
+import com.pocketshell.uikit.icons.PocketShellIcons
 
 /**
  * Shared screen header — the title block that sits atop the tree, host list,
@@ -34,20 +36,16 @@ import com.pocketshell.uikit.theme.PocketShellType
  * └───────────────────────────────────────────────────────┘
  * ```
  *
- * - **Title** rides [PocketShellType.bodyDense] bumped to SemiBold so it reads
- *   as the primary heading without pulling in the heavier M3 `headlineSmall`
- *   (the dev-tool density wants a tight header, not a marketing hero).
+ * - **Title** uses the Quiet screen style (28sp/34sp) and the optional subtitle
+ *   uses the 16sp metadata rung.
  * - **Subtitle** (optional) is the `N x · M y` facet line — muted, dense — the
  *   same count-subtitle vocabulary `ListRow`/`SectionHeader` use. Callers build
  *   the string (e.g. `"4 hosts · 7 sessions"`); this component does not invent
  *   pluralisation.
- * - **Leading slot** (optional) is a left-aligned `@Composable` lambda for a
- *   back affordance / status dot — the detail-screen variant (the folder tree's
- *   `‹` back chevron + active dot, #479 Slice A). List/dashboard headers leave
- *   it null so the title sits flush-left.
- * - **Trailing slot** (optional) is a right-aligned `@Composable` lambda for the
- *   header's toggles / actions (refresh, add, a density toggle, …). It lays out
- *   on the same baseline as the title so a row of icon buttons sits flush-right.
+ * - **[onBack]** renders the shared 48dp navigation affordance. The legacy
+ *   [leading] slot remains for non-navigation context.
+ * - **[trailing]** is one meaningful secondary action, normally a kebab that
+ *   owns occasional page actions.
  *
  * Density follows [PocketShellDensity] horizontal/vertical row padding so the
  * header lines up with the rows beneath it. Colours stay on the always-dark raw
@@ -59,19 +57,21 @@ import com.pocketshell.uikit.theme.PocketShellType
  *   folder tree's `FOLDER_LIST_TITLE_TAG` / counts tag) keep their existing
  *   instrumentation hooks after migrating onto [ScreenHeader].
  *
- * This is presentational only — no click handling on the header itself; wire
- * any affordance through [leading] / [trailing].
+ * This is presentational only — wire navigation through [onBack] and the one
+ * secondary affordance through [trailing].
  */
 @Composable
 fun ScreenHeader(
     title: String,
     modifier: Modifier = Modifier,
     subtitle: String? = null,
-    subtitleMaxLines: Int = 1,
-    titleMaxLines: Int = 1,
+    subtitleMaxLines: Int = 2,
+    titleMaxLines: Int = 2,
     titleStyle: TextStyle = PocketShellType.screen,
     titleTestTag: String? = null,
     subtitleTestTag: String? = null,
+    onBack: (() -> Unit)? = null,
+    backTestTag: String? = null,
     leading: (@Composable () -> Unit)? = null,
     trailing: (@Composable () -> Unit)? = null,
 ) {
@@ -79,21 +79,42 @@ fun ScreenHeader(
         modifier = modifier
             .fillMaxWidth()
             .padding(
-                horizontal = PocketShellDensity.rowPadH,
-                vertical = PocketShellDensity.rowPadV,
+                start = if (onBack != null || leading != null) PocketShellSpacing.md else PocketShellSpacing.xl,
+                end = PocketShellSpacing.md,
+                top = PocketShellSpacing.lg,
+                bottom = PocketShellSpacing.xl,
             ),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = Alignment.Top,
     ) {
-        if (leading != null) {
-            leading()
-            Spacer(modifier = Modifier.width(PocketShellSpacing.sm))
+        when {
+            onBack != null -> {
+                IconButton(
+                    onClick = onBack,
+                    modifier = Modifier
+                        .size(PocketShellDensity.tapTargetMin)
+                        .let { base -> if (backTestTag == null) base else base.testTag(backTestTag) },
+                ) {
+                    Icon(
+                        imageVector = PocketShellIcons.Back,
+                        contentDescription = "Back",
+                        tint = PocketShellColors.TextSecondary,
+                    )
+                }
+            }
+            leading != null -> {
+                leading()
+                Spacer(modifier = Modifier.width(PocketShellSpacing.sm))
+            }
         }
-        Column(modifier = Modifier.weight(1f)) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(top = PocketShellSpacing.xs),
+        ) {
             Text(
                 text = title,
                 color = PocketShellColors.Text,
                 style = titleStyle,
-                fontWeight = FontWeight.Bold,
                 maxLines = titleMaxLines,
                 overflow = TextOverflow.Ellipsis,
                 modifier = if (titleTestTag != null) Modifier.testTag(titleTestTag) else Modifier,

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/SegmentedToggle.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/SegmentedToggle.kt
@@ -2,12 +2,12 @@ package com.pocketshell.uikit.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -75,7 +75,7 @@ fun SegmentedToggle(
                         color = if (selected) PocketShellColors.Accent else PocketShellColors.SurfaceElev,
                         shape = PocketShellShapes.small,
                     )
-                    .clickable(role = Role.Tab, onClick = { onSelected(index) })
+                    .selectable(selected = selected, role = Role.Tab) { onSelected(index) }
                     .padding(
                         horizontal = PocketShellDensity.chipPadH,
                         vertical = PocketShellDensity.chipPadV,

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/WorkspaceRow.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/components/WorkspaceRow.kt
@@ -15,14 +15,16 @@ import com.pocketshell.uikit.theme.PocketShellType
 @Composable
 fun WorkspaceRow(
     title: String,
-    subtitle: String,
+    subtitle: String? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     testTag: String? = null,
+    subtitleContent: (@Composable () -> Unit)? = null,
 ) {
     ListRow(
         title = title,
         subtitle = subtitle,
+        subtitleContent = subtitleContent,
         trailing = { NavigationChevron() },
         onClick = onClick,
         titleMaxLines = 2,

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/theme/Spacing.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/theme/Spacing.kt
@@ -10,9 +10,8 @@ import androidx.compose.ui.unit.dp
  * freehand `.dp` literals so the 4 dp grid stays enforced; if a padding/gap/margin
  * value doesn't land on a rung, it's a bug or scope creep (§3).
  *
- * The defaults deliberately favour the tighter rungs for the dev-tool density the
- * maintainer asked for (#461 Δ6) — see [PocketShellDensity] for the row/chip knobs
- * that consume these.
+ * The scale follows the Quiet design kit. Row and touch dimensions live in
+ * [PocketShellDensity] so spacing and hit targets cannot drift independently.
  */
 object PocketShellSpacing {
     /** 4 dp — micro-gaps (icon-to-label, breadcrumb separators). */
@@ -21,16 +20,24 @@ object PocketShellSpacing {
     /** 8 dp — standard gap (chip-to-chip, row-to-row padding), key bar gap. */
     val sm = 8.dp
 
-    /** 12 dp — card internal padding, row vertical padding (the compact default). */
+    /** 12 dp — local control gaps and compact inline padding. */
     val md = 12.dp
 
     /** 16 dp — large padding (app bar, sheet header, host-card internal), dialog padding. */
     val lg = 16.dp
+
+    /** 20 dp — the Quiet screen gutter and primary page inset. */
+    val xl = 20.dp
+
+    /** 24 dp — sheet and large surface inset. */
+    val xxl = 24.dp
+
+    /** 32 dp — separation between independent content sections. */
+    val section = 32.dp
 }
 
 /**
- * PocketShell density knob (#461 Δ6) — the compact dev-tool defaults for rows,
- * chips, and trees.
+ * PocketShell geometry shared by rows, chips and the workspace tree.
  *
  * **Visual density is kept separate from the touch floor.** [rowPadV]/[chipPadV]
  * shrink the *paint* so more rows fit per screen, while [tapTargetMin] (48 dp) is
@@ -48,11 +55,11 @@ object PocketShellDensity {
     /** 72 dp — the Quiet standard row's minimum touch and reading height. */
     val standardRowMinHeight = 72.dp
 
-    /** 12 dp — row vertical padding. Rows may grow for wrapped content. */
-    val rowPadV = 12.dp
+    /** 16 dp — row vertical padding. Rows may grow for wrapped content. */
+    val rowPadV = 16.dp
 
-    /** 12 dp — row horizontal padding. */
-    val rowPadH = 12.dp
+    /** 20 dp — Quiet screen gutter used by standard and workspace rows. */
+    val rowPadH = 20.dp
 
     /** 6 dp — chip vertical padding. */
     val chipPadV = 6.dp
@@ -60,8 +67,8 @@ object PocketShellDensity {
     /** 10 dp — chip horizontal padding. */
     val chipPadH = 10.dp
 
-    /** 8 dp — gap between sections / stacked groups. */
-    val sectionGap = 8.dp
+    /** 32 dp — separation between independent sections. */
+    val sectionGap = 32.dp
 
     /** 16 dp — indent applied per workspace-tree nesting level. */
     val treeIndent = 16.dp

--- a/shared/ui-kit/src/main/java/com/pocketshell/uikit/theme/Theme.kt
+++ b/shared/ui-kit/src/main/java/com/pocketshell/uikit/theme/Theme.kt
@@ -39,7 +39,7 @@ private val PocketShellDarkColorScheme = darkColorScheme(
     onError = PocketShellColors.Background,
     errorContainer = PocketShellColors.Surface,
     onErrorContainer = PocketShellColors.Red,
-    scrim = Color.Black,
+    scrim = PocketShellColors.Scrim,
 )
 
 /**

--- a/shared/ui-kit/src/test/java/com/pocketshell/uikit/theme/QuietThemeTokenTest.kt
+++ b/shared/ui-kit/src/test/java/com/pocketshell/uikit/theme/QuietThemeTokenTest.kt
@@ -84,7 +84,7 @@ class QuietThemeTokenTest {
             assertEquals(PocketShellColors.BorderSoft, mapped.outlineVariant)
             assertEquals(PocketShellColors.Red, mapped.error)
             assertEquals(PocketShellColors.Background, mapped.onError)
-            assertEquals(Color.Black, mapped.scrim)
+            assertEquals(PocketShellColors.Scrim, mapped.scrim)
         }
     }
 

--- a/tools/pocketshell/pyproject.toml
+++ b/tools/pocketshell/pyproject.toml
@@ -81,8 +81,12 @@ dependencies = [
     # so the pinned wheel is the ONLY aplexer this CLI can run. Bumping the
     # pin is a deliberate, reviewed change.
     #
-    # 0.1.4 is required for the session tree to say WHICH agent is running.
-    # Through 0.1.3 a snapshot row's only agent-ish field was `engine`, and
+    # 0.1.5 is required for PocketShell's plain attach path. `a attach
+    # --no-status` removes aplexer's status chrome and reserved row while
+    # forwarding raw input and every PTY resize, so the Android terminal gets
+    # the full screen without a second terminal UI. 0.1.4 is also required
+    # for the session tree to say WHICH agent is running. Through 0.1.3 a
+    # snapshot row's only agent-ish field was `engine`, and
     # `engine` cannot answer that question: every session PocketShell creates
     # is `engine: "shell"` with the agent launched by hand inside it, so a
     # tree full of claude/codex/opencode sessions is indistinguishable from a
@@ -166,12 +170,12 @@ dependencies = [
     # no bundled aplexer at all, so `sessions create` there fails loud (there
     # is no PATH fallback — D22).
     #
-    # Install-surface note (unchanged in 0.1.4): as of 0.1.2 the wheels moved
+    # Install-surface note (unchanged in 0.1.5): as of 0.1.2 the wheels moved
     # from manylinux_2_17 to manylinux_2_28, raising the minimum glibc from
     # 2.17 to 2.28. Linux hosts older than that (CentOS 7, Ubuntu 18.04) can
     # no longer install pocketshell at all now that aplexer is a hard
     # dependency. Flagged, not solved here — see docs/aplexer-integration.md.
-    "aplexer==0.1.4; sys_platform == 'linux'",
+    "aplexer==0.1.5; sys_platform == 'linux'",
 ]
 
 [project.scripts]
@@ -237,7 +241,8 @@ required-version = "==0.10.11"
 # runtime dep landed at 00:32:04Z) for the session-tree regression fix above,
 # and now past aplexer 0.1.4's 2026-09-06T16:14:52Z PyPI upload (its
 # `aplexer-client` runtime dep landed at 16:14:48Z) for the `agent` field.
-exclude-newer = "2026-09-06T17:00:00Z"
+# 0.1.5 uploaded at 21:06:11Z (client at 21:06:06Z) for plain attach.
+exclude-newer = "2026-09-08T22:00:00Z"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tools/pocketshell/src/pocketshell/sessions.py
+++ b/tools/pocketshell/src/pocketshell/sessions.py
@@ -523,7 +523,10 @@ def sessions_attach(ctx: click.Context, name: str) -> None:
         click.echo(f"pocketshell: session {row.name!r} has no aplexer id.", err=True)
         ctx.exit(ATTACH_EXIT_NOT_FOUND)
         return
-    _exec([resolution.path, "attach", str(row.aplexer_id)])
+    # PocketShell owns the session header, status and controls. Ask aplexer
+    # for its plain full-screen relay so its terminal attach UI cannot leak
+    # Multiplexer chrome into the Android terminal.
+    _exec([resolution.path, "attach", "--no-status", str(row.aplexer_id)])
 
 
 def _emit_kill_failure(

--- a/tools/pocketshell/tests/test_aplexer_resolution.py
+++ b/tools/pocketshell/tests/test_aplexer_resolution.py
@@ -398,6 +398,9 @@ def test_aplexer_is_pinned_exactly() -> None:
       scan on a session directory that has no `session.json` yet, which is the
       state every `a start` creates for 26-43 ms, so a session being created
       blanked the phone's aplexer session rows (aplexer#2 / aplexer#3).
+    * 0.1.5, never 0.1.4 — `a attach --no-status` keeps the Android terminal
+      plain: no status chrome or reserved row, raw input reaches the worker,
+      and PTY resize geometry still propagates to the session.
     * 0.1.4, never 0.1.3 — 0.1.3 emits no `agent` field, so the session tree
       cannot say WHICH agent a session is running. `engine` cannot stand in
       for it: every session PocketShell creates is `engine: "shell"` with the
@@ -409,7 +412,7 @@ def test_aplexer_is_pinned_exactly() -> None:
     """
     requirement = _aplexer_requirement()
     pin = requirement.split(";")[0].strip()
-    assert pin == "aplexer==0.1.4", pin
+    assert pin == "aplexer==0.1.5", pin
 
 
 def test_aplexer_dependency_marker_is_linux_only() -> None:

--- a/tools/pocketshell/tests/test_sessions_attach.py
+++ b/tools/pocketshell/tests/test_sessions_attach.py
@@ -24,7 +24,9 @@ def test_attach_execs_the_resolved_aplexer_binary(monkeypatch) -> None:
     result = CliRunner().invoke(sessions.sessions_group, ["attach", "project:shell"])
 
     assert result.exit_code == 0, result.output
-    assert executed == [["/fake/a", "attach", "b3feff71-4a78-4055-a2d3-6c99187ecffb"]]
+    assert executed == [
+        ["/fake/a", "attach", "--no-status", "b3feff71-4a78-4055-a2d3-6c99187ecffb"]
+    ]
 
 
 def test_attach_fails_loudly_when_listing_cannot_reach_aplexer(monkeypatch) -> None:

--- a/tools/pocketshell/uv.lock
+++ b/tools/pocketshell/uv.lock
@@ -3,27 +3,27 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-09-06T17:00:00Z"
+exclude-newer = "2026-09-08T22:00:00Z"
 
 [[package]]
 name = "aplexer"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aplexer-client" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/66/62a25e0299c7e378f25960afe54fea0432d4c56b694f071a84c5d2a0eeb9/aplexer-0.1.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d7bbb60ac5c9bdb7db1d882374cbec3e91ea3f0d6f23e2d1272c0eb945b517c7", size = 2717004, upload-time = "2026-09-06T16:14:51.769Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e7/4bb8451c729457bf739aa86722c43db48c407ca82f4922bc67b24c6fffbe/aplexer-0.1.4-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:052705edcf832f35a336e0c20fe133ad2532fd27028f7dd332b40402c58da07d", size = 2822247, upload-time = "2026-09-06T16:14:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7d/389a7bf716c09aca91ce99b71544c8619db7380d66425ce459e883911ef8/aplexer-0.1.5-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:251432e441341a431a5ee5485a1a96935092103fdc5dd3cd4ee7ffbefb5aeb24", size = 3093121, upload-time = "2026-09-08T21:06:09.724Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/9b9acd6f0a915e9a0cee6042c4005c4f34bb4c87d991a2e1a2a048149c8a/aplexer-0.1.5-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b1dee06a0659f175b2eeb344478289b04428dc537948e2009f04ff9eef8540fd", size = 3210572, upload-time = "2026-09-08T21:06:11.421Z" },
 ]
 
 [[package]]
 name = "aplexer-client"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/68/8f5263a3df4061ae4b9d9b0119a9baaca6bb0a832bb5ecf09d5ab3aa1440/aplexer_client-0.1.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48b3b171f07a8126e61624d191ecb320fb24e5cf73d70cd3ec73d34426a814d3", size = 1192947, upload-time = "2026-09-06T16:14:46.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/b8/060e123125438e294f7b44d20e70f56acb1c0e0b13251203caffd3eab7c8/aplexer_client-0.1.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7fe606b60b5b0b2276952df202e770fc588123e675b62468538e02de0f263c67", size = 1227601, upload-time = "2026-09-06T16:14:48.211Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/59/5c4e64bcbb724cc1f066d7abedd5ea2fcb2702927f3694c6fa2a62d51836/aplexer_client-0.1.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:afd285083fc61e525363a7dc11bc6889401fc488366de3241dbb6b38cd01a920", size = 1242100, upload-time = "2026-09-08T21:06:04.774Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b9/3b15a37009ae09e973e5350182046e1fdcbe5e2608cbed78376bc199c7f1/aplexer_client-0.1.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8f8b26005bcd81a1955257751fcc1d727ccf75c7da3f0c802d6c9da67c6b1143", size = 1274674, upload-time = "2026-09-08T21:06:06.105Z" },
 ]
 
 [[package]]
@@ -332,7 +332,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aplexer", marker = "sys_platform == 'linux'", specifier = "==0.1.4" },
+    { name = "aplexer", marker = "sys_platform == 'linux'", specifier = "==0.1.5" },
     { name = "click", specifier = ">=8.2.0" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },


### PR DESCRIPTION
## Problem
The released app still exposed the old visual hierarchy and tmux session path because the redesign and tmux removal work were left in unmerged worktrees.

## Change
- Apply the quiet redesign across the app2 screens and shared UI kit: readable session/workspace labels, consistent sheets and dialogs, composer/input improvements, clearer host/tools/settings/file/usage flows, and the shared visual tokens.
- Remove tmux from PocketShell's product runtime and CLI attach path; sessions use bundled aplexer plain attach with no status chrome.
- Pin and test aplexer 0.1.5, including PTY coverage for raw input, mouse, resize, and status removal.
- Add the SSH key public-key/import error handling needed by the host-tools journey.
- Add the product tmux absence guard and update affected unit/instrumentation tests.

## Validation
- Formal reviewer: APPROVED.
- Canonical full JVM gate: 523 tasks, BUILD SUCCESSFUL.
- `scripts/assemble-debug.sh`: PASS.
- Product tmux guard and self-test: PASS.
- PocketShell Python suite: 903 passed, 1 skipped.
- Real emulator J17 host-tools journey: 1 executed, 0 failures; seven screenshots inspected.
- aplexer 0.1.5 release gate and PyPI publication: PASS.
