### PR TITLE
build: gate the APK signing-identity check in CI (#2638)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Assemble debug APK
         run: ./gradlew assembleDebug --stacktrace
 
+      # Issue #2638: assert the packaged signing identity before the APK is
+      # renamed/uploaded. This is the gate for the identity contract: it fails
+      # the build if a release APK is ever signed with the debug keystore
+      # again, or if the debug APK's identity (package, label, signer) drifts.
+      - name: Check debug APK signing identity
+        run: chmod +x scripts/check-apk-signing.sh && scripts/check-apk-signing.sh --variant debug --apk app2/build/outputs/apk/debug/app2-debug.apk
+
       - name: Rename APK
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -94,6 +101,14 @@ jobs:
           ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
           ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
           ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+
+      # Issue #2638: same gate for the release APK. Deliberately NO
+      # ANDROID_RELEASE_* env here (assembleRelease's env is per-step) and no
+      # keystore.properties exists on runners, so the script's
+      # ==local-keystore assertion auto-skips and exactly its 4 assertions
+      # run — CI is verified against the same secrets it signed with.
+      - name: Check release APK signing identity
+        run: scripts/check-apk-signing.sh --variant release --apk app2/build/outputs/apk/release/app2-release.apk
 
       - name: Rename release APK
         run: |


### PR DESCRIPTION
Follow-up fix to the changeset that landed directly on `main` as `3fd08f4c0` (release APK signing identity, side-by-side install — see #2638). The independent review round 1 returned CHANGES REQUESTED with exactly one blocking finding: the new `scripts/check-apk-signing.sh` was invoked by no gate, so the identity contract (a release APK must never silently be signed with `debug.keystore` again) had no automated enforcement. Round 2: **APPROVED**.

This PR wires the script into `.github/workflows/build.yml` (+15 lines, no other changes):

- after "Assemble debug APK": debug-variant check (`chmod +x` + run against `app2-debug.apk` before rename/upload);
- after "Assemble release APK": release-variant check, deliberately WITHOUT the `ANDROID_RELEASE_*` env (per-step env doesn't leak), so the `==local-keystore` assertion auto-skips on runners (no `keystore.properties` there) and exactly the script's 4 base assertions run — CI verifies the APK against the same secrets-based signer it was built with.

Re-review evidence (reviewer, first-hand): script re-run release 5/5 + debug 4/4 locally; behavioral proof of the CI shape by moving `keystore.properties` aside (4 assertions + skip, exit 0); YAML validates; round-1 device evidence (side-by-side co-install, distinct signers, both launch) stands on the unchanged `3fd08f4c0`.

Round-1 verdict: https://github.com/PocketShell-io/pocketshell/issues/2638#issuecomment-5626477482
Round-2 verdict: https://github.com/PocketShell-io/pocketshell/issues/2638#issuecomment-5626569019

Closes #2638