### PR TITLE
Resume auto-forward from MainActivity.onStart (#2654)

### DIFF
--- a/app2/src/androidTest/java/com/pocketshell/next/connect/AppGraph.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/connect/AppGraph.kt
@@ -10,6 +10,7 @@ import com.pocketshell.core.storage.dao.SshKeyDao
 import com.pocketshell.next.composer.ComposerAttachmentStager
 import com.pocketshell.next.composer.ComposerDraftStore
 import com.pocketshell.next.ports.ForwardingController
+import com.pocketshell.next.ports.ForwardingResume
 import com.pocketshell.next.settings.SettingsRepository
 import com.pocketshell.next.terminal.GraceCoordinator
 import com.pocketshell.next.voice.PendingTranscriptionStore
@@ -37,6 +38,7 @@ interface AppGraph {
     fun projectRootDao(): ProjectRootDao
     fun connectionsRegistry(): ConnectionsRegistry
     fun forwardingController(): ForwardingController
+    fun forwardingResume(): ForwardingResume
 
     /**
      * Task P-1. The composer's sent-message log, so a journey can read what the

--- a/app2/src/androidTest/java/com/pocketshell/next/ports/J18AutoForwardResumeJourney.kt
+++ b/app2/src/androidTest/java/com/pocketshell/next/ports/J18AutoForwardResumeJourney.kt
@@ -1,9 +1,13 @@
 package com.pocketshell.next.ports
 
+import android.app.Activity
 import android.app.ActivityManager
+import android.content.Intent
 import android.os.SystemClock
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.pocketshell.core.portfwd.TunnelInfo
@@ -16,11 +20,13 @@ import com.pocketshell.next.connect.SeedBeforeLaunchRule
 import com.pocketshell.next.connect.appGraph
 import com.pocketshell.next.connect.awaitIdle
 import com.pocketshell.next.hosts.HOST_LIST_TAG
+import com.pocketshell.next.share.ShareActivity
 import com.pocketshell.next.workspaces.HOST_WORKSPACES_TAG
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -36,6 +42,13 @@ import org.junit.runner.RunWith
  * enabled host. The rewrite kept the engine but only called
  * [ForwardService.resume] from the Services screens, so a cold start never
  * forwarded anything.
+ *
+ * The wholesale `app2-journey` suite (#2474) runs J13 then J18 in one process.
+ * J13 leaves ForwardService running and the process lifecycle observer
+ * attached; ProcessLifecycleOwner stays STARTED, so J18's MainActivity never
+ * sees another ON_START. `awaitForwardService()` must not treat that leftover
+ * FGS as success — this seed unmounts it, re-attaches the leftover observer,
+ * and asserts host 9918's in-window tunnel plus the HTTP body.
  *
  * Fixture: Docker `agents` on `10.0.2.2:2222`. Bring it up first:
  * `docker compose -f tests/docker/docker-compose.yml up -d --build agents`
@@ -54,10 +67,29 @@ class J18AutoForwardResumeJourney {
 
     private var hostId: Long = 0
 
+    /**
+     * Holds ProcessLifecycleOwner at STARTED across MainActivity launch, like
+     * J13's leftover activity in the wholesale suite. Closed in [tearDown].
+     */
+    private var leftoverStarted: ActivityScenario<out Activity>? = null
+
+    @After
+    fun tearDown() {
+        leftoverStarted?.close()
+        leftoverStarted = null
+    }
+
     private suspend fun seed(description: Description) {
         grantNotificationPermission()
         val graph = appGraph()
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
         graph.connectionsRegistry().closeAll()
+
+        // J13 (and any prior journey) may have left ForwardService running.
+        // Tear it down so "some FGS is alive" cannot satisfy this test.
+        graph.forwardingController().stopAll()
+        context.stopService(Intent(context, ForwardService::class.java))
+        awaitForwardServiceStopped()
         graph.hostDao().getAll().first().forEach {
             graph.portRemappingDao().deleteByHostId(it.id)
             graph.hostDao().deleteById(it.id)
@@ -73,6 +105,15 @@ class J18AutoForwardResumeJourney {
             "nohup python3 -m http.server $DISCOVERED_PORT --directory /tmp " +
                 ">/tmp/pocketshell-j18-http.log 2>&1 </dev/null &",
         )
+
+        // Suite class: process already STARTED, observer already attached
+        // (J13 leftover). Keep a leftover activity so ProcessLifecycleOwner
+        // stays STARTED and MainActivity launch does not emit another ON_START.
+        leftoverStarted = launchLeftoverStartedActivity()
+        val sweepsBefore = graph.forwardingResume().resumeSweepCount.get()
+        graph.forwardingResume().observeProcessLifecycle()
+        awaitObserverAttached()
+        awaitResumeSweep(sweepsBefore)
 
         hostId = HOST_ID
         val keyPath = AgentsFixture.installPrivateKey(fileName = "j18_fixture_key")
@@ -92,6 +133,23 @@ class J18AutoForwardResumeJourney {
                 trustedHostKeySha256 = fingerprint,
             ),
         )
+        unmountKeepingEnabled()
+        val processState = ProcessLifecycleOwner.get().lifecycle.currentState
+        val leftoverFgs = isForwardServiceRunning()
+        println(
+            "J18_LEFTOVER_CLASS process=$processState leftoverFgs=$leftoverFgs " +
+                "host=$HOST_ID enabled=true observerAttached=" +
+                graph.forwardingResume().lifecycleObserverAttached,
+        )
+        check(!leftoverFgs) {
+            "leftover ForwardService still running after seed unmount"
+        }
+        check(graph.forwardingController().snapshot.value.none { it.hostId == HOST_ID }) {
+            "host $HOST_ID must not already be mounted before MainActivity launch"
+        }
+        check(graph.hostDao().getById(HOST_ID)?.enabled == true) {
+            "host $HOST_ID must stay enabled so onStart remounts it"
+        }
     }
 
     @Test
@@ -102,10 +160,10 @@ class J18AutoForwardResumeJourney {
         }
         JourneyScreenshots.capture("01-after-launch", JOURNEY)
 
-        awaitForwardService()
         val localPort = awaitForwardedLocalPort()
         reportForwardingSnapshot("before-http-local=$localPort")
         awaitForwardedHttpBody(localPort)
+        reportForwardingSnapshot("after-http-local=$localPort")
         JourneyScreenshots.capture("02-forward-live", JOURNEY)
 
         compose.onAllNodesWithTag(SERVICES_SCREEN_TAG).fetchSemanticsNodes().let { nodes ->
@@ -133,21 +191,6 @@ class J18AutoForwardResumeJourney {
         )
     }
 
-    private fun awaitForwardService() {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
-        while (SystemClock.elapsedRealtime() < deadline) {
-            @Suppress("DEPRECATION")
-            val running = context.getSystemService(ActivityManager::class.java)
-                ?.getRunningServices(100)
-                ?.any { it.service.className == ForwardService::class.java.name } == true
-            if (running) return
-            SystemClock.sleep(POLL_MS)
-        }
-        val shot = JourneyScreenshots.capture("failure-foreground-service", JOURNEY)
-        throw AssertionError("ForwardService was not running. Screenshot: ${shot.absolutePath}")
-    }
-
     private fun awaitForwardedLocalPort(): Int {
         val deadline = SystemClock.elapsedRealtime() + TIMEOUT_MS
         while (SystemClock.elapsedRealtime() < deadline) {
@@ -158,23 +201,24 @@ class J18AutoForwardResumeJourney {
         reportForwardingSnapshot("timeout-waiting-for-tunnel")
         val shot = JourneyScreenshots.capture("failure-no-tunnel", JOURNEY)
         throw AssertionError(
-            "in-window port $DISCOVERED_PORT was never forwarded. " +
+            "in-window port $DISCOVERED_PORT was never forwarded for host $HOST_ID. " +
                 "Screenshot: ${shot.absolutePath}",
         )
     }
 
     private fun forwardedTunnel(): TunnelInfo? =
         appGraph().forwardingController().snapshot.value
-            .asSequence()
-            .flatMap { it.tunnels.asSequence() }
-            .firstOrNull {
+            .firstOrNull { it.hostId == HOST_ID }
+            ?.tunnels
+            ?.firstOrNull {
                 it.remotePort == DISCOVERED_PORT && it.status == TunnelInfo.Status.FORWARDING
             }
 
     private fun reportForwardingSnapshot(label: String) {
         val snapshot = appGraph().forwardingController().snapshot.value
+        val fgs = isForwardServiceRunning()
         println(
-            "J18_FORWARDING_SNAPSHOT label=$label " +
+            "J18_FORWARDING_SNAPSHOT label=$label fgs=$fgs " +
                 snapshot.joinToString { host ->
                     "host=${host.hostId}/${host.connection} " +
                         "tunnels=${host.tunnels.joinToString { tunnel ->
@@ -202,7 +246,10 @@ class J18AutoForwardResumeJourney {
                     val responseCode = connection.responseCode
                     lastBody = connection.inputStream.bufferedReader().use { it.readText() }
                     assertTrue("forwarded HTTP response must be 200", responseCode == 200)
-                    if (lastBody.contains(HTTP_BODY_TOKEN)) return
+                    if (lastBody.contains(HTTP_BODY_TOKEN)) {
+                        println("J18_HTTP_BODY=${lastBody.trim()}")
+                        return
+                    }
                     lastFailure = AssertionError(
                         "HTTP $responseCode from forwarded port contained: $lastBody",
                     )
@@ -221,6 +268,78 @@ class J18AutoForwardResumeJourney {
         )
     }
 
+    private fun unmountKeepingEnabled() {
+        val graph = appGraph()
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        runBlocking {
+            if (graph.forwardingController().isRunning(HOST_ID)) {
+                graph.forwardingController().stop(HOST_ID)
+            }
+            val host = graph.hostDao().getById(HOST_ID)
+            if (host != null && !host.enabled) {
+                graph.hostDao().update(host.copy(enabled = true))
+            }
+        }
+        context.stopService(Intent(context, ForwardService::class.java))
+        awaitForwardServiceStopped()
+    }
+
+    private fun launchLeftoverStartedActivity(): ActivityScenario<out Activity> {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = Intent(context, ShareActivity::class.java).apply {
+            action = Intent.ACTION_SEND
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, "j18-leftover-keep-started")
+        }
+        val scenario = ActivityScenario.launch<ShareActivity>(intent)
+        val deadline = SystemClock.elapsedRealtime() + SEED_WAIT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(
+                    androidx.lifecycle.Lifecycle.State.STARTED,
+                )
+            ) {
+                return scenario
+            }
+            SystemClock.sleep(POLL_MS)
+        }
+        throw AssertionError("leftover ShareActivity did not move ProcessLifecycleOwner to STARTED")
+    }
+
+    private fun awaitResumeSweep(sweepsBefore: Int) {
+        val deadline = SystemClock.elapsedRealtime() + SEED_WAIT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (appGraph().forwardingResume().resumeSweepCount.get() > sweepsBefore) return
+            SystemClock.sleep(POLL_MS)
+        }
+        throw AssertionError("leftover attach ON_START sweep did not complete")
+    }
+
+    private fun awaitObserverAttached() {
+        val deadline = SystemClock.elapsedRealtime() + SEED_WAIT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (appGraph().forwardingResume().lifecycleObserverAttached) return
+            SystemClock.sleep(POLL_MS)
+        }
+        throw AssertionError("leftover ProcessLifecycleOwner observer did not attach")
+    }
+
+    private fun awaitForwardServiceStopped() {
+        val deadline = SystemClock.elapsedRealtime() + SEED_WAIT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (!isForwardServiceRunning()) return
+            SystemClock.sleep(POLL_MS)
+        }
+        throw AssertionError("leftover ForwardService did not stop within ${SEED_WAIT_MS}ms")
+    }
+
+    private fun isForwardServiceRunning(): Boolean {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        @Suppress("DEPRECATION")
+        return context.getSystemService(ActivityManager::class.java)
+            ?.getRunningServices(100)
+            ?.any { it.service.className == ForwardService::class.java.name } == true
+    }
+
     private fun grantNotificationPermission() {
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.TIRAMISU) return
         val instrumentation = InstrumentationRegistry.getInstrumentation()
@@ -232,6 +351,7 @@ class J18AutoForwardResumeJourney {
 
     private companion object {
         const val TIMEOUT_MS = 60_000L
+        const val SEED_WAIT_MS = 5_000L
         const val POLL_MS = 250L
         const val HTTP_TIMEOUT_MS = 1_000
         const val HTTP_BODY_TOKEN = "POCKETSHELL_J18_HTTP_2654"

--- a/app2/src/main/java/com/pocketshell/next/MainActivity.kt
+++ b/app2/src/main/java/com/pocketshell/next/MainActivity.kt
@@ -109,8 +109,9 @@ class MainActivity : FragmentActivity() {
     /**
      * Same reason [grace] is registered here: instrumentation replaces
      * [App] with `HiltTestApplication`, so [App.onCreate] never runs.
-     * The observer is attached once; a later call still resumes when the
-     * process is already `STARTED` (the journey suite's shape).
+     * Observer attach is in [onCreate]; the sweep is [onStart] because
+     * `startForegroundService` is only legal once this activity is foreground
+     * and ProcessLifecycleOwner can stay `STARTED` across launches.
      */
     @Inject
     lateinit var forwardingResume: ForwardingResume
@@ -183,6 +184,11 @@ class MainActivity : FragmentActivity() {
                 }
             }
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        forwardingResume.resumeNow()
     }
 }
 

--- a/app2/src/main/java/com/pocketshell/next/ports/ForwardingResume.kt
+++ b/app2/src/main/java/com/pocketshell/next/ports/ForwardingResume.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.pocketshell.core.storage.dao.HostDao
 import com.pocketshell.core.storage.dao.SshKeyDao
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -29,8 +31,11 @@ import kotlinx.coroutines.withContext
  *
  * Foreground-only (D21): no WorkManager, no AlarmManager, no boot receiver.
  * The observer is attached once so [com.pocketshell.next.App] and
- * [com.pocketshell.next.MainActivity] can both call [observeProcessLifecycle];
- * a later call still resumes when the owner is already `STARTED`.
+ * [com.pocketshell.next.MainActivity] can both call [observeProcessLifecycle].
+ * `ON_START` covers app-from-background. [resumeNow] is the activity-foreground
+ * sweep: the process can stay `STARTED` across activity launches (no new
+ * `ON_START`) and `startForegroundService` is only legal once the activity is
+ * in the foreground (API 31+).
  */
 @Singleton
 class ForwardingResume @Inject constructor(
@@ -51,15 +56,21 @@ class ForwardingResume @Inject constructor(
 
     private var lifecycleAttached: Boolean = false
 
+    /** Completed [resumeIfNeeded] sweeps. Journey seed waits on this. */
+    internal val resumeSweepCount = AtomicInteger(0)
+
+    private val _lifecycleObserverAttached = AtomicBoolean(false)
+    internal val lifecycleObserverAttached: Boolean
+        get() = _lifecycleObserverAttached.get()
+
     /**
      * Attach [ProcessLifecycleOwner] (or any [LifecycleOwner]) so a resume
      * sweep fires on every `ON_START`. The observer is added once.
      *
-     * A later call still seeds an immediate resume when the owner is already
-     * `STARTED`. Instrumentation keeps the process in `STARTED` across
-     * activity launches ([App] is replaced by `HiltTestApplication`, so
-     * [com.pocketshell.next.MainActivity] is the attach site) and would
-     * otherwise never see another `ON_START`.
+     * A later call is attach-only. Instrumentation keeps the process
+     * `STARTED` across activity launches, so there is no new `ON_START`;
+     * [resumeNow] from [com.pocketshell.next.MainActivity.onStart] is the
+     * foreground sweep (`startForegroundService` is legal then).
      */
     fun observeProcessLifecycle(owner: LifecycleOwner = ProcessLifecycleOwner.get()) {
         val attachObserver = synchronized(this) {
@@ -71,14 +82,22 @@ class ForwardingResume @Inject constructor(
             }
         }
         scope.launch {
-            val alreadyStarted = withContext(Dispatchers.Main) {
+            withContext(Dispatchers.Main) {
                 if (attachObserver) {
                     owner.lifecycle.addObserver(processLifecycleObserver)
                 }
-                owner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+                _lifecycleObserverAttached.set(true)
             }
-            if (alreadyStarted) requestResume()
         }
+    }
+
+    /**
+     * Run the enabled-host sweep now. [com.pocketshell.next.MainActivity.onStart]
+     * calls this so `startForegroundService` happens while the activity is
+     * foreground. Idempotent with an already-mounted supervisor (`reconnectNow`).
+     */
+    fun resumeNow() {
+        requestResume()
     }
 
     private fun requestResume() {
@@ -86,11 +105,17 @@ class ForwardingResume @Inject constructor(
     }
 
     private suspend fun resumeIfNeeded() {
-        val enabled = hostDao.getEnabled().first()
-        if (enabled.isEmpty()) return
-        val usable = enabled.any { host -> hostHasUsableKey(host.id, host.keyId) }
-        if (!usable) return
-        startService(applicationContext)
+        try {
+            val enabled = hostDao.getEnabled().first()
+            if (enabled.isEmpty()) return
+            val usable = enabled.any { host -> hostHasUsableKey(host.id, host.keyId) }
+            if (!usable) return
+            withContext(Dispatchers.Main) {
+                startService(applicationContext)
+            }
+        } finally {
+            resumeSweepCount.incrementAndGet()
+        }
     }
 
     private suspend fun hostHasUsableKey(hostId: Long, keyId: Long): Boolean {

--- a/app2/src/test/java/com/pocketshell/next/ports/ForwardingResumeTest.kt
+++ b/app2/src/test/java/com/pocketshell/next/ports/ForwardingResumeTest.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -108,7 +107,7 @@ class ForwardingResumeTest {
     }
 
     @Test
-    fun secondObserveWhileAlreadyStarted_requestsResumeAgain() = runTest(dispatcher) {
+    fun secondObserveWhileAlreadyStarted_doesNotStartServiceAgain() = runTest(dispatcher) {
         seedHost(enabled = true)
         val started = AtomicInteger(0)
         val resume = resume { started.incrementAndGet() }
@@ -118,13 +117,14 @@ class ForwardingResumeTest {
         resume.observeProcessLifecycle(owner)
         advanceUntilIdle()
         val afterFirst = started.get()
-        assertTrue("already-STARTED owner must seed an immediate resume", afterFirst >= 1)
+        assertEquals("addObserver on STARTED dispatches ON_START", 1, afterFirst)
 
         resume.observeProcessLifecycle(owner)
         advanceUntilIdle()
-        assertTrue(
-            "later MainActivity attach must resume even if ProcessLifecycleOwner stayed STARTED",
-            started.get() > afterFirst,
+        assertEquals(
+            "second observe is attach-only; process stays STARTED so there is no new ON_START",
+            afterFirst,
+            started.get(),
         )
     }
 
@@ -139,7 +139,7 @@ class ForwardingResumeTest {
         resume.observeProcessLifecycle(owner)
         advanceUntilIdle()
 
-        assertTrue("already-STARTED owner must seed an immediate resume", started.get() >= 1)
+        assertEquals("addObserver on STARTED dispatches ON_START", 1, started.get())
     }
 
     @Test
@@ -155,6 +155,65 @@ class ForwardingResumeTest {
 
         assertEquals(0, started.get())
     }
+
+    @Test
+    fun resumeNow_withEnabledHost_startsService() = runTest(dispatcher) {
+        seedHost(enabled = true)
+        val started = AtomicInteger(0)
+        val resume = resume { started.incrementAndGet() }
+
+        resume.resumeNow()
+        advanceUntilIdle()
+
+        assertEquals(1, started.get())
+    }
+
+    @Test
+    fun resumeNow_withNoEnabledHost_doesNotStartService() = runTest(dispatcher) {
+        seedHost(enabled = false)
+        val started = AtomicInteger(0)
+        val resume = resume { started.incrementAndGet() }
+
+        resume.resumeNow()
+        advanceUntilIdle()
+
+        assertEquals(0, started.get())
+    }
+
+    @Test
+    fun resumeNow_passphraseProtected_isSkipped() = runTest(dispatcher) {
+        seedHost(enabled = true, hasPassphrase = true)
+        val started = AtomicInteger(0)
+        val resume = resume { started.incrementAndGet() }
+
+        resume.resumeNow()
+        advanceUntilIdle()
+
+        assertEquals(0, started.get())
+    }
+
+    @Test
+    fun resumeNow_afterLeftoverAttachWhileProcessStarted_startsServiceWithoutNewOnStart() =
+        runTest(dispatcher) {
+            seedHost(enabled = true)
+            val started = AtomicInteger(0)
+            val resume = resume { started.incrementAndGet() }
+            val owner = FakeLifecycleOwner()
+            owner.registry.currentState = Lifecycle.State.STARTED
+
+            resume.observeProcessLifecycle(owner)
+            advanceUntilIdle()
+            assertEquals("leftover attach consumed ON_START", 1, started.get())
+
+            started.set(0)
+            resume.resumeNow()
+            advanceUntilIdle()
+            assertEquals(
+                "MainActivity.onStart must resume after leftover attach with no new process ON_START",
+                1,
+                started.get(),
+            )
+        }
 
     private fun resume(onStart: () -> Unit): ForwardingResume {
         val resume = ForwardingResume(


### PR DESCRIPTION
Closes #2654

Forward fix for the post-merge app2-journey red. Isolated J18 was a false green: after J13, ProcessLifecycleOwner stayed STARTED, so J18 never requested resume, and `awaitForwardService()` passed on J13's leftover FGS.

`MainActivity.onStart` now calls `ForwardingResume.resumeNow()`. J18 seeds leftover observer + STARTED process, tears down leftover FGS, and asserts host 9918's in-window HTTP body.

Reviewer APPROVED (round 2): https://github.com/PocketShell-io/pocketshell/issues/2654#issuecomment-5645901706
Also ran J13 then J18 in one process this review (the CI suite shape).