### PR TITLE
Rename launcher labels: debug "PocketShell Debug", release "PocketShell"

### DIFF
--- a/app2/src/main/res/values/strings.xml
+++ b/app2/src/main/res/values/strings.xml
@@ -1,4 +1,9 @@
 <resources>
-    <!-- User-visible launcher name. This is PocketShell, not a rebrand. -->
-    <string name="app_name">PocketShell</string>
+    <!--
+        Daily-driver DEBUG install's launcher label. Issue #2650: the debug
+        build says what it is; the plain "PocketShell" name belongs to the
+        release overlay (src/release). The two labels must stay distinct —
+        see LauncherBrandingTest and scripts/check-apk-signing.sh.
+    -->
+    <string name="app_name">PocketShell Debug</string>
 </resources>

--- a/app2/src/release/res/values/strings.xml
+++ b/app2/src/release/res/values/strings.xml
@@ -1,9 +1,10 @@
 <resources>
     <!--
-        Issue #2638: the release build installs under
-        com.pocketshell.app.release NEXT TO the daily-driver debug install, so
-        both launcher icons must be tellable apart at a glance. The debug label
-        (src/main, "PocketShell") must not change — see LauncherBrandingTest.
+        Issue #2650 (supersedes #2638's suffixed naming): the release
+        build IS PocketShell; the daily-driver debug install it sits
+        next to (com.pocketshell.app, src/main label) says
+        "PocketShell Debug" instead. The two labels must stay distinct —
+        see LauncherBrandingTest and scripts/check-apk-signing.sh.
     -->
-    <string name="app_name">PocketShell Rel</string>
+    <string name="app_name">PocketShell</string>
 </resources>

