### PR TITLE
Restore lean auto-forward resume on app foreground (#2654)

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/ports/J18AutoForwardResumeJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/ports/J18AutoForwardResumeJourney.kt
@@ -1,0 +1,242 @@
+package com.pocketshell.next.ports
+
+import android.app.ActivityManager
+import android.os.SystemClock
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.pocketshell.core.portfwd.TunnelInfo
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import com.pocketshell.next.MainActivity
+import com.pocketshell.next.connect.AgentsFixture
+import com.pocketshell.next.connect.JourneyScreenshots
+import com.pocketshell.next.connect.SeedBeforeLaunchRule
+import com.pocketshell.next.connect.appGraph
+import com.pocketshell.next.connect.awaitIdle
+import com.pocketshell.next.hosts.HOST_LIST_TAG
+import com.pocketshell.next.workspaces.HOST_WORKSPACES_TAG
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+
+/**
+ * Journey J18 — opening the app with `hosts.enabled = 1` must auto-forward
+ * in-window ports without visiting Services / Ports / Add tunnel (issue #2654).
+ *
+ * Pre-0.5.0, ProcessLifecycleOwner ON_START remounted AutoForwarder for every
+ * enabled host. The rewrite kept the engine but only called
+ * [ForwardService.resume] from the Services screens, so a cold start never
+ * forwarded anything.
+ *
+ * Fixture: Docker `agents` on `10.0.2.2:2222`. Bring it up first:
+ * `docker compose -f tests/docker/docker-compose.yml up -d --build agents`
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class J18AutoForwardResumeJourney {
+
+    private val compose = createAndroidComposeRule<MainActivity>()
+
+    @get:Rule
+    val chain: RuleChain = RuleChain
+        .outerRule(HiltAndroidRule(this))
+        .around(SeedBeforeLaunchRule { description -> seed(description) })
+        .around(compose)
+
+    private var hostId: Long = 0
+
+    private suspend fun seed(description: Description) {
+        grantNotificationPermission()
+        val graph = appGraph()
+        graph.connectionsRegistry().closeAll()
+        graph.hostDao().getAll().first().forEach {
+            graph.portRemappingDao().deleteByHostId(it.id)
+            graph.hostDao().deleteById(it.id)
+        }
+        graph.sshKeyDao().getAll().first().forEach { graph.sshKeyDao().deleteById(it.id) }
+
+        val fingerprint = AgentsFixture.probeHostKeyFingerprint()
+        println("J18_FIXTURE ${AgentsFixture.host}:${AgentsFixture.port} $fingerprint")
+        AgentsFixture.exec(
+            "printf 'POCKETSHELL_J18_HTTP_2654\\n' > /tmp/j18-body.txt",
+        )
+        AgentsFixture.exec(
+            "nohup python3 -m http.server $DISCOVERED_PORT --directory /tmp " +
+                ">/tmp/pocketshell-j18-http.log 2>&1 </dev/null &",
+        )
+
+        hostId = HOST_ID
+        val keyPath = AgentsFixture.installPrivateKey(fileName = "j18_fixture_key")
+        val keyId = graph.sshKeyDao().insert(
+            SshKeyEntity(name = "j18-${description.methodName}", privateKeyPath = keyPath),
+        )
+        graph.hostDao().insert(
+            HostEntity(
+                id = hostId,
+                name = "docker-fixture",
+                hostname = AgentsFixture.host,
+                port = AgentsFixture.port,
+                username = AgentsFixture.USER,
+                keyId = keyId,
+                enabled = true,
+                trustedHostKeyAlgorithm = "SHA256",
+                trustedHostKeySha256 = fingerprint,
+            ),
+        )
+    }
+
+    @Test
+    fun openingTheAppWithEnabledHostAutoForwardsWithoutOpeningServices() {
+        awaitHostListOrTree()
+        compose.onAllNodesWithTag(SERVICES_SCREEN_TAG).fetchSemanticsNodes().let { nodes ->
+            assertTrue("must not open Services / Ports / Add tunnel", nodes.isEmpty())
+        }
+        JourneyScreenshots.capture("01-after-launch", JOURNEY)
+
+        awaitForwardService()
+        val localPort = awaitForwardedLocalPort()
+        reportForwardingSnapshot("before-http-local=$localPort")
+        awaitForwardedHttpBody(localPort)
+        JourneyScreenshots.capture("02-forward-live", JOURNEY)
+
+        compose.onAllNodesWithTag(SERVICES_SCREEN_TAG).fetchSemanticsNodes().let { nodes ->
+            assertTrue("Services must stay unopened after auto-forward", nodes.isEmpty())
+        }
+    }
+
+    private fun awaitHostListOrTree() {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            compose.awaitIdle("host list or tree")
+            val onHosts = compose.onAllNodesWithTag(HOST_LIST_TAG)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+            val onTree = compose.onAllNodesWithTag(HOST_WORKSPACES_TAG)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+            if (onHosts || onTree) return
+            SystemClock.sleep(POLL_MS)
+        }
+        val shot = JourneyScreenshots.capture("failure-landing", JOURNEY)
+        throw AssertionError(
+            "host list or tree never appeared within ${TIMEOUT_MS}ms.\n" +
+                "Screenshot: ${shot.absolutePath}",
+        )
+    }
+
+    private fun awaitForwardService() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            @Suppress("DEPRECATION")
+            val running = context.getSystemService(ActivityManager::class.java)
+                ?.getRunningServices(100)
+                ?.any { it.service.className == ForwardService::class.java.name } == true
+            if (running) return
+            SystemClock.sleep(POLL_MS)
+        }
+        val shot = JourneyScreenshots.capture("failure-foreground-service", JOURNEY)
+        throw AssertionError("ForwardService was not running. Screenshot: ${shot.absolutePath}")
+    }
+
+    private fun awaitForwardedLocalPort(): Int {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val tunnel = forwardedTunnel()
+            if (tunnel != null) return tunnel.localPort
+            SystemClock.sleep(POLL_MS)
+        }
+        reportForwardingSnapshot("timeout-waiting-for-tunnel")
+        val shot = JourneyScreenshots.capture("failure-no-tunnel", JOURNEY)
+        throw AssertionError(
+            "in-window port $DISCOVERED_PORT was never forwarded. " +
+                "Screenshot: ${shot.absolutePath}",
+        )
+    }
+
+    private fun forwardedTunnel(): TunnelInfo? =
+        appGraph().forwardingController().snapshot.value
+            .asSequence()
+            .flatMap { it.tunnels.asSequence() }
+            .firstOrNull {
+                it.remotePort == DISCOVERED_PORT && it.status == TunnelInfo.Status.FORWARDING
+            }
+
+    private fun reportForwardingSnapshot(label: String) {
+        val snapshot = appGraph().forwardingController().snapshot.value
+        println(
+            "J18_FORWARDING_SNAPSHOT label=$label " +
+                snapshot.joinToString { host ->
+                    "host=${host.hostId}/${host.connection} " +
+                        "tunnels=${host.tunnels.joinToString { tunnel ->
+                            "${tunnel.remotePort}->${tunnel.localPort}:${tunnel.status}"
+                        }}"
+                },
+        )
+    }
+
+    private fun awaitForwardedHttpBody(localPort: Int) {
+        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
+        var lastBody = ""
+        var lastFailure: Throwable? = null
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val connection = runCatching {
+                (java.net.URL("http://127.0.0.1:$localPort/j18-body.txt")
+                    .openConnection() as java.net.HttpURLConnection).apply {
+                    connectTimeout = HTTP_TIMEOUT_MS
+                    readTimeout = HTTP_TIMEOUT_MS
+                    requestMethod = "GET"
+                }
+            }.getOrNull()
+            if (connection != null) {
+                try {
+                    val responseCode = connection.responseCode
+                    lastBody = connection.inputStream.bufferedReader().use { it.readText() }
+                    assertTrue("forwarded HTTP response must be 200", responseCode == 200)
+                    if (lastBody.contains(HTTP_BODY_TOKEN)) return
+                    lastFailure = AssertionError(
+                        "HTTP $responseCode from forwarded port contained: $lastBody",
+                    )
+                } catch (failure: Throwable) {
+                    lastFailure = failure
+                } finally {
+                    connection.disconnect()
+                }
+            }
+            SystemClock.sleep(POLL_MS)
+        }
+        throw AssertionError(
+            "GET http://127.0.0.1:$localPort/j18-body.txt did not return " +
+                "the fixture body '$HTTP_BODY_TOKEN'; lastBody='$lastBody'",
+            lastFailure,
+        )
+    }
+
+    private fun grantNotificationPermission() {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.TIRAMISU) return
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        instrumentation.uiAutomation.grantRuntimePermission(
+            instrumentation.targetContext.packageName,
+            android.Manifest.permission.POST_NOTIFICATIONS,
+        )
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 60_000L
+        const val POLL_MS = 250L
+        const val HTTP_TIMEOUT_MS = 1_000
+        const val HTTP_BODY_TOKEN = "POCKETSHELL_J18_HTTP_2654"
+        const val DISCOVERED_PORT = 5_173
+        const val JOURNEY = "j18-auto-forward-resume"
+        const val HOST_ID = 9_918L
+    }
+}

--- a/app2/src/main/java/com/pocketshell/next/App.kt
+++ b/app2/src/main/java/com/pocketshell/next/App.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import com.pocketshell.next.crash.CrashReporter
 import com.pocketshell.next.diagnostics.DiagnosticEvents
 import com.pocketshell.next.diagnostics.DiagnosticRecorder
+import com.pocketshell.next.ports.ForwardingResume
 import com.pocketshell.next.release.UpdateCheckScheduler
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -13,12 +14,12 @@ import javax.inject.Inject
  * app2's Application.
  *
  * Beyond the Hilt entry point (plan §M-1 non-goal: "no DI beyond
- * `@HiltAndroidApp`"), `onCreate` does three things: installs the generic
- * diagnostics event sink, installs the crash reporter's uncaught-exception
- * handler, and attaches the foreground-only GitHub-Releases update check
- * (issue #2531) to [androidx.lifecycle.ProcessLifecycleOwner]. The check is
- * not background work — D21: it only fires on `ON_START`, throttled, one
- * HTTP round-trip. No WorkManager, no AlarmManager.
+ * `@HiltAndroidApp`"), `onCreate` installs the diagnostics event sink, the
+ * crash reporter's uncaught-exception handler, the foreground-only
+ * GitHub-Releases update check (issue #2531), and the auto-forward resume
+ * (issue #2654) on [androidx.lifecycle.ProcessLifecycleOwner]. Both the
+ * update check and the resume are foreground-only — D21: they fire on
+ * `ON_START`. No WorkManager, no AlarmManager.
  *
  * ## The Robolectric guard
  *
@@ -48,16 +49,20 @@ class App : Application() {
     @Inject
     lateinit var updateCheckScheduler: UpdateCheckScheduler
 
+    @Inject
+    lateinit var forwardingResume: ForwardingResume
+
     override fun onCreate() {
         super.onCreate()
         if (isRunningUnderRobolectric()) return
         DiagnosticEvents.install(diagnosticRecorder)
         DiagnosticEvents.record("app", "created")
         CrashReporter.install(this)
-        // Foreground-only (D21 / #698): ON_START of ProcessLifecycleOwner.
+        // Foreground-only (D21 / #698 / #2654): ON_START of ProcessLifecycleOwner.
         // Skipped under Robolectric so JVM unit tests never poll GitHub or
         // attach a process-lifecycle observer that would leak across tests.
         updateCheckScheduler.observeProcessLifecycle()
+        forwardingResume.observeProcessLifecycle()
     }
 
     private fun isRunningUnderRobolectric(): Boolean = Build.FINGERPRINT == "robolectric"

--- a/app2/src/main/java/com/pocketshell/next/MainActivity.kt
+++ b/app2/src/main/java/com/pocketshell/next/MainActivity.kt
@@ -48,6 +48,7 @@ import com.pocketshell.next.hosts.HostListRoute
 import com.pocketshell.next.hosts.SshKeysRoute
 import com.pocketshell.next.nav.Destination
 import com.pocketshell.next.ports.AddTunnelRoute
+import com.pocketshell.next.ports.ForwardingResume
 import com.pocketshell.next.ports.PortForwardRoute
 import com.pocketshell.next.ports.ServicesRoute
 import com.pocketshell.next.ports.TunnelDetailRoute
@@ -105,6 +106,14 @@ class MainActivity : FragmentActivity() {
     @Inject
     lateinit var grace: GraceCoordinator
 
+    /**
+     * Same reason [grace] is registered here: instrumentation replaces
+     * [App] with `HiltTestApplication`, so [App.onCreate] never runs.
+     * [ForwardingResume.observeProcessLifecycle] is idempotent.
+     */
+    @Inject
+    lateinit var forwardingResume: ForwardingResume
+
     @Inject
     lateinit var connections: ConnectionsRegistry
 
@@ -114,6 +123,7 @@ class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         grace.register(application)
+        forwardingResume.observeProcessLifecycle()
         // #887/#2533: after edge-to-edge, SOFT_INPUT_ADJUST_NOTHING so the OS
         // neither resizes nor pans the window when the keyboard shows.
         // enableEdgeToEdge already sets setDecorFitsSystemWindows(false), which

--- a/app2/src/main/java/com/pocketshell/next/ports/ForwardingResume.kt
+++ b/app2/src/main/java/com/pocketshell/next/ports/ForwardingResume.kt
@@ -1,0 +1,100 @@
+package com.pocketshell.next.ports
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.pocketshell.core.storage.dao.HostDao
+import com.pocketshell.core.storage.dao.SshKeyDao
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Restores auto-forward when the app comes to the foreground (issue #2654).
+ *
+ * [ForwardingController.resumeEnabled] already remounts every host with
+ * `hosts.enabled = 1`. This class is the missing process-lifecycle hook:
+ * [ProcessLifecycleOwner] `ON_START` starts [ForwardService] when at least
+ * one enabled host has a usable key. Passphrase-protected and missing keys
+ * are skipped — launch cannot prompt.
+ *
+ * Foreground-only (D21): no WorkManager, no AlarmManager, no boot receiver.
+ * [observeProcessLifecycle] is idempotent so [com.pocketshell.next.App] and
+ * [com.pocketshell.next.MainActivity] can both attach.
+ */
+@Singleton
+class ForwardingResume @Inject constructor(
+    @ApplicationContext private val applicationContext: Context,
+    private val hostDao: HostDao,
+    private val sshKeyDao: SshKeyDao,
+) {
+    /** Testable start-service seam. Production starts [ForwardService]. */
+    internal var startService: (Context) -> Unit = { ForwardService.resume(it) }
+
+    internal var scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val processLifecycleObserver = LifecycleEventObserver { _: LifecycleOwner, event ->
+        if (event == Lifecycle.Event.ON_START) {
+            requestResume()
+        }
+    }
+
+    private var lifecycleAttached: Boolean = false
+
+    /**
+     * Attach [ProcessLifecycleOwner] (or any [LifecycleOwner]) so a resume
+     * sweep fires on every `ON_START`. Subsequent calls are no-ops. Seeds an
+     * immediate resume when the owner is already `STARTED` (cold launch).
+     */
+    fun observeProcessLifecycle(owner: LifecycleOwner = ProcessLifecycleOwner.get()) {
+        synchronized(this) {
+            if (lifecycleAttached) return
+            lifecycleAttached = true
+        }
+        scope.launch {
+            val alreadyStarted = withContext(Dispatchers.Main) {
+                owner.lifecycle.addObserver(processLifecycleObserver)
+                owner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+            }
+            if (alreadyStarted) requestResume()
+        }
+    }
+
+    private fun requestResume() {
+        scope.launch { resumeIfNeeded() }
+    }
+
+    private suspend fun resumeIfNeeded() {
+        val enabled = hostDao.getEnabled().first()
+        if (enabled.isEmpty()) return
+        val usable = enabled.any { host -> hostHasUsableKey(host.id, host.keyId) }
+        if (!usable) return
+        startService(applicationContext)
+    }
+
+    private suspend fun hostHasUsableKey(hostId: Long, keyId: Long): Boolean {
+        val key = sshKeyDao.getById(keyId)
+        if (key == null) {
+            Log.w(TAG, "resume skipped: no key for host $hostId")
+            return false
+        }
+        if (key.hasPassphrase) {
+            Log.i(TAG, "resume skipped: passphrase-protected key for host $hostId")
+            return false
+        }
+        return true
+    }
+
+    companion object {
+        private const val TAG = "PsForwardingResume"
+    }
+}

--- a/app2/src/test/java/com/pocketshell/next/ports/ForwardingResumeTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/ports/ForwardingResumeTest.kt
@@ -1,0 +1,173 @@
+package com.pocketshell.next.ports
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.pocketshell.core.storage.AppDatabase
+import com.pocketshell.core.storage.entity.HostEntity
+import com.pocketshell.core.storage.entity.SshKeyEntity
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class ForwardingResumeTest {
+
+    private lateinit var context: Context
+    private lateinit var db: AppDatabase
+    private val dispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .setQueryExecutor { it.run() }
+            .setTransactionExecutor { it.run() }
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun enabledHost_onStart_requestsForwardServiceResume() = runTest(dispatcher) {
+        seedHost(enabled = true)
+        val started = AtomicInteger(0)
+        val resume = resume { started.incrementAndGet() }
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.CREATED
+
+        resume.observeProcessLifecycle(owner)
+        advanceUntilIdle()
+        assertEquals(0, started.get())
+
+        owner.registry.currentState = Lifecycle.State.STARTED
+        advanceUntilIdle()
+
+        assertEquals(1, started.get())
+    }
+
+    @Test
+    fun noEnabledHost_doesNotStartService() = runTest(dispatcher) {
+        seedHost(enabled = false)
+        val started = AtomicInteger(0)
+        val resume = resume { started.incrementAndGet() }
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.STARTED
+
+        resume.observeProcessLifecycle(owner)
+        advanceUntilIdle()
+
+        assertEquals(0, started.get())
+    }
+
+    @Test
+    fun secondObserveProcessLifecycle_isANoOp() = runTest(dispatcher) {
+        seedHost(enabled = true)
+        val started = AtomicInteger(0)
+        val resume = resume { started.incrementAndGet() }
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.CREATED
+
+        resume.observeProcessLifecycle(owner)
+        resume.observeProcessLifecycle(owner)
+        advanceUntilIdle()
+        assertEquals(0, started.get())
+
+        owner.registry.currentState = Lifecycle.State.STARTED
+        advanceUntilIdle()
+
+        assertEquals(1, started.get())
+    }
+
+    @Test
+    fun alreadyStartedOwner_atAttach_seedsImmediateResume() = runTest(dispatcher) {
+        seedHost(enabled = true)
+        val started = AtomicInteger(0)
+        val resume = resume { started.incrementAndGet() }
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.STARTED
+
+        resume.observeProcessLifecycle(owner)
+        advanceUntilIdle()
+
+        assertTrue("already-STARTED owner must seed an immediate resume", started.get() >= 1)
+    }
+
+    @Test
+    fun passphraseProtectedEnabledHost_isSkipped() = runTest(dispatcher) {
+        seedHost(enabled = true, hasPassphrase = true)
+        val started = AtomicInteger(0)
+        val resume = resume { started.incrementAndGet() }
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.STARTED
+
+        resume.observeProcessLifecycle(owner)
+        advanceUntilIdle()
+
+        assertEquals(0, started.get())
+    }
+
+    private fun resume(onStart: () -> Unit): ForwardingResume {
+        val resume = ForwardingResume(
+            applicationContext = context,
+            hostDao = db.hostDao(),
+            sshKeyDao = db.sshKeyDao(),
+        )
+        resume.scope = CoroutineScope(SupervisorJob() + dispatcher)
+        resume.startService = { onStart() }
+        return resume
+    }
+
+    private fun seedHost(enabled: Boolean, hasPassphrase: Boolean = false): Long = runBlocking {
+        val keyId = db.sshKeyDao().insert(
+            SshKeyEntity(
+                name = "fixture-key",
+                privateKeyPath = "/dev/null",
+                hasPassphrase = hasPassphrase,
+            ),
+        )
+        db.hostDao().insert(
+            HostEntity(
+                name = "fixture",
+                hostname = "10.0.2.2",
+                port = 2222,
+                username = "testuser",
+                keyId = keyId,
+                enabled = enabled,
+            ),
+        )
+    }
+
+    private class FakeLifecycleOwner : LifecycleOwner {
+        val registry = LifecycleRegistry.createUnsafe(this)
+        override val lifecycle: Lifecycle get() = registry
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,9 @@ tests/docker/               disposable SSH and aplexer fixtures
 is pure JVM code, so the host contract is tested against captured JSON without
 an emulator. `core-terminal` contains the vendored emulator and the
 PocketShell-specific PTY bridge helpers. The app owns screen state and connects
-those modules through `ConnectionsRegistry`.
+those modules through `ConnectionsRegistry`. `core-portfwd` auto-forwards
+in-window ports once a supervisor is mounted; auto-forward resume is
+`ProcessLifecycleOwner` `ON_START`, not a screen.
 
 ## Session contract
 


### PR DESCRIPTION
Closes #2654

Automatic port forwarding stopped after the 0.5.0 rewrite because `ForwardService.resume` was only called from the Services/Ports screens. This restores the pre-0.5.0 behaviour with a lean `ProcessLifecycleOwner` `ON_START` hook (`ForwardingResume`), not a port of the old authority/barrier scheduler.

Opening the app with `hosts.enabled = 1` remounts AutoForwarder, which still auto-forwards in-window ports (default 1000–10000). No FGS when nothing is enabled. Passphrase-protected keys are skipped at launch.

Reviewer APPROVED: https://github.com/PocketShell-io/pocketshell/issues/2654#issuecomment-5645387633