--- a/app2/src/test/java/com/pocketshell/next/LauncherBrandingTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/LauncherBrandingTest.kt
@@ -11,7 +11,9 @@ import org.w3c.dom.Element
  * Pins the shipping launcher identity (issue #2517) and install id
  * (issue #2519): this is PocketShell under `com.pocketshell.app`, so an
  * upgrade replaces the v0.4.x install (same signature). Kotlin namespace
- * stays `com.pocketshell.next`.
+ * stays `com.pocketshell.next`. Issue #2650 split the launcher labels:
+ * the daily-driver debug build is "PocketShell Debug", the release build
+ * plain "PocketShell".
  */
 class LauncherBrandingTest {
 
@@ -29,21 +31,22 @@ class LauncherBrandingTest {
     }
 
     @Test
-    fun launcherLabelIsPocketShellNotNext() {
-        val document = parseXml(locate("app2/src/main/res/values/strings.xml"))
-        val strings = document.getElementsByTagName("string")
-        var appName: String? = null
-        for (i in 0 until strings.length) {
-            val el = strings.item(i) as Element
-            if (el.getAttribute("name") == "app_name") {
-                appName = el.textContent.trim()
-                break
-            }
-        }
-        assertEquals("PocketShell", appName)
+    fun debugLauncherLabelIsPocketShellDebugNotNext() {
+        val appName = appNameIn(locate("app2/src/main/res/values/strings.xml"))
+        assertEquals("PocketShell Debug", appName)
         assertTrue(
             "launcher label must not carry the rewrite's side-by-side 'Next' suffix",
             appName != null && !appName.contains("Next"),
+        )
+    }
+
+    @Test
+    fun releaseOverlayLabelIsPlainPocketShellAndDistinctFromDebug() {
+        val releaseName = appNameIn(locate("app2/src/release/res/values/strings.xml"))
+        assertEquals("PocketShell", releaseName)
+        assertTrue(
+            "debug and release launcher labels must stay distinct",
+            releaseName != appNameIn(locate("app2/src/main/res/values/strings.xml")),
         )
     }
 
@@ -123,6 +126,17 @@ class LauncherBrandingTest {
         DocumentBuilderFactory.newInstance().apply { isNamespaceAware = true }
             .newDocumentBuilder()
             .parse(file)
+
+    private fun appNameIn(file: File): String? {
+        val strings = parseXml(file).getElementsByTagName("string")
+        for (i in 0 until strings.length) {
+            val el = strings.item(i) as Element
+            if (el.getAttribute("name") == "app_name") {
+                return el.textContent.trim()
+            }
+        }
+        return null
+    }
 
     private fun Element.androidAttr(name: String): String =
         getAttributeNS(ANDROID_NS, name).ifBlank { getAttribute("android:$name") }

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,7 +21,7 @@ signing identity:
 | | debug APK | release APK |
 |---|---|---|
 | applicationId | `com.pocketshell.app` | `com.pocketshell.app.release` |
-| launcher label | PocketShell | PocketShell Rel |
+| launcher label | PocketShell Debug | PocketShell |
 | signer | committed `debug.keystore` | dedicated release keystore |
 
 Different signatures cannot replace each other under one applicationId, so

--- a/scripts/check-apk-signing.sh
+++ b/scripts/check-apk-signing.sh
@@ -8,14 +8,15 @@ set -euo pipefail
 # introduced:
 #
 #   release variant: packageName == com.pocketshell.app.release, launcher
-#     label DISTINCT from debug's "PocketShell", and the signer certificate
-#     is NOT the committed debug.keystore's certificate (and, when release
-#     signing material is resolvable on this machine, IS the release
-#     keystore's certificate).
+#     label == "PocketShell" — DISTINCT from debug's "PocketShell Debug"
+#     (issue #2650) — and the signer certificate is NOT the committed
+#     debug.keystore's certificate (and, when release signing material is
+#     resolvable on this machine, IS the release keystore's certificate).
 #
-#   debug variant: packageName == com.pocketshell.app, label "PocketShell",
-#     signer IS the committed debug.keystore — i.e. the daily-driver install
-#     identity did not move when release signing landed.
+#   debug variant: packageName == com.pocketshell.app, label
+#     "PocketShell Debug", signer IS the committed debug.keystore — i.e.
+#     the daily-driver install identity did not move when release signing
+#     landed.
 #
 # Neither check can be done from source alone: the point is what actually got
 # packaged and signed, so this runs against APK files. Side-by-side coinstall
@@ -176,9 +177,9 @@ if [[ "$VARIANT" == "release" ]]; then
   pass "packageName == com.pocketshell.app.release"
 
   [[ -n "$LABEL" ]] || fail "release APK has no application-label"
-  [[ "$LABEL" != "PocketShell" ]] ||
-    fail "release APK launcher label is 'PocketShell' — it must be distinct from debug's label"
-  pass "launcher label is distinct from debug's ('$LABEL')"
+  [[ "$LABEL" == "PocketShell" ]] ||
+    fail "release APK launcher label is '$LABEL', expected 'PocketShell' (distinct from debug's 'PocketShell Debug')"
+  pass "launcher label is 'PocketShell'"
 
   [[ "$SIGNER_SHA" != "$DEBUG_CERT_SHA" ]] ||
     fail "release APK is signed by the DEBUG certificate ($DEBUG_CERT_SHA) — the release identity did not apply"
@@ -209,9 +210,9 @@ else
     fail "debug APK packageName is '$PACKAGE_NAME', expected com.pocketshell.app"
   pass "packageName == com.pocketshell.app"
 
-  [[ "$LABEL" == "PocketShell" ]] ||
-    fail "debug APK launcher label is '$LABEL', expected 'PocketShell'"
-  pass "launcher label is still 'PocketShell'"
+  [[ "$LABEL" == "PocketShell Debug" ]] ||
+    fail "debug APK launcher label is '$LABEL', expected 'PocketShell Debug'"
+  pass "launcher label is 'PocketShell Debug'"
 
   [[ "$SIGNER_SHA" == "$DEBUG_CERT_SHA" ]] ||
     fail "debug APK signer ($SIGNER_SHA) is not the committed debug.keystore cert ($DEBUG_CERT_SHA)"


### PR DESCRIPTION
Closes #2650. Maintainer ask 2026-09-11: the release build should be the one called "PocketShell"; the daily debug install becomes "PocketShell Debug".

Only display labels move — applicationIds (`com.pocketshell.app` / `com.pocketshell.app.release`), signatures (committed debug.keystore / dedicated release keystore), and icons are untouched, so both existing installs pick the new names up on their next `adb install -r`.

All automated label assertions follow the strings: `LauncherBrandingTest` (reviewer-run red→green) and `scripts/check-apk-signing.sh` (release exact-pins "PocketShell", debug "PocketShell Debug"; runs in the Build workflow on every dispatch). Docs signing table updated.

Evidence: implementer + reviewer status on #2650; reviewer APPROVED with emulator side-by-side proof (labels verified on the installed base.apks and in the launcher drawer, both apps launch, certs unchanged: release `0f9116…94e4`, debug `19ed5a…9d02`).